### PR TITLE
[Error Propagation] Faithful, panic-free MsQuic → h3 error propagation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,12 +3,18 @@ name: build
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
+  # ── Default + `tracing` compile/lint rows ───────────────────────────────────
+  # These rows do a COMPILE/LINT check only (no test/attestation/bench gate):
+  # they prove the library and all targets build and lint cleanly with the
+  # default feature set and with `tracing` enabled. The attested conformance
+  # matrix below still owns the full test/attestation/bench gate on the native
+  # provenance rows. `--all-features` is intentionally NOT used (the two native
+  # provenance features are mutually exclusive).
+  default-tracing-lint:
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows-latest, ubuntu-latest ]
         rust: [ 1.90.0, 1.97.0 ]
     steps:
     - uses: actions/checkout@v7
@@ -22,9 +28,63 @@ jobs:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
 
-    # choose a older version to avoid apt error
-    - name: Install msquic from apt (linux)
-      if: runner.os == 'Linux'
+    - name: Run cargo check (default features)
+      run: cargo +${{ matrix.rust }} check --all-targets
+
+    - name: Run cargo check (tracing)
+      run: cargo +${{ matrix.rust }} check --all-targets --features tracing
+
+    - name: Run cargo fmt
+      run: cargo +${{ matrix.rust }} fmt --all -- --check
+
+    - name: Run cargo clippy (default features)
+      run: cargo +${{ matrix.rust }} clippy --all-targets -- -D warnings
+
+    - name: Run cargo clippy (tracing)
+      run: cargo +${{ matrix.rust }} clippy --all-targets --features tracing -- -D warnings
+
+  # ── Attested conformance-support matrix (MF-3) ──────────────────────────────
+  # Two committed clean-checkout provenance rows, selected by a committed feature
+  # (never an uncommitted Cargo.toml edit):
+  #   * native-find → links the system-package libmsquic (Linux CI installs 2.5.8)
+  #                   → attested version [2,5,8]
+  #   * native-src  → builds the vendored msquic-2.5.1-beta source via cmake
+  #                   → attested version [2,5,1]
+  # The two features are MUTUALLY EXCLUSIVE (the msquic build script fails fast if
+  # both are set), so `--all-features` is intentionally NOT used anywhere here.
+  linux-conformance:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ 1.90.0, 1.97.0 ]
+        provenance: [ native-find, native-src ]
+        # Row-specific expected native version (major.minor.patch). Pins the
+        # attestation gate per cell so a silent library drift fails the job.
+        include:
+          - provenance: native-find
+            expected: "2.5.8"
+          - provenance: native-src
+            expected: "2.5.1"
+    env:
+      # Consumed by the `native_version_preflight` attestation test.
+      MSQUIC_EXPECTED_VERSION: ${{ matrix.expected }}
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Get latest version of CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install rust stable
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+        components: rustfmt, clippy
+
+    # Only the native-find row installs the system package; native-src builds the
+    # crate-bundled msquic source, so it must NOT have a system libmsquic present.
+    - name: Install msquic from apt (native-find only)
+      if: matrix.provenance == 'native-find'
       run: |
         wget -q https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/packages-microsoft-prod.deb;
         sudo dpkg -i packages-microsoft-prod.deb;
@@ -32,8 +92,76 @@ jobs:
         sudo apt-get install libmsquic=2.5.8;
         dpkg -L libmsquic;
 
+    - name: Run cargo check
+      run: cargo +${{ matrix.rust }} check --all-targets --no-default-features --features ${{ matrix.provenance }}
+
+    - name: Run cargo fmt
+      run: cargo +${{ matrix.rust }} fmt --all -- --check
+
+    - name: Run cargo clippy
+      run: cargo +${{ matrix.rust }} clippy --all-targets --no-default-features --features ${{ matrix.provenance }} -- -D warnings
+
+    - name: Run cargo test
+      run: cargo +${{ matrix.rust }} test --no-default-features --features ${{ matrix.provenance }} -- --nocapture
+
+    # ── BLOCKING attestation + exact seam/conformance gate ──────────────────
+    # Replaces any `teardown` substring filter: each named test is run with
+    # `--exact` and the job FAILS unless all four ran (a green job can never
+    # silently run zero seam/conformance tests). The attestation test records the
+    # loaded library's version + git-hash + SHA-256 digest and asserts the
+    # row-specific expected version.
+    - name: Blocking attestation + seam/conformance gate
+      run: |
+        set -euo pipefail
+        OUT=$(cargo +${{ matrix.rust }} test -p msquic-h3 --no-default-features \
+          --features ${{ matrix.provenance }} -- --exact --nocapture \
+          attest::tests::native_version_preflight \
+          send_seam::accepted_send_reclaims_via_callback_exactly_once \
+          send_seam::immediate_send_failure_reclaims_without_completion \
+          conformance::accepted_send_completes_and_teardown_is_panic_free)
+        echo "$OUT"
+        echo "$OUT" | grep -Eq "test result: ok\. 4 passed" \
+          || { echo "::error::expected exactly 4 seam/conformance tests to run under --exact"; exit 1; }
+
+    # ── BLOCKING send-copy benchmark gate (MF-4) ────────────────────────────
+    # Builds AND runs the Criterion target under the same provenance row plus the
+    # committed `bench-internals` feature. Timing is INFORMATIONAL (no hard 10 ms
+    # assertion); the deterministic memory bound is the in-crate
+    # `send_copy_peak_resident_bound` #[test] run above. A build/run failure here
+    # fails the job.
+    - name: Blocking send-copy bench build + run (informational timing)
+      run: |
+        cargo +${{ matrix.rust }} bench -p msquic-h3 --no-default-features \
+          --features ${{ matrix.provenance }},bench-internals --bench send_copy -- --noplot
+
+  # ── Windows compile/test support (vcpkg) ────────────────────────────────────
+  # SCOPE: this job proves the crate compiles and its tests pass on Windows via a
+  # vcpkg-provided libmsquic (the `native-find` feature locates it through
+  # VCPKG_ROOT). It is deliberately DISTINCT from the attested conformance matrix
+  # above: vcpkg's pinned msquic version is not asserted here, so the
+  # `native_version_preflight` gate is skipped. Loaded-module attestation on
+  # Windows (enumerating the mapped `msquic.dll` via GetModuleHandle /
+  # GetModuleFileName) is future work; until then Windows is compile/test support,
+  # not an attested conformance cell.
+  windows-build:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust: [ 1.90.0, 1.97.0 ]
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Get latest version of CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Install rust stable
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        toolchain: ${{ matrix.rust }}
+        components: rustfmt, clippy
+
     - name: Run Vcpkg (windows)
-      if: runner.os == 'Windows'
       uses: lukka/run-vcpkg@v11
       with:
         vcpkgGitCommitId: 52c9e08cdf8580d2d9762f547d22b96fd81e82f2 # 2026.06.24
@@ -41,7 +169,6 @@ jobs:
         VCPKG_BINARY_SOURCES: default,rw
 
     - name: Set up binary cache
-      if: runner.os == 'Windows'
       uses: actions/cache@v6
       with:
         path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
@@ -50,25 +177,29 @@ jobs:
           ${{ runner.os }}-vcpkg-binary-cache-
 
     - name: install msquic from vcpkg (windows)
-      if: runner.os == 'Windows'
-      run: |
-        vcpkg install msquic
+      run: vcpkg install msquic
 
+    # Generates the MsQuic-Test certificate the loopback tests need on Windows.
     - name: run cmake
-      run: > 
-        cmake . -B build
+      run: cmake . -B build
 
     - name: run build
       run: cmake --build build
-    
+
     - name: Run cargo check
-      run: cargo +${{ matrix.rust }} check --all-targets --all-features
+      run: cargo +${{ matrix.rust }} check --all-targets --no-default-features --features native-find
 
     - name: Run cargo fmt
       run: cargo +${{ matrix.rust }} fmt --all -- --check
-    
-    - name: Run cargo clippy
-      run: cargo +${{ matrix.rust }} clippy --all-targets --all-features -- -D warnings
 
-    - name: Run cargo test
-      run: cargo +${{ matrix.rust }} test --all -- --nocapture
+    - name: Run cargo clippy
+      run: cargo +${{ matrix.rust }} clippy --all-targets --no-default-features --features native-find -- -D warnings
+
+    # Compile/test support only: skip the version-attestation gate (vcpkg's msquic
+    # version is not asserted on this platform — see the job-level SCOPE note).
+    - name: Run cargo test (skip version attestation)
+      run: cargo +${{ matrix.rust }} test --no-default-features --features native-find -- --nocapture --skip native_version_preflight
+
+    # Verify the bench still builds+runs on Windows (informational timing only).
+    - name: send-copy bench build + run (informational timing)
+      run: cargo +${{ matrix.rust }} bench -p msquic-h3 --no-default-features --features native-find,bench-internals --bench send_copy -- --noplot

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 bin
 obj
 .vscode
+.reviews

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 obj
 .vscode
 .reviews
+.paw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Cargo pre-1.0 semantics](https://doc.rust-lang.org/cargo/reference/semver.html)
+where every `0.0.z` bump may contain breaking changes.
+
+## [0.0.7] - 2026-07-18
+
+The MsQuic → h3 error-propagation refactor. Callbacks are now panic-free across
+the FFI boundary, terminals carry their true cause, the send half owns its buffer
+with exactly-once reclamation, and the release process is gated on native-version
+attestation plus send-copy measurements.
+
+### Added
+
+- Per-operation send-size ceiling: `send_data` payloads above `MAX_ADAPTER_SEND`
+  (16 MiB, provisional) are rejected with `StreamErrorIncoming::Unknown(OversizedSend)`
+  instead of being submitted.
+- Observable peer `STOP_SENDING`: it now surfaces from the send side as
+  `StreamErrorIncoming::StreamTerminated { error_code }`, both with a send in
+  flight and with none.
+- Distinct connection-close causes: peer application close, idle/handshake
+  timeout, transport shutdown, and local application close now each map to their
+  own `ConnectionErrorIncoming` value.
+- Local `SendStream::reset(code)` surfaces as a distinct local reset rather than a
+  peer termination; all outgoing application/error codes are clamped to the 62-bit
+  QUIC varint maximum before crossing the FFI boundary.
+- Runtime native-version attestation gate and a committed provenance feature
+  matrix (`native-find` / `native-src`), plus a buildable send-copy benchmark and
+  a blocking peak-resident memory test.
+
+### Changed
+
+- **BREAKING — panic-free FFI callbacks.** Connection, stream, and listener
+  callbacks no longer `unwrap`/`expect`; a dropped receiver or poisoned lock is
+  handled as a recoverable fault instead of unwinding across the FFI boundary.
+- **BREAKING — terminal/error classifications.** A peer `RESET_STREAM` now maps to
+  `StreamErrorIncoming::StreamTerminated` (previously conflated with EOF); a real
+  connection close maps to its specific cause instead of a blanket
+  `ApplicationClose { error_code: 0 }`; an empty, non-FIN receive notification is
+  no longer treated as end-of-stream (only a FIN flag or peer send-shutdown ends
+  the stream); after a local `stop_sending`, subsequent reads return a clean
+  end-of-stream rather than a stream error.
+
+### Removed
+
+- **BREAKING — `pub H3Buff` removed.** Outgoing sends now use an internal, owned
+  `SendBuffer`; the public `H3Buff` type is gone.
+
+### Migration
+
+- **`H3Buff` consumers:** stop naming `H3Buff`. The adapter now materializes
+  outgoing payloads into an internal owned `SendBuffer`; there is no public
+  replacement type to name — pass your data through the normal
+  `h3::quic::SendStream` API and the adapter copies it into an owned buffer.
+- **Error-handling consumers:** update any logic that relied on the old behavior:
+  - treating a peer reset as EOF → now a `StreamTerminated` error at the read
+    point;
+  - matching `ApplicationClose { error_code: 0 }` as a catch-all for connection
+    close → now match the specific `ConnectionErrorIncoming` cause (application
+    close, `Timeout`, transport `Undefined`, or local close);
+  - treating an empty receive as EOF → the empty non-FIN case no longer ends the
+    stream;
+  - expecting a stream error after your own `stop_sending` → reads now return a
+    clean end-of-stream (`Ok(None)`).
+- **Oversized sends:** a single `send_data` above 16 MiB (`MAX_ADAPTER_SEND`) is
+  now rejected with `OversizedSend`; chunk large payloads below the ceiling.
+
+### Rollback
+
+- Reverting the crate to `0.0.6` restores the prior behavior and public API
+  (including `pub H3Buff`, reset-as-EOF, and the blanket `ApplicationClose { 0 }`
+  connection mapping). If a consumer cannot yet adopt the new error model, pin
+  `msquic-h3 = "0.0.6"` and the last-known-good native/config matrix row.
+
+[0.0.7]: https://github.com/youyuanwu/msquic-h3/releases/tag/v0.0.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "msquic-h3"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,43 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -25,10 +58,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "ctor"
@@ -62,6 +239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +259,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures"
@@ -156,6 +345,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,10 +372,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -223,6 +460,7 @@ checksum = "bea65fda5241a20053862abd4fc4e8ce92a08b5471a3ce26714d02fe42ebd6f6"
 dependencies = [
  "bitflags",
  "c-types",
+ "cmake",
  "ctor",
  "libc",
  "socket2 0.5.10",
@@ -233,6 +471,7 @@ name = "msquic-h3"
 version = "0.0.6"
 dependencies = [
  "bytes",
+ "criterion",
  "futures",
  "h3",
  "http",
@@ -252,10 +491,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "parking_lot"
@@ -287,6 +541,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +587,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,10 +616,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -327,6 +716,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -388,6 +783,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -489,10 +894,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "windows-link"
@@ -590,3 +1069,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "msquic-h3"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 license = "MIT"
 authors = ["youyuanwu@outlook.com"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ tokio = {version = "1", features = ["full"]}
 tracing-subscriber = "0.3"
 tracing = { version = "0.1", features = ["log"] }
 msquic = { version = "2.5.1-beta", default-features = false, features = ["find"] }
+# Backend feature exposes h3's internal `proto::frame::Frame` / `WriteBuf` builders
+# so seam tests can construct a real data-carrying `WriteBuf<Bytes>` exactly as
+# h3's own frontend does. Dev-only: not enabled for the published library build.
+h3 = { version = "0.0.8", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,14 +25,42 @@ futures = { version = "0.3", default-features = false, features = ["std"]}
 # default = ["tracing"]
 tracing = ["dep:tracing"]
 
+# Native-library provenance (MF-3). MUTUALLY EXCLUSIVE — enabling both selects
+# `msquic/find` + `msquic/src`, which the msquic build script rejects with
+# `feature src and find are mutually exclusive`. Because they cannot coexist,
+# `--all-features` is NO LONGER a valid verification command (Phase 9 / plan S1);
+# verify with a single provenance row instead, e.g.
+#   cargo test --no-default-features --features native-find
+# (system-package libmsquic; the canonical local invocation on this 2.5.8 host)
+#   cargo test --no-default-features --features native-src
+# (crate-built from the vendored msquic source via cmake).
+native-find = ["msquic/find"] # system-package libmsquic (find::find symlinks it)
+native-src = ["msquic/src"]   # crate-built from vendored source via cmake
+
+# Committed bench feature (MF-4): gates the public
+# `msquic_h3::bench_support::copy_into_send_buffer` re-export so the separate
+# Criterion crate can reach the ONE production copy path.
+bench-internals = []
+
 
 [dev-dependencies]
 http = "1"
 tokio = {version = "1", features = ["full"]}
 tracing-subscriber = "0.3"
 tracing = { version = "0.1", features = ["log"] }
-msquic = { version = "2.5.1-beta", default-features = false, features = ["find"] }
+# Provenance is now selected by the committed `native-find` / `native-src`
+# features above (not a hard-wired dev-dep feature), so exactly one native
+# library is chosen per invocation from the command line. `native-find` is the
+# canonical local row on this Linux/2.5.8 host.
+msquic = { version = "2.5.1-beta", default-features = false }
+criterion = { version = "0.5", features = ["html_reports"] }
 # Backend feature exposes h3's internal `proto::frame::Frame` / `WriteBuf` builders
 # so seam tests can construct a real data-carrying `WriteBuf<Bytes>` exactly as
 # h3's own frontend does. Dev-only: not enabled for the published library build.
 h3 = { version = "0.0.8", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
+
+[[bench]]
+name = "send_copy"
+path = "msquic-h3/benches/send_copy.rs"
+harness = false                          # Criterion provides its own harness
+required-features = ["bench-internals"]  # bench needs the gated public entry point

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,8 +1,96 @@
+# Development
+
+## Canonical build / test / bench invocations
+
+Native-library provenance is selected by a **committed, mutually-exclusive**
+feature (`native-find` or `native-src`), so `--all-features` is intentionally
+invalid (it would enable both and the `msquic` build script rejects that). Verify
+with a single provenance row:
 
 ```sh
-# This is required to run tests
+# Canonical local row: system-package libmsquic (Linux 2.5.8 host).
+cargo check  --all-targets --no-default-features --features native-find
+cargo clippy --all-targets --no-default-features --features native-find -- -D warnings
+cargo fmt --all -- --check
+cargo test               --no-default-features --features native-find -- --nocapture
+
+# Vendored-source row: crate-built from the bundled msquic source via cmake.
+cargo test --no-default-features --features native-src -- --nocapture
+
+# Default / tracing rows (no native tests):
+cargo test --all -- --nocapture
+cargo test --all --features tracing -- --nocapture
+
+# Send-copy benchmark (separate Criterion crate; needs the gated entry point):
+cargo bench --no-default-features --features native-find,bench-internals --bench send_copy
+```
+
+If the linked `libmsquic` is not on the default loader path, point the loader at
+it (e.g. a locally built copy under `build/`):
+
+```sh
+# This is required to run tests when the lib is not already installed system-wide
 export LD_LIBRARY_PATH="$(pwd)/build"
 ```
+
+## Supported configuration matrix
+
+The native-version attestation gate is **per row** (see below). `native-find`
+links the system package; `native-src` builds the vendored `msquic-2.5.1-beta`
+source.
+
+| OS / arch          | Provenance    | Native `libmsquic` | Expected version | Status                 |
+|--------------------|---------------|--------------------|------------------|------------------------|
+| Linux x86-64       | `native-find` | system package     | `2.5.8`          | CI + canonical local   |
+| Linux x86-64       | `native-src`  | crate-built (cmake)| `2.5.1`          | CI                     |
+| Windows x86-64     | vcpkg / pwsh  | vcpkg-provided     | matrix-pinned    | compile / test support |
+
+`MSQUIC_EXPECTED_VERSION="major.minor.patch"` overrides the per-row default so any
+supported matrix cell can pin its own value.
+
+## Native-version attestation policy
+
+`native_version_preflight` (`msquic-h3/src/attest.rs`, `#[cfg(test)]`) is a
+**blocking** release gate that attests the library the test process *actually
+loaded*, not merely an installed package:
+
+1. **Live-handle identity (primary).** Queries `QUIC_PARAM_GLOBAL_LIBRARY_VERSION`
+   (`[major, minor, patch, build]`; build id ignored) and
+   `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH` through the live MsQuic handle. The
+   version must equal the **row-specific** pin: `native-find → [2,5,8]`,
+   `native-src → [2,5,1]`.
+2. **Loaded-artifact digest (secondary, Linux — blocking).** Resolves the
+   `libmsquic.so*` the loader actually mapped (via `/proc/self/maps`) and records
+   its SHA-256. If the path/digest cannot be resolved the gate **fails** rather
+   than passing silently. Platforms without the digest mechanism (e.g. Windows)
+   are an explicit, separately-scoped skip.
+
+Every job records the captured version + git hash + loaded-artifact digest as its
+attestation.
+
+## Send-copy performance and memory measurements (Phase 9)
+
+Outgoing sends are materialized into a single owned `SendBuffer` via one
+`copy_to_bytes` allocation on the production copy path
+(`copy_into_send_buffer`). The measurements below feed the **provisional** 16 MiB
+`MAX_ADAPTER_SEND` ceiling (FR-012); the ceiling is recorded, not ratified, from
+this evidence alone.
+
+| Measurement                         | Result (informational)                          |
+|-------------------------------------|-------------------------------------------------|
+| Per-send copy cost (16 MiB)         | ~3 ms per owned copy                             |
+| Synchronous copy latency vs. size   | 1 KiB ~36 ns … 16 MiB ~3 ms                      |
+| Aggregate retained (256 × 16 MiB)   | ~4.29 GB held simultaneously — **unbounded** in the number of in-flight sends (no adapter-level ceiling on the sum) |
+| Peak resident per send (16 MiB)     | ≤ `2 × payload + 1 MiB` (blocking `send_copy_peak_resident_bound` test) |
+
+The Criterion timings are informational / relative to a same-run baseline (no hard
+wall-time assertion until a pinned, isolated runner exists). The **blocking**
+deterministic memory gate is the in-crate `send_copy_peak_resident_bound` test,
+which bounds the transient source+destination doubling. The aggregate figure
+demonstrates the design's documented unbounded-aggregate concern: retained memory
+grows linearly with concurrent outstanding sends.
+
+## Notes and prerequisites
 
 ```ps1
 $env:RUST_LOG = "info"

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -41,12 +41,20 @@ source.
 
 | OS / arch          | Provenance    | Native `libmsquic` | Expected version | Status                 |
 |--------------------|---------------|--------------------|------------------|------------------------|
-| Linux x86-64       | `native-find` | system package     | `2.5.8`          | CI + canonical local   |
-| Linux x86-64       | `native-src`  | crate-built (cmake)| `2.5.1`          | CI                     |
-| Windows x86-64     | vcpkg / pwsh  | vcpkg-provided     | matrix-pinned    | compile / test support |
+| Linux x86-64       | `native-find` | system package     | `2.5.8`          | CI + canonical local — attested (SC-012) |
+| Linux x86-64       | `native-src`  | crate-built (cmake)| `2.5.1`          | CI — attested (SC-012)  |
+| Windows x86-64     | vcpkg / pwsh  | vcpkg-provided     | UNATTESTED       | compile / test only — outside SC-012 |
 
 `MSQUIC_EXPECTED_VERSION="major.minor.patch"` overrides the per-row default so any
 supported matrix cell can pin its own value.
+
+> **Windows scope (honest limitation).** The Windows job builds and runs the test
+> suite but does **not** run `native_version_preflight`: the loaded-module (DLL)
+> path/digest query is not yet implemented, so no version/git-hash/digest is
+> attested there. Windows is therefore explicitly **outside** the SC-012 attested
+> conformance-support matrix — it has no expected-version pin and must not be
+> described as attested until the loaded-module query lands. Only the two Linux
+> provenance rows are attested release gates.
 
 ## Native-version attestation policy
 

--- a/docs/error-propagation.md
+++ b/docs/error-propagation.md
@@ -1,0 +1,1235 @@
+# MsQuic to h3 error propagation
+
+This document reviews how `msquic-h3` 0.0.6 maps errors from `msquic`
+2.5.1-beta into the `h3` 0.0.8 QUIC traits. It compares the adapter with
+`h3-quinn` 0.0.10 and the internal `s2n-quic-h3` adapter.
+
+The review covers errors after a connection has been handed to `h3`. Errors
+from constructing a registration, configuration, listener, or connection are
+ordinary `Result<_, msquic::Status>` values and are outside the h3 transport
+trait boundary.
+
+## Summary
+
+The MsQuic binding exposes the information needed for useful h3 errors, but the
+adapter currently discards most of it:
+
+- connection shutdown is always reported as application close code `0`;
+- peer stream resets are reported as clean end-of-stream;
+- peer `STOP_SENDING` codes are lost;
+- `SendStream::reset` panics instead of sending `RESET_STREAM`;
+- several normal cancellation and drop races can panic in an MsQuic callback;
+- some connection failures become generic stream errors instead of
+  `StreamErrorIncoming::ConnectionErrorIncoming`.
+
+This is primarily a state propagation problem. `ConnCtxSender` and
+`StreamSendCtx` send data or completion notifications, but they do not carry a
+terminal reason. Closing a channel is then used for every kind of shutdown, so
+the polling side cannot distinguish FIN, reset, connection close, or an
+internal adapter failure.
+
+## h3 error contract
+
+`h3::quic` defines two incoming error levels:
+
+| h3 variant | Meaning |
+| --- | --- |
+| `ConnectionErrorIncoming::ApplicationClose { error_code }` | The peer closed the QUIC connection with an HTTP/3 application code. |
+| `ConnectionErrorIncoming::Timeout` | The QUIC connection timed out. |
+| `ConnectionErrorIncoming::InternalError` | The adapter violated its own contract or failed internally. h3 closes with `H3_INTERNAL_ERROR`. |
+| `ConnectionErrorIncoming::Undefined` | A transport or implementation error that h3 cannot classify. |
+| `StreamErrorIncoming::ConnectionErrorIncoming` | A stream operation failed because the connection failed. |
+| `StreamErrorIncoming::StreamTerminated { error_code }` | The peer reset its send side or sent `STOP_SENDING` for the local send side. |
+| `StreamErrorIncoming::Unknown` | An unclassified stream-local failure. h3 handles it like stream termination. |
+
+`Ok(None)` from `RecvStream::poll_data` has a different meaning: the peer
+finished its sending side cleanly. It must not represent `RESET_STREAM` or a
+connection failure.
+
+## Review findings
+
+### 1. Peer resets become clean EOF (high)
+
+[`stream_callback`](../msquic-h3/src/lib.rs#L473) ignores
+`StreamEvent::PeerSendAborted { error_code }`. A later
+`StreamEvent::ShutdownComplete` drops the receive sender, and
+[`poll_data`](../msquic-h3/src/lib.rs#L693) converts the closed channel to
+`Ok(None)`.
+
+The HTTP/3 layer therefore cannot distinguish a graceful FIN from
+`RESET_STREAM`. Request streams lose the peer's application code, and critical
+streams can take the wrong protocol path before h3 detects that the stream
+ended.
+
+Expected result:
+
+```text
+PeerSendAborted { error_code }
+    -> StreamErrorIncoming::StreamTerminated { error_code }
+```
+
+### 2. `SendStream::reset` panics (high)
+
+[`H3SendStream::reset`](../msquic-h3/src/lib.rs#L669) is part of the h3 QUIC
+trait contract, but it calls `panic!`. h3 uses this operation to abort request
+and control streams. A protocol-level stream cancellation can consequently
+unwind the executor, and potentially cross an FFI callback boundary depending
+on the call path.
+
+It should call:
+
+```rust
+let _ = self
+  .stream
+  .shutdown(StreamShutdownFlags::ABORT_SEND, reset_code);
+```
+
+As in the Quinn and s2n adapters, the trait returns no result, so an immediate
+local failure can only be ignored or recorded for the next stream poll.
+
+### 3. Every connection close is reported as `H3_NO_ERROR` (high)
+
+[`connection_callback`](../msquic-h3/src/lib.rs#L110) ignores both
+`ShutdownInitiatedByPeer { error_code }` and
+`ShutdownInitiatedByTransport { status, error_code }`. On
+`ShutdownComplete`, it only closes the incoming-stream channels.
+
+Both [`poll_accept_recv`](../msquic-h3/src/lib.rs#L252) and
+[`poll_accept_bidi`](../msquic-h3/src/lib.rs#L268) turn that channel closure into:
+
+```rust
+ConnectionErrorIncoming::ApplicationClose { error_code: 0 }
+```
+
+This changes transport failures, timeouts, local shutdown, and non-zero peer
+HTTP/3 closes into a successful peer application close. The code is not merely
+missing diagnostic detail: h3 makes control-flow decisions from these variants.
+
+### 4. Peer `STOP_SENDING` is discarded (high)
+
+`StreamEvent::PeerReceiveAborted { error_code }` means the peer no longer
+accepts data on the local send side. The callback ignores it. An in-flight send
+may later complete as cancelled, but [`poll_ready`](../msquic-h3/src/lib.rs#L590)
+can then report only `Unknown(QUIC_STATUS_ABORTED)`. If no send is in progress,
+`poll_ready` returns `Ok(())` without observing any terminal state.
+
+Expected result:
+
+```text
+PeerReceiveAborted { error_code }
+    -> StreamErrorIncoming::StreamTerminated { error_code }
+```
+
+The error must be visible from `poll_ready` and `poll_finish`, including when no
+send is currently in flight. Note that today `poll_ready` returns `Ok(())`
+immediately when `!send_inprogress` and never inspects the send channel in that
+branch, so a `PeerReceiveAborted` that arrives while the send side is idle is
+invisible. The sticky terminal state must therefore be checked *before* that
+early return (see structural change 5).
+
+### 5. Normal cancellation and split-stream drops can panic (high)
+
+Callbacks use `unwrap` or `expect` when a one-shot receiver or stream half may
+legitimately have been dropped. Examples include:
+
+- connection establishment is cancelled before `Connected`;
+- an h3 receive half is dropped before another receive callback;
+- an h3 send half is dropped before `SendComplete`;
+- connection shutdown cancels a pending stream start;
+- a finish waiter is dropped before `SendShutdownComplete`.
+
+An FFI callback must not panic for these lifecycle races. Sending to a closed
+channel should be handled explicitly. There is an additional ownership
+constraint for `SendComplete`: the submitted allocation must be reclaimed even
+if its receiver is gone.
+
+Do not retain the current generic erasure. It would require at least
+`B: Send + 'static`, and [`H3Buff::new`](../msquic-h3/src/buffer.rs) assumes
+that advancing an arbitrary `Buf` does not invalidate chunks returned before
+the advance. Neither property is part of h3's `B: Buf` contract.
+
+Materialize each `WriteBuf<B>` synchronously into owned `Bytes` before calling
+MsQuic. `bytes::Buf::copy_to_bytes(data.remaining())` consumes the complete wire
+representation while `B` is still on the caller's thread. The callback-owned
+allocation is concrete:
+
+```rust
+struct SendBuffer {
+  buffers: [BufferRef; 1],
+  bytes: Bytes,
+}
+```
+
+A single send request is capped at `u32::MAX` bytes by MsQuic itself:
+`MsQuicStreamSend` sums every `QUIC_BUFFER.Length` into a `u64 TotalLength` and
+returns `QUIC_STATUS_INVALID_PARAMETER` when that sum exceeds `UINT32_MAX`,
+before the request is queued. Partitioning a larger payload across multiple
+`BufferRef` entries therefore does not help — the whole request is rejected — so
+the design validates the complete length up front and keeps a single buffer:
+
+```text
+remaining == 0              -> successful no-op (no allocation, no native send,
+                               send_inprogress stays false)
+remaining > u32::MAX        -> Err(StreamErrorIncoming::Unknown(OversizedSend))
+                               before any allocation or native submission;
+                               finish/terminal state unchanged
+0 < remaining <= u32::MAX   -> materialize into owned Bytes, construct one
+                               BufferRef, submit one native send
+```
+
+`OversizedSend` is a small adapter-owned `Debug + Display + Error` type. An
+oversized send is a stream-operation limitation, not a connection failure or a
+peer termination, so `StreamErrorIncoming::Unknown` is the closest h3 class.
+
+Construct `bytes` first, then construct the `BufferRef` from its slice and put
+both in the box. Moving `Bytes` does not move its referenced byte storage, so
+the pointer remains stable. `SendBuffer` is therefore self-referential:
+`buffers[0]` points into the heap storage owned by `bytes`, not into the struct,
+and stays valid for as long as the box lives. This invariant is load-bearing and
+warrants an explicit safety comment at the construction site. Pass
+`Box::into_raw(send_buffer)` as `client_context`. On `SendComplete`, the callback
+reconstructs `Box<SendBuffer>` and drops it immediately before enqueueing the
+completion event. MsQuic documents that `SendComplete` ends its use of the
+submitted buffers. On an immediate `Stream::send` error, `send_data`
+reconstructs and drops the same box.
+
+This deliberately trades zero-copy sends for a sound implementation of the
+existing `B: Buf` API. It adds no `Send` or `'static` bound to h3's generic
+buffer type. The cost is one full wire-buffer materialization per non-empty
+`send_data`: the call site is `WriteBuf<B>::copy_to_bytes(remaining())`, and
+`h3::stream::WriteBuf` does **not** override `copy_to_bytes`, so the default
+`bytes::Buf` implementation runs — `BytesMut::with_capacity(len)` then a copy of
+every chunk (the frame header array plus the payload), then `freeze()`. This is
+an allocation and byte copy even when the inner payload `B` is a single
+contiguous `Bytes`; it is not a refcount split. This remains a reasonable
+correctness tradeoff for a sound `B: Buf` implementation, but it should be
+measured rather than assumed cheap. The allocation crossing FFI contains only
+owned `Bytes` plus pointer metadata, and the callback knows its concrete
+destructor. The old generic `H3Buff` can be deleted after its remaining uses are
+removed.
+
+### 6. Pending stream open can panic on connection close (medium)
+
+[`poll_open_inner`](../msquic-h3/src/lib.rs#L341) expects the start one-shot to
+produce a value. `StreamEvent::ShutdownComplete` can instead drop its sender,
+making the one-shot return `Err(Canceled)`. The subsequent `expect("cannot
+receive")` panics.
+
+A connection-caused cancellation should be
+`StreamErrorIncoming::ConnectionErrorIncoming`. If no connection reason is
+available, it should be `Unknown`, never a panic.
+
+`poll_open_inner` checks the shared connection terminal before creating a
+native stream and again before polling an existing `OpeningStream`. A published
+terminal drops any opening holder and immediately returns
+`StreamErrorIncoming::ConnectionErrorIncoming`. If the start channel is
+cancelled without a published reason, it returns
+`ConnectionErrorIncoming::InternalError` rather than waiting or panicking.
+
+### 7. Send state has two contract hazards (medium)
+
+[`send_data`](../msquic-h3/src/lib.rs#L621) panics when called before the prior
+send becomes ready. Quinn and s2n classify this as an adapter/h3 contract
+failure using `StreamErrorIncoming::ConnectionErrorIncoming` containing
+`ConnectionErrorIncoming::InternalError`; that is safer than unwinding.
+
+[`poll_finish`](../msquic-h3/src/lib.rs#L647) calls MsQuic graceful shutdown on
+every poll and treats every `SendShutdownComplete`, including
+`graceful: false`, as success. It should record whether shutdown was initiated,
+call it once, and resolve from a terminal send event. A non-graceful completion
+must use the peer stream error or connection error when available.
+
+### 8. Empty receive data is treated as EOF (medium)
+
+The receive callback drops its sender when an event contains no non-empty
+buffers, even without `ReceiveFlags::FIN`. A zero-length notification is not by
+itself a graceful stream end. Only FIN or `PeerSendShutdown` should enqueue a
+clean EOF marker.
+
+### 9. Connection establishment loses the transport status (medium)
+
+This occurs before the connection reaches h3, but it is part of the public
+error path. A transport shutdown during `Connection::connect` is ignored until
+`ShutdownComplete` drops the `connected` one-shot. The connect future then
+returns a synthetic `QUIC_STATUS_ABORTED`, losing useful statuses such as
+handshake failure, timeout, connection refusal, or ALPN negotiation failure.
+
+The connection-establishment one-shot should carry `Result<(), Status>`.
+`ShutdownInitiatedByTransport` can send its status directly. A peer application
+close has no lossless representation in the existing `Result<_, Status>` API;
+the implementation keeps the existing public API and returns
+`QUIC_STATUS_ABORTED` in that case, while still storing the exact
+`PeerApplication(error_code)` in the shared connection terminal state. A future
+public connect error enum can expose that code without changing the h3 mapping.
+All one-shot sends are fallible because cancellation of the connect future is
+normal.
+
+### 10. Stream ID access can panic after shutdown (medium)
+
+[`get_id`](../msquic-h3/src/lib.rs#L675) queries a native parameter and unwraps
+both the MsQuic result and h3 conversion from the infallible `send_id` and
+`recv_id` trait methods. A late ID query after shutdown can therefore panic,
+and these trait methods have no error channel.
+
+Cache a validated `h3::quic::StreamId` before exposing an `H3Stream`. For local
+streams, replace the temporary `H3Stream` in `poll_open_inner` with an
+`OpeningStream`; `StartComplete` sends `Result<u64, Status>`, and a successful
+poll validates the ID before constructing `H3Stream` with concrete ID fields in
+both halves. A local-stream ID that fails h3 validation is an adapter/internal
+error surfaced as nested `ConnectionErrorIncoming::InternalError`, not
+`Unknown(Status)`. For accepted streams, `H3Stream::attach` performs two
+distinct fallible steps whose error types differ, so it cannot funnel both into
+`Result<H3Stream, Status>`:
+
+1. `Stream::get_stream_id() -> Result<u64, Status>` — a native failure keeps its
+   `Status` and returns it from `connection_callback`.
+2. `u64::try_into::<h3::quic::StreamId>() -> Result<_, h3::quic::InvalidStreamId>`
+   — MsQuic IDs are 62-bit so this branch is impossible by contract, but it must
+   still be handled: publish
+   `ConnectionTerminal::Internal("accepted stream ID is invalid")` and return
+   `Status::new(QUIC_STATUS_INTERNAL_ERROR)` from the callback.
+
+Remove the on-demand `get_id` helper. In both accepted cases below, failure
+drops the owned native stream and publishes a connection terminal (first-writer
+preserved), so the failure is h3-visible rather than only a native status.
+
+Returning a failure status from `connection_callback` does **not** tear down the
+connection. In MsQuic v2.5.1 the `PEER_STREAM_STARTED` handler
+(`stream_set.c`) checks the callback status and, on failure, calls
+`QuicStreamClose(Stream)` to reject and close **that individual native stream**
+as "not accepted" — the connection is untouched. The connection-level result is
+produced by the published terminal instead: a later `poll_accept_*` observes
+`ConnectionErrorIncoming::InternalError`, and h3's connection-error handling
+closes the QUIC connection with `H3_INTERNAL_ERROR`. Accepted-stream attachment
+failure therefore does both, using the same first-writer rules as every other
+connection terminal:
+
+1. Publish the winning h3 connection terminal and wake both acceptors: if
+   `ConnectionState` already holds a terminal reason, that winner is preserved;
+   otherwise publish `ConnectionTerminal::Internal` — with
+   `"accepted stream ID query failed"` for a native `get_stream_id` error, or
+   `"accepted stream ID is invalid"` for an h3 `InvalidStreamId`. Do not hold the
+   connection-state lock during the enqueue or the native-stream drop.
+2. Return failure from `PEER_STREAM_STARTED` (the preserved native `Status`, or
+   `QUIC_STATUS_INTERNAL_ERROR` for an invalid h3 ID) so MsQuic rejects and
+   closes the individual native stream.
+3. h3 observes `ConnectionTerminal::Internal` via the accept channel and invokes
+   connection close with `H3_INTERNAL_ERROR`.
+
+The rejected stream is never handed to h3.
+
+## Reference adapter behavior
+
+The reference adapters preserve the same boundaries:
+
+- `h3-quinn` maps peer application close to `ApplicationClose`, timeout to
+  `Timeout`, and other connection failures to `Undefined`.
+- Quinn open-stream failures are wrapped in
+  `StreamErrorIncoming::ConnectionErrorIncoming`.
+- Quinn `ReadError::Reset` and `WriteError::Stopped` become
+  `StreamTerminated` with the peer code.
+- `s2n-quic-h3` maps `StreamReset` to `StreamTerminated` and a stream's
+  `ConnectionError` to `ConnectionErrorIncoming`.
+- Both adapters implement `reset` by sending the supplied application code.
+- Both adapters report `send_data`-while-busy as `InternalError`, rather than
+  panicking.
+
+Sources:
+
+- [h3 0.0.8 QUIC traits](https://docs.rs/h3/0.0.8/h3/quic/index.html)
+- [h3-quinn 0.0.10 adapter](https://docs.rs/h3-quinn/0.0.10/src/h3_quinn/lib.rs.html)
+- [s2n-quic-h3 adapter](https://github.com/aws/s2n-quic/blob/main/quic/s2n-quic-h3/src/s2n_quic.rs)
+
+## Required mapping
+
+Terminal precedence is scoped rather than global:
+
+- the first connection terminal reason wins for the connection;
+- the first receive-side terminal reason wins for each stream;
+- the first send-side terminal reason wins for each stream.
+
+Consequently a receive reset does not suppress a distinct peer `STOP_SENDING`
+on the send half. Later `ShutdownComplete` events perform cleanup but do not
+overwrite an earlier terminal reason in the same scope.
+
+| MsQuic source | h3 result |
+| --- | --- |
+| `ConnectionEvent::ShutdownInitiatedByPeer { error_code }` | `ApplicationClose { error_code }` |
+| Transport status `QUIC_STATUS_CONNECTION_TIMEOUT` or `QUIC_STATUS_CONNECTION_IDLE` | `Timeout` |
+| Other `ShutdownInitiatedByTransport { status, error_code }` | `Undefined(Arc::new(MsQuicTransportError { status, error_code }))` |
+| Local connection close | `Undefined` with an adapter-owned local-close error; do not invent a peer code |
+| Connection channel closes without a recorded reason | `InternalError("connection closed without a terminal reason")` |
+| `StreamEvent::PeerSendAborted { error_code }` | Receive side: `StreamTerminated { error_code }` |
+| `StreamEvent::PeerReceiveAborted { error_code }` | Send side: `StreamTerminated { error_code }` |
+| Stream shutdown caused by connection shutdown | `ConnectionErrorIncoming { connection_error }` |
+| Failed `StartComplete` not caused by connection shutdown | `Unknown(Box::new(status))` |
+| Cancelled `SendComplete` with recorded peer/connection reason | The recorded `StreamTerminated` or connection error |
+| Cancelled `SendComplete` without a reason | `Unknown(QUIC_STATUS_ABORTED)` |
+| `Receive` with data and FIN | Deliver data, then `Ok(None)` on the next poll |
+| `Receive` with FIN and no data, or `PeerSendShutdown` | `Ok(None)` |
+| `Receive` with no data and no FIN | No terminal event |
+| `SendShutdownComplete { graceful: true }` | `poll_finish -> Ok(())` |
+| `SendShutdownComplete { graceful: false }` | Recorded stream/connection error, otherwise `Unknown` |
+
+The MsQuic transport `error_code` accompanying
+`ShutdownInitiatedByTransport` is a QUIC transport code, not an HTTP/3
+application code. It should be retained for diagnostics but must not be placed
+in `ApplicationClose`.
+
+Conversion helpers implement these exact terminal mappings:
+
+| Adapter terminal | h3 result |
+| --- | --- |
+| `ConnectionTerminal::PeerApplication(code)` | `ConnectionErrorIncoming::ApplicationClose { error_code: code }` |
+| `ConnectionTerminal::Timeout` | `ConnectionErrorIncoming::Timeout` |
+| `ConnectionTerminal::Transport { status, error_code }` | `ConnectionErrorIncoming::Undefined(Arc<MsQuicTransportError>)`, retaining both values |
+| `ConnectionTerminal::LocalClose` | `ConnectionErrorIncoming::Undefined(Arc<LocalConnectionClose>)` |
+| `ConnectionTerminal::Internal(message)` | `ConnectionErrorIncoming::InternalError(message.into())` |
+| `ReceiveTerminal::Fin` | `Ok(None)` |
+| `ReceiveTerminal::Reset(code)` | `StreamErrorIncoming::StreamTerminated { error_code: code }` |
+| `ReceiveTerminal::Connection(reason)` | `StreamErrorIncoming::ConnectionErrorIncoming` using the connection conversion |
+| `SendTerminal::Stopped(code)` | `StreamErrorIncoming::StreamTerminated { error_code: code }` |
+| `SendTerminal::Connection(reason)` | `StreamErrorIncoming::ConnectionErrorIncoming` using the connection conversion |
+| `ReceiveTerminal::Internal` or `SendTerminal::Internal` | `StreamErrorIncoming::ConnectionErrorIncoming` containing `ConnectionErrorIncoming::InternalError` |
+| `SendTerminal::LocalReset(code)` | `StreamErrorIncoming::Unknown(Box<LocalStreamReset>)` |
+| `SendTerminal::Failed(status)` | `StreamErrorIncoming::Unknown(Box::new(status))` |
+
+`MsQuicTransportError`, `LocalConnectionClose`, and `LocalStreamReset` are
+small adapter-owned `Debug + Display + Error` types. The transport error's
+display includes both the status and wire transport code.
+
+## Proposed adapter state
+
+Keep callback-facing state in small, adapter-owned enums that are `Clone` where
+multiple consumers need the reason. Convert to fresh h3 error values only at
+the polling boundary; h3's error enums themselves do not need to be cloneable.
+
+```rust
+#[derive(Clone)]
+enum ConnectionTerminal {
+    PeerApplication(u64),
+    Timeout,
+    Transport {
+        status: Status,
+        error_code: u64,
+    },
+    LocalClose,
+    Internal(&'static str),
+}
+
+enum ReceiveEvent {
+    Data(Bytes),
+    Fin,
+    Reset(u64),
+    Connection(ConnectionTerminal),
+}
+
+enum SendEvent {
+    Complete {
+        cancelled: bool,
+    },
+  TerminalWake,
+    FinishComplete {
+        graceful: bool,
+    },
+}
+
+#[derive(Clone)]
+enum ReceiveTerminal {
+    Fin,
+    Reset(u64),
+    Connection(ConnectionTerminal),
+    Internal(&'static str),
+}
+
+#[derive(Clone)]
+enum SendTerminal {
+    Stopped(u64),
+    Connection(ConnectionTerminal),
+    LocalReset(u64),
+    Failed(Status),
+    Internal(&'static str),
+}
+
+struct ConnectionState {
+    terminal: std::sync::Mutex<Option<ConnectionTerminal>>,
+}
+
+struct StreamState {
+    connection: Arc<ConnectionState>,
+    send_terminal: std::sync::Mutex<Option<SendTerminal>>,
+}
+
+enum IncomingStream<T> {
+    Stream(T),
+    Terminal(ConnectionTerminal),
+}
+```
+
+`LocalReset` is deliberately not converted to `StreamTerminated`, which means
+termination by the peer. h3 should not poll a send stream after calling
+`reset`; if it does, return `Unknown` with an adapter-owned local-reset error.
+Recording it still prevents a later non-graceful completion from being reported
+as an unrelated cancellation.
+
+### Connection terminal publication
+
+Store `Option<ConnectionTerminal>` behind a mutex in an `Arc` owned by
+`ConnHandle`. The connection callback, every locally opened stream, and every
+accepted stream receive a clone. The first writer sets the value; subsequent
+writes leave it unchanged.
+
+Create the shared state before `msquic::Connection::open` or before installing
+the callback on an accepted connection. The callback closure and `ConnHandle`
+each receive an `Arc` clone; this is not a cycle because the state does not own
+the native connection. `ConnCtxSender` also holds the clone, so
+`PeerStreamStarted` calls `H3Stream::attach(stream, state.clone())`.
+`H3Stream::open_and_start` accepts `&ConnHandle`, rather than only
+`&msquic::Connection`, and copies the same state into locally opened streams.
+Each stream creates one `Arc<StreamState>` shared by its callback and send
+frontend. Receive terminal ordering remains in the receive event channel;
+send-terminal publication uses `StreamState::send_terminal`.
+
+Returned `H3SendStream` and `H3RecvStream` values also contain the cached
+`StreamId`. Only `OpeningStream`, which is private to `StreamOpener`, may exist
+without one. Thus `send_id` and `recv_id` are plain field reads and remain
+infallible after shutdown.
+
+All mutex access uses a helper that recovers poisoned state with
+`PoisonError::into_inner`; an FFI callback must not panic merely because another
+task previously panicked while holding adapter state. Publication helpers insert
+the candidate only if the slot is empty, clone and return the stored winner,
+then release the lock before sending wakeups or acquiring any other lock. No
+code holds `ConnectionState` and `StreamState` locks at the same time. A
+fallback that loses a publication race therefore propagates the actual winner,
+not its rejected candidate.
+
+Publish the reason on `ShutdownInitiatedByPeer` or
+`ShutdownInitiatedByTransport`, then enqueue it to both incoming-stream
+channels. This preserves already queued streams ahead of the terminal event and
+wakes both accept methods. `OpenStreams::close` records `LocalClose` before
+calling `Connection::shutdown`, because an application-initiated shutdown may
+proceed directly to `ShutdownComplete`. Registration-wide shutdown and a bare
+`ShutdownComplete` use `LocalClose` if no more specific reason was published.
+
+The unidirectional and bidirectional channels carry
+`IncomingStream<H3Stream>`, not nested `Option` values. On `Terminal`, each
+accept frontend stores its own sticky copy and returns the converted connection
+error. Later polls return that error class without polling again. Channel
+closure before a terminal item stores and returns
+`Internal("incoming stream channel closed without a terminal reason")`.
+
+Stream callbacks primarily clone the shared reason when
+`StreamEvent::ShutdownComplete { connection_shutdown: true, .. }` arrives.
+Because connection and stream callbacks may execute concurrently, they also
+need this deterministic fallback when the shared slot is still empty:
+
+1. `connection_shutdown_by_app && connection_closed_remotely` becomes
+  `PeerApplication(connection_error_code)`.
+2. `connection_shutdown_by_app && !connection_closed_remotely` becomes
+  `LocalClose`.
+3. A timeout `connection_close_status` becomes `Timeout`.
+4. Any other connection close becomes `Transport { status:
+  connection_close_status, error_code: connection_error_code }`.
+5. A `ShutdownComplete` event with `connection_shutdown == false` does not
+  publish a connection terminal reason; it represents stream-local shutdown.
+
+This ordering follows MsQuic's implementation: `ConnectionShutdownByApp` is
+derived from the connection's `AppClosed` state, which is used for application
+close frames from either endpoint, while `ConnectionClosedRemotely` identifies
+which endpoint initiated the close. `ConnectionCloseStatus` cannot identify an
+application close because arbitrary HTTP/3 application codes may map to a
+generic MsQuic status.
+
+The fallback attempts to publish its derived value into the shared slot before
+notifying the stream halves. Whichever callback publishes first establishes the
+connection-wide result. The transport `error_code` is retained for diagnostics
+but is never converted to an HTTP/3 application close code.
+
+### Receive-side transitions
+
+The receive callback enqueues data before a terminal event from the same MsQuic
+notification. `Receive` with FIN therefore produces `Data` followed by `Fin`.
+`PeerSendShutdown` produces `Fin`; `PeerSendAborted` produces `Reset(code)`.
+Empty non-FIN receive notifications produce no event.
+
+`StreamSendCtx` tracks whether a receive terminal event has already been sent.
+The first `Fin`, `Reset`, or connection terminal wins and suppresses later
+receive events. This prevents the normal MsQuic sequence of `Receive { FIN }`
+followed by `PeerSendShutdown` from queueing duplicate FIN events. Data from a
+single `Receive { data, FIN }` event is always enqueued before setting and
+enqueueing the terminal marker.
+
+`poll_data` drains one event at a time. `Data` returns `Ok(Some(data))`; a
+terminal event is stored in `RecvStreamReceiveCtx` and converted to `Ok(None)`
+for `Fin`, `StreamTerminated` for `Reset`, or
+`ConnectionErrorIncoming` for a connection terminal. Once stored, every later
+poll returns the same class of result without polling the channel. A closed
+channel without a terminal event becomes `Internal`.
+
+### Send-side transitions
+
+For `SendComplete`, the callback first reconstructs and drops the
+`Box<SendBuffer>`, then enqueues `Complete { cancelled }`. It maps
+`SendShutdownComplete` to `FinishComplete { graceful }`. On
+`PeerReceiveAborted`, it publishes `Stopped(code)` and enqueues `TerminalWake`;
+connection-caused `ShutdownComplete` publishes `Connection(reason)` and also
+enqueues `TerminalWake`. Failed channel delivery drops only the small event
+value and does not panic or affect buffer ownership.
+
+`client_context` must be non-null because every successful adapter send passes
+one `Box<SendBuffer>`. The callback checks it with `NonNull::new` before
+`Box::from_raw`; a null value publishes `SendTerminal::Internal` and sends a
+wakeup event instead of invoking undefined behavior. The design relies on the
+MsQuic `StreamSend` contract that a successful submission returns its context
+exactly once in `SendComplete`, while a failed submission does not take
+ownership and produces no completion.
+
+Send terminal publication is synchronous and shared between callback and
+frontend state. `PeerReceiveAborted` stores `Stopped(code)` before enqueueing
+its wakeup event; connection shutdown stores `Connection(reason)` before its
+wakeup event. `send_data`, `poll_ready`, and `poll_finish` consult this slot
+before invoking MsQuic. Unlike receive state, send state has no queued payload
+ordering to preserve. MsQuic processes `STOP_SENDING` by delivering
+`PeerReceiveAborted` before cancelling send requests, so a following cancelled
+`SendComplete` observes the exact `Stopped(code)` reason. A cancelled completion
+without any published peer or connection reason remains `Failed(ABORTED)`.
+
+`poll_ready` uses this order:
+
+1. Return the stored `SendTerminal`, if any.
+2. Poll queued send events even when no send is in progress. This makes a peer
+   `STOP_SENDING` visible before the current early `Ok(())` path.
+3. `TerminalWake` reloads and returns the sticky shared terminal. A wake marker
+   without a terminal stores and returns `SendTerminal::Internal`.
+4. `Complete { cancelled: false }` clears `send_inprogress` and returns
+   `Ok(())`; the callback has already reclaimed the buffer.
+5. A cancelled completion returns the already recorded peer/connection
+   terminal reason. If none exists, store and return
+   `Failed(QUIC_STATUS_ABORTED)`; its buffer was also already reclaimed.
+6. If no event is queued, return `Pending` while a send is in progress and
+   `Ready(Ok(()))` otherwise. Polling the channel first registers the waker in
+   either case.
+
+A direct `poll_ready` call after `finish_started` is an adapter/h3 contract
+misuse and returns the nested `InternalError`; `poll_finish` processes finish
+events directly after that point.
+
+`send_data` first rejects stored terminal state, then returns
+`StreamErrorIncoming::ConnectionErrorIncoming` containing
+`ConnectionErrorIncoming::InternalError` if `send_inprogress` is already true
+or graceful finish has started. No native send occurs in either misuse case.
+After successful native submission it sets `send_inprogress = true`. Immediate
+native failures use a shared conversion helper: a published connection reason
+becomes `ConnectionErrorIncoming`; otherwise the `Status` remains `Unknown`.
+
+`poll_finish` first returns `Ok(())` when `finish_complete` is already set, then
+checks a stored terminal error. Successful finish is absorbing: a later
+connection shutdown does not retroactively change a completed finish. While a
+send is in progress it delegates to `poll_ready`; after readiness it continues
+in the same poll. It then submits
+`GRACEFUL` exactly once and sets `finish_started`. Subsequent polls only process
+events. `FinishComplete { graceful: true }` sets `finish_complete` and returns
+`Ok(())`. A non-graceful completion returns an already stored peer/connection
+terminal reason, or stores `Failed(QUIC_STATUS_ABORTED)` if no specific reason
+exists. A `Complete` event encountered after finish starts is consumed normally;
+any impossible event/state combination becomes `SendTerminal::Internal`.
+If the native `GRACEFUL` submission fails immediately, publish an already
+available connection terminal or `Failed(status)` and return it; do not retry
+the shutdown on a later poll.
+
+`reset(code)` emits `SubmitReset(code)` only when no send terminal is stored.
+After the native call, it publishes `LocalReset(code)` on success or
+`Failed(status)` on failure, each only if a peer or connection terminal did not
+win concurrently. A reset may replace a graceful finish that has started but
+not completed; after `finish_complete`, reset is a no-op. Because the trait
+method is infallible, the stored state is surfaced only if h3 polls the stream
+again.
+
+`stop_sending(code)` submits `ABORT_RECEIVE` with the clamped code. Because the
+trait method is infallible and terminal — h3 has declared it will no longer
+consume the receive side — an immediate `Stream::shutdown` error is treated as
+best effort: log it under the `tracing` feature and return. Do not panic and do
+not attempt to inject a receive terminal. The clamp to the 62-bit maximum still
+applies.
+
+All application codes passed to MsQuic use one helper that clamps `u64` to an
+adapter constant `MAX_QUIC_VARINT: u64 = (1 << 62) - 1` without panicking.
+(`msquic::u62` is only a `u64` type alias and has no narrowed `MAX`.) h3's own
+codes are already in range, but this prevents arbitrary trait callers from
+violating the native precondition in `reset` or `stop_sending`.
+Connection close receives `h3::error::Code` and is already valid. Incoming
+MsQuic codes are `u62` and require no normalization.
+
+### Native stream teardown on drop
+
+**Support policy.** The adapter keeps direct final-owner drop: the native
+`msquic::Stream` lives behind an `Arc` shared by both public halves, and
+dropping the last owner runs the binding's `Drop`, which calls `StreamClose`.
+This is memory-safe and leak-free for send-buffer reclamation (argued below),
+and is treated as a *tested compatibility expectation* — asserted by the
+outstanding-send teardown test — rather than as a universal guarantee extracted
+from MsQuic's documentation. Strict deferred-until-`ShutdownComplete` ownership
+is explicitly not adopted.
+
+Dropping the last owner calls `StreamClose` without an explicit prior shutdown.
+For reclamation this is well-defined. MsQuic's public stream documentation
+(`docs/Streams.md`) states: "If the app closes a stream before it is shutdown,
+the stream will be shutdown abortively with an error code of `0`," and further
+that an app may "abortively shutdown a stream and immediately close it from the
+same thread, without waiting for the `QUIC_STREAM_EVENT_SHUTDOWN_COMPLETE`
+event." The v2.5.1 implementation matches this: `QuicStreamClose` on a
+started-but-unshutdown stream logs a `CloseWithoutShutdown` warning and performs
+an internal `ABORT_SEND | ABORT_RECEIVE | IMMEDIATE` shutdown with
+`QUIC_ERROR_NO_ERROR` (code `0`). Because MsQuic runs callbacks inline during
+close (it blocks until all work drains) and still dispatches while
+`HandleClosed` is set, any outstanding send receives its cancelled
+`SendComplete` before the binding drops the callback context. The
+`Box<SendBuffer>` is therefore reclaimed exactly once even on drop-triggered
+teardown; no explicit shutdown-before-close is required for memory safety or
+leak freedom.
+
+MsQuic's public documentation is not fully consistent on close-before-shutdown,
+and the design should not paper over that. The API-specific
+[`StreamClose.md`](https://github.com/microsoft/msquic/blob/v2.5.1/docs/api/StreamClose.md)
+(present upstream, though only top-level `docs/` ships in the crate tarball)
+says closing before full shutdown "produces **undefined behavior**," while
+`docs/Streams.md` says the stream "will be shutdown abortively with an error
+code of `0`." The reconciliation is in `StreamClose.md`'s own explanation: the
+unspecified part is strictly the **wire error code** — "clean up ... must be
+reflected on the wire with an application specific error code. When the app
+closes a stream without first shutting down, MsQuic has to guess which error
+code to use (currently uses `0`)." It is not a statement about memory safety or
+about whether outstanding sends are completed; the same paragraph confirms
+MsQuic does perform the cleanup (with code `0`). So the contradiction is about
+protocol-quality (which HTTP/3 code the peer sees), not about `SendBuffer`
+reclamation.
+
+The one residual is a quality concern, not a safety gate: a plain drop of a
+still-active stream aborts it toward the peer with code `0` rather than a
+meaningful HTTP/3 code, and would convert an in-flight graceful finish into an
+abort. h3 normally finishes or `reset`s a stream before dropping it, so this
+only affects abnormal cancellation. Emitting an explicit abort with a chosen
+code before close is a reasonable future enhancement; it is intentionally out of
+scope for this change.
+
+#### Why the "native stream owner" redesign is rejected
+
+A prior review proposed gating implementation on an adapter-owned native stream
+that defers `StreamClose` until `StreamEvent::ShutdownComplete` is observed,
+calling close-before-shutdown undefined behavior. As reconciled above, the
+"undefined behavior" language in `StreamClose.md` is scoped to the wire error
+code, which MsQuic resolves to `0`; it is not a memory-safety hazard. Exactly-
+once `Box<SendBuffer>` reclamation does not depend on an inspected internal: it
+follows from the abortive cancellation of outstanding sends (each returns its
+`SendComplete` context exactly once) plus the Rust binding keeping the callback
+context alive until `StreamClose` returns.
+
+That last point is load-bearing and is **not** specific to this adapter or to
+the bundled v2.5.1 source. The `msquic` binding's `close_inner` is identical for
+every handle type: `get_callback_ctx()` → native `*Close(...)` → `drop(ctx)`
+(the `Connection` variant even comments "During handle close the ctx might still
+be used"). The binding already assumes, for all of `Connection`, `Listener`, and
+`Stream`, that the native close call drains and dispatches every pending
+callback inline before it returns. A `libmsquic` that violated that — delivering
+an outstanding `SendComplete` asynchronously *after* close returns — would
+deliver into a freed callback context and break the binding wholesale, not
+merely this adapter. This is therefore treated as a **tested compatibility
+expectation** — asserted by the outstanding-send teardown test below against
+whatever library is linked — rather than an ironclad guarantee extracted from
+every MsQuic distribution's documentation. Adopting strict deferred-until-
+`ShutdownComplete` ownership (a connection-owned close queue with cross-callback
+lifetime coordination) is rejected: it adds substantial machinery for no
+memory-safety or leak benefit over this tested expectation.
+
+A later review then proposed a lighter `NativeStream { Drop -> shutdown(ABORT |
+INLINE) }` wrapper instead of a deferred-close queue. That does not work either
+and is also rejected: `MsQuicStreamShutdown` accepts `IMMEDIATE` only when
+`Flags` equals *exactly* `IMMEDIATE | ABORT_SEND | ABORT_RECEIVE`, so
+`IMMEDIATE | INLINE` is `QUIC_STATUS_INVALID_PARAMETER`; and `ABORT | INLINE`
+(without `IMMEDIATE`) does not imply `ShutdownComplete`, so the subsequent field
+drop still runs `StreamClose` before full shutdown. A synchronous `Drop` hook
+cannot wait for the asynchronous `ShutdownComplete` (which `StreamShutdown.md`
+notes is delivered "not necessarily inline to the call"), so the wrapper adds no
+memory-safety guarantee over MsQuic's own close-time abort — only wire-code
+quality, which is the deferred enhancement below.
+
+Two smaller points from those reviews are retained but deferred, not blocking:
+
+1. **Meaningful abandonment code.** MsQuic's own docs recommend an explicit
+   abort with a meaningful code before close (`StreamClose.md`: shutdown with
+   `ABORT | IMMEDIATE` and an error code, then close after `SHUTDOWN_COMPLETE`).
+   Sending an intentional `ABORT_SEND | ABORT_RECEIVE` code on abnormal
+   abandonment (instead of the default `0`) is a protocol-quality enhancement,
+   tracked separately. If added, it must use a valid flag combination —
+   `ABORT` alone, or the documented `ABORT | IMMEDIATE` — never
+   `IMMEDIATE | INLINE`, per the flag-validation rule above.
+2. **Native library provenance.** This crate uses `default-features = false`
+   (and the `find` dev feature can link a system `libmsquic.so.2`), so the
+   linked library may not be the bundled v2.5.1 source. This is acceptable
+   because the reclamation behavior relied upon is the general MsQuic close
+   model already assumed by the binding for every handle type, and it is
+   asserted directly by the outstanding-send teardown test below rather than
+   taken on faith.
+
+**Supported native configuration.** The tested compatibility expectation is
+scoped to the configurations CI actually exercises, so a downstream user linking
+a system library is not silently assumed supported:
+
+- Supported = the exact native MsQuic versions and platform builds listed in the
+  CI matrix (the version the `msquic` crate binds, plus any others explicitly
+  added), each having passed the outstanding-send teardown conformance test.
+- Any other library — a different patch/minor `v2.5.x`, a different major, or a
+  system `libmsquic.so.2` — is unsupported until it is added to CI and passes
+  that test; such users must run the named test against their library before
+  deployment. A floating "all v2.5.x" claim is intentionally avoided.
+- Bumping the `msquic` crate or the native library version requires rerunning
+  the teardown test and re-reviewing `StreamClose` and send-cancellation
+  behavior.
+- A conformance failure is reported as an unsupported native environment, not as
+  an adapter test flake. The exact matrix and test command live in the
+  development documentation once the tests exist.
+
+**Release gate.** Before release, record the exact supported native
+versions/platforms and the teardown test command in
+[`docs/Development.md`](Development.md) and link that matrix from this teardown
+section. Until that list exists, "supported" has no auditable configuration and
+the release is gated (this is a documentation gate, not an additional
+state-machine change).
+
+Implement send transitions as a production reducer, not duplicated branches.
+There is exactly one authoritative sticky terminal slot,
+`StreamState::send_terminal` (the `Arc`-shared, poison-safe mutex the callback
+publishes into). The reducer does **not** keep its own terminal copy; instead
+the caller reads the shared winner and passes it into every input, and the
+reducer publishes local candidates back through a command:
+
+```rust
+struct SendState {
+    // `send_submitting` / `finish_submitting` / `reset_submitting` are
+    // transaction reservations set before the native call so a reentrant or
+    // repeated input cannot emit a second submission; each is cleared when its
+    // matching `*Submitted` result is fed back. `send_inprogress` is committed
+    // only on `SendSubmitted(Ok)`; `finish_started` only on `GracefulSubmitted(Ok)`.
+    send_submitting: bool,
+    send_inprogress: bool,
+    finish_submitting: bool,
+    finish_started: bool,
+    finish_complete: bool,
+    reset_submitting: bool,
+}
+
+/// Which frontend method initiated a `PublishTerminal`, so the reducer can
+/// choose the correct continuation once the first-writer winner is known.
+enum TerminalContinuation {
+    SendData,
+    PollReady,
+    PollFinish,
+    Reset,
+}
+
+/// Outcome of polling the `mpsc` send-event channel. Distinguishing `Closed`
+/// from `Pending` is required: a channel closed without a terminal item is an
+/// adapter-internal error, not "no event yet".
+enum SendPoll {
+    Pending,
+    Event(SendEvent),
+    Closed,
+}
+
+/// `send_data` payload classification, computed after conversion into
+/// `WriteBuf<B>` but before any owned bytes are materialized.
+enum SendPayload {
+    Empty,
+    NonEmpty { len: u32 },
+    Oversized { len: usize },
+}
+
+enum SendInput {
+    /// A `send_data` request; `payload` is classified before allocation.
+    SendRequested { payload: SendPayload, terminal: Option<SendTerminal> },
+    /// Immediate result of the `SubmitSend` native call.
+    SendSubmitted { result: Result<(), Status>, terminal: Option<SendTerminal> },
+    /// A `poll_ready` request, carrying the send-channel poll outcome.
+    PollReady { poll: SendPoll, terminal: Option<SendTerminal> },
+    /// A `poll_finish` request, carrying the send-channel poll outcome.
+    PollFinish { poll: SendPoll, terminal: Option<SendTerminal> },
+    /// A `reset(code)` request.
+    Reset { code: u64, terminal: Option<SendTerminal> },
+    /// Immediate result of a `SubmitGraceful` native call.
+    GracefulSubmitted { result: Result<(), Status>, terminal: Option<SendTerminal> },
+    /// Immediate result of a `SubmitReset` native call.
+    ResetSubmitted { code: u64, result: Result<(), Status>, terminal: Option<SendTerminal> },
+    /// The actual winner returned by the first-writer publish helper, fed back
+    /// after a `PublishTerminal` command, tagged with its initiating method.
+    TerminalPublished { winner: SendTerminal, continuation: TerminalContinuation },
+}
+
+/// One-shot, non-sticky adapter error for `send_data`. Unlike `SendTerminal`,
+/// it is never stored in the shared slot; a later `poll_ready` is unaffected.
+enum SendOperationError {
+    OversizedSend { len: usize },
+    Misuse(&'static str),
+}
+
+enum SendCommand {
+    /// `Poll::Pending`; the caller has already registered the waker.
+    Pending,
+    /// Infallible no-op (e.g. `reset` after `finish_complete`).
+    NoOp,
+    /// `send_data` success / no-op (empty payload); no bytes submitted.
+    ReturnSent,
+    /// Construct the allocation and call `Stream::send`; result -> `SendSubmitted`.
+    SubmitSend,
+    /// Call graceful/reset shutdown; result -> `GracefulSubmitted`/`ResetSubmitted`.
+    SubmitGraceful,
+    SubmitReset(u64),
+    /// Re-poll the send channel and feed a fresh `PollFinish`. Used after a
+    /// successful graceful submission so a synchronously-queued `FinishComplete`
+    /// is consumed and, failing that, the waker is registered before `Pending`.
+    RepollFinish,
+    /// Publish a local terminal candidate via the first-writer helper; the
+    /// resolved winner is fed back as `TerminalPublished { winner, continuation }`.
+    PublishTerminal { candidate: SendTerminal, continuation: TerminalContinuation },
+    /// Return a one-shot, non-sticky `send_data` error (oversized / misuse).
+    ReturnImmediateError(SendOperationError),
+    ReturnReady,
+    ReturnFinished,
+    ReturnError(SendTerminal),
+}
+
+/// Pure, native-free transition. Mutates only `SendState` and emits one command.
+fn transition(state: &mut SendState, input: SendInput) -> SendCommand;
+```
+
+`transition` is pure and holds no native handle and no terminal slot, so it is
+exhaustively unit testable. All `SendState` mutation happens inside it; the
+caller only executes the returned `SendCommand` and feeds results back as
+further inputs. This keeps a single terminal owner and an explicit reducer
+boundary for observing and publishing it:
+
+- The caller loads the current `StreamState::send_terminal` winner (poison-safe)
+  and passes it as the `terminal` field of the input. Terminal precedence is
+  **input-specific, not global** — a shared winner must never pre-empt the
+  bookkeeping a `*Submitted` result owes its reservation. The reducer evaluates
+  each input in four ordered groups:
+
+  1. **Submitted-result bookkeeping first.** `SendSubmitted`,
+     `GracefulSubmitted`, and `ResetSubmitted` always validate and clear their
+     matching reservation (or commit success) *before* any terminal is
+     considered. Only then is a raced shared winner applied to the frontend
+     result. This prevents a stale `finish_submitting`/`reset_submitting` and
+     lets infallible `reset` end in `NoOp` even when a terminal raced in.
+  2. **Absorbing success next.** `finish_complete` makes `PollFinish` return
+     `ReturnFinished` before considering later terminals.
+  3. **Queued successful finish next.** A
+     `PollFinish(Event(FinishComplete { graceful: true }))` while `finish_started`
+     sets `finish_complete` and returns `ReturnFinished` **before** method
+     terminal handling. Channel order is the tiebreaker: if the successful finish
+     event was queued ahead of a later `TerminalWake`, finish is absorbing and
+     wins; a terminal queued first is processed first and wins. This exception
+     applies only to graceful finish — never to a terminal wake or a non-graceful
+     finish.
+  4. **Method-specific terminal handling.** A current shared winner produces an
+     error for `send_data`/`poll_ready`/`poll_finish`, but `NoOp` for `reset`
+     (after clearing any reset reservation).
+  5. **Event rows last.** The channel poll outcome is processed only when no
+     earlier group returns.
+- `send_data` is inside the machine and classifies its payload before allocating
+  any bytes. `SendRequested { payload, terminal }` applies this precedence, and
+  no owned bytes are materialized before the final row: (1) a shared `terminal`
+  winner returns that error; (2) `send_inprogress` or a finish/submission
+  reservation is h3 misuse (`ReturnImmediateError(Misuse)`); (3) `SendPayload::Empty`
+  is a successful no-op (`ReturnSent`, no reservation, no native send);
+  (4) `SendPayload::Oversized` returns the non-sticky
+  `ReturnImmediateError(OversizedSend { len })`, leaving all state unchanged and
+  publishing nothing; (5) `SendPayload::NonEmpty` reserves `send_submitting =
+  true` and emits `SubmitSend`. `SendSubmitted(Ok)` clears `send_submitting`,
+  sets `send_inprogress = true` exactly once, and returns `ReturnSent`
+  (`send_data`'s `Ok(())`) — not `ReturnReady`, which belongs to `poll_ready`;
+  `SendSubmitted(Err)` clears `send_submitting`, leaves `send_inprogress` false
+  (the caller reclaims the `SendBuffer` first), and **publishes sticky
+  `Failed(status)`** unless a peer or connection terminal already won — a failed
+  native send means the stream is unusable, so a later `poll_ready` must not
+  report ready. A `SendSubmitted` without an outstanding `send_submitting`
+  reservation publishes adapter `Internal`. A synchronous `SendComplete` queued
+  by the native call is consumed on the next poll and clears `send_inprogress`
+  normally.
+- Local terminal candidates (`Failed(status)` from immediate graceful/reset
+  failure, `LocalReset(code)` on successful reset, `Internal` for a lone
+  `TerminalWake`) are emitted as
+  `PublishTerminal { candidate, continuation }`. The caller runs the
+  first-writer helper — which returns the actual winner, possibly a
+  callback-published `Stopped`/`Connection` that raced in — and feeds
+  `TerminalPublished { winner, continuation }` back. No native call or channel
+  send occurs while the terminal lock is held. The winner, not the rejected
+  candidate, is what every later `send_data`/`poll_ready`/`poll_finish` returns.
+  The `continuation` tag records which method initiated the publish, because
+  `SendState` alone cannot distinguish them; `&mut self` serialization means at
+  most one publish loop is in flight, so the tag is unambiguous. Its result:
+
+  | `continuation` | Result after publication |
+  | --- | --- |
+  | `SendData` | `Err(StreamErrorIncoming)` from `send_data` |
+  | `PollReady` | `Poll::Ready(Err(winner))` |
+  | `PollFinish` | `Poll::Ready(Err(winner))` |
+  | `Reset` | Return from the infallible method; the winner is stored for a later poll, no second native op |
+
+Keeping submission results and the published winner as explicit inputs — rather
+than mutating state around the native call — fixes ordering under synchronous
+callbacks and immediate failure.
+
+#### Send transition table
+
+Frontend methods are serialized by `&mut self`; callback events are queued
+concurrently but observed only as the `PollReady`/`PollFinish` `poll` outcome
+(`SendPoll::{Pending, Event(..), Closed}`). Rows are grouped by the precedence
+above: submitted-result bookkeeping, then absorbing finish, then method-specific
+terminal, then event rows. Every submission command has exactly one matching
+`*Submitted` result input, and a reservation flag
+(`send_submitting` / `finish_submitting` / `reset_submitting`) blocks a duplicate
+submission until that result arrives. In the tables, `winner` means the shared
+terminal passed in (possibly a raced callback `Stopped`/`Connection`).
+
+Submitted-result inputs (bookkeeping runs before terminal precedence):
+
+| Input | State mutation | Command |
+| --- | --- | --- |
+| `SendSubmitted(Ok)` | require `send_submitting`; clear it; `send_inprogress = true` | `ReturnSent`, or `ReturnError(winner)` if a winner raced in |
+| `SendSubmitted(Err)` | require `send_submitting`; clear it; stays not in progress; allocation already reclaimed | `PublishTerminal{winner or Failed(status), SendData}` (sticky) |
+| `GracefulSubmitted(Ok)` | require `finish_submitting`; clear it; `finish_started=true` | `RepollFinish` (never `Pending` directly) |
+| `GracefulSubmitted(Err)` | require `finish_submitting`; clear it (no retry) | `PublishTerminal{winner or Failed(status), PollFinish}` |
+| `ResetSubmitted(Ok)` | require `reset_submitting`; clear it | `PublishTerminal{winner or LocalReset(code), Reset}` |
+| `ResetSubmitted(Err)` | require `reset_submitting`; clear it | `PublishTerminal{winner or Failed(status), Reset}` |
+| any `*Submitted` without its reservation | none | `PublishTerminal{Internal, <continuation>}` (never panic) |
+
+Request and event inputs:
+
+| Input | Relevant state | State mutation | Command |
+| --- | --- | --- | --- |
+| `SendRequested{terminal:Some(winner)}` | any | none | `ReturnError(winner)` |
+| `SendRequested` | `send_inprogress` / `send_submitting` / finishing | none | `ReturnImmediateError(Misuse)` |
+| `SendRequested{Empty}` | idle, no winner | none | `ReturnSent` (no-op, no reservation) |
+| `SendRequested{Oversized{len}}` | idle, no winner | none | `ReturnImmediateError(OversizedSend{len})` (state unchanged) |
+| `SendRequested{NonEmpty}` | idle, no winner | `send_submitting=true` | `SubmitSend` |
+| `Reset` | `finish_complete` or terminal stored | none | `NoOp` |
+| `Reset` | `send_submitting`/`finish_submitting`/`reset_submitting` set | none | `PublishTerminal{Internal, Reset}` (impossible under serialized callers; never a 2nd native op) |
+| `Reset` | otherwise (incl. incomplete finish) | `reset_submitting=true` | `SubmitReset(code)` |
+| `PollReady`/`PollFinish` while a submission reservation is set | any | none | `PublishTerminal{Internal, <caller>}` (impossible under serialized callers) |
+| `PollReady` / `PollFinish` `Closed` | any, no winner | none | `PublishTerminal{Internal("send channel closed without a terminal"), <caller>}` |
+| `PollReady` / `PollFinish` `Closed` | winner present | none | error(winner) via caller continuation |
+| `PollReady` after `finish_started` | any | none | `ReturnError(Internal)` (h3 misuse; no native call) |
+| `PollReady(Event(Complete{cancelled:false}))` | send pending | `send_inprogress=false` | `ReturnReady` |
+| `PollReady(Event(Complete{cancelled:true}))` | send pending | `send_inprogress=false` | `PublishTerminal{winner or Failed(ABORTED), PollReady}` |
+| `PollReady(Event(TerminalWake))` | any | none | `PublishTerminal{winner or Internal, PollReady}` |
+| `PollReady(Pending)` | send pending | none | `Pending` |
+| `PollReady(Pending)` | idle | none | `ReturnReady` |
+| `PollFinish(_)` | `finish_complete` | none | `ReturnFinished` (absorbing) |
+| `PollFinish(Event(Complete{cancelled:false}))` | send pending, not finishing | `send_inprogress=false`, `finish_submitting=true` | `SubmitGraceful` |
+| `PollFinish(Event(Complete{cancelled:true}))` | send pending, not finishing | `send_inprogress=false` | `PublishTerminal{winner or Failed(ABORTED), PollFinish}` |
+| `PollFinish(Event(TerminalWake))` | any (not complete) | none | `PublishTerminal{winner or Internal, PollFinish}` |
+| `PollFinish(Pending)` | idle, not finishing | `finish_submitting=true` | `SubmitGraceful` |
+| `PollFinish(Event(FinishComplete{graceful:true}))` | `finish_started` | `finish_complete=true` | `ReturnFinished` |
+| `PollFinish(Event(FinishComplete{graceful:false}))` | `finish_started` | none | `PublishTerminal{winner or Failed(ABORTED), PollFinish}` |
+| `PollFinish(Pending)` | `finish_started`, not complete | none | `Pending` |
+| any impossible event/state combination | none | none | `PublishTerminal{Internal, <caller>}` (never panic) |
+
+Notes: submitted-result bookkeeping (top table) always runs before the winner is
+applied, so a raced terminal cannot leave a reservation stale or force
+infallible `reset` down an error path. Successful finish is absorbing \u2014 the
+`finish_complete` row precedes any terminal row; additionally a *queued*
+`FinishComplete{graceful:true}` (while `finish_started`) is processed before
+method-terminal handling, so if that success event was enqueued ahead of a later
+`TerminalWake`, finish wins on channel order (graceful finish only; a terminal
+wake or non-graceful finish still lets the shared winner win).
+`GracefulSubmitted(Ok)` returns `RepollFinish`, never `Pending` directly:
+because `futures` mpsc registers the receiver waker only on a `Pending` poll, a
+synchronously-queued `FinishComplete` must be drained (or the waker re-armed) by
+re-polling in the same `poll_finish` call, otherwise the wakeup is lost.
+Successful `send_data` returns `ReturnSent` (`Ok(())`), never `ReturnReady`
+(which is `poll_ready` only). `PollFinish` after consuming a
+successful `Complete` continues to `SubmitGraceful` in the same poll. An
+unexpected or impossible event is adapter `Internal`, never a panic. Unit tests
+call the reducer and prove that repeated finish polls
+emit `SubmitGraceful` exactly once and reset emits exactly one
+`SubmitReset(code)` without a mock native stream abstraction.
+
+
+Recommended structural changes:
+
+1. Store the connection's first terminal reason in shared state owned by
+  `ConnHandle` and available to the connection callback, stream openers, and
+  streams.
+2. Change incoming-stream channels to carry either a stream or a terminal
+   connection reason. Wake both unidirectional and bidirectional acceptors when
+   shutdown begins.
+3. Replace implicit stream-channel closure with explicit `ReceiveEvent` and
+   `SendEvent` terminal items. Channel closure without an item is an internal
+   adapter error.
+4. Preserve event order: queued receive data is yielded before a following FIN
+   or reset event.
+5. Make connection, receive, and send terminal states independently sticky.
+   Every poll after termination returns the same class of result without
+   invoking MsQuic again.
+6. Make all callback sends fallible and non-panicking. Ensure a failed
+   `SendComplete` delivery cannot affect buffer reclamation because the callback
+   drops its concrete `Box<SendBuffer>` first.
+7. Add `finish_started` and `finish_complete` state so graceful shutdown is
+   submitted once and later polls are side-effect free.
+8. Preserve the existing `B: Buf` trait bounds by owning the complete wire
+   bytes before crossing FFI.
+
+## Test plan
+
+Most conversion and channel behavior can be tested without a network by
+constructing callback events and polling the corresponding receiver.
+
+Required unit tests:
+
+- peer application close preserves its non-zero code for both accept methods;
+- idle and connection timeout map to `Timeout`;
+- another transport status maps to `Undefined`, not `ApplicationClose`;
+- `PeerSendAborted` makes `poll_data` return `StreamTerminated` with the code;
+- `PeerReceiveAborted` makes `poll_ready` and `poll_finish` return
+  `StreamTerminated` with the code;
+- data followed by FIN yields `Some(data)` and then `None`;
+- an empty non-FIN receive event does not yield EOF;
+- connection shutdown while stream start is pending returns a connection error
+  without panic;
+- stream open after a published connection terminal performs no native open;
+- dropping either split stream half before callbacks does not panic;
+- failed `SendComplete` delivery reclaims the send allocation;
+- cancelled `SendComplete` reclaims the allocation and prefers an already
+  recorded peer or connection reason;
+- `send_data` while busy returns `InternalError` rather than panicking;
+- `send_data` after finish starts returns `InternalError` and performs no
+  native send;
+- receive reset and send stop on the same bidirectional stream remain
+  independently observable;
+- a stream connection shutdown can derive and publish a terminal reason before
+  the connection callback runs;
+- accepted and locally opened streams share the same connection terminal slot;
+- accepted-stream attachment failure publishes
+  `ConnectionTerminal::Internal`, wakes both acceptors, and does not expose the
+  rejected stream; an already published peer or transport terminal wins over
+  it;
+- a native `get_stream_id` failure returns its `Status` from the callback while
+  a synthetic invalid h3 `StreamId` publishes the internal terminal and returns
+  `QUIC_STATUS_INTERNAL_ERROR`; a local-stream invalid ID surfaces nested
+  `InternalError`;
+- queued incoming streams drain in order before a following
+  `IncomingStream::Terminal`, for both the unidirectional and bidirectional
+  channels;
+- FIN from both `ReceiveFlags::FIN` and `PeerSendShutdown` is published once;
+- a borrowed, non-`Send` `Buf` is copied before `send_data` returns and is not
+  retained across FFI;
+- a send length validation helper accepts exactly `u32::MAX`, rejects
+  `u32::MAX + 1` as `OversizedSend`, and performs that rejection before any
+  materialization or native submission (exercise the pure helper with synthetic
+  lengths, not real multi-gigabyte allocations);
+- an accepted non-empty send constructs exactly one `BufferRef` whose length
+  equals the owned byte length;
+- empty `send_data` input is a no-op that does not set `send_inprogress` or wait
+  for a completion;
+- an oversized-send rejection leaves finish and terminal state unchanged;
+- `SendRequested` payload precedence: an empty send after a peer/connection
+  terminal returns the winner, an empty send after finish started returns
+  `Misuse`, oversized-while-busy follows the misuse-before-size order, and only
+  `NonEmpty` sets `send_submitting` and emits `SubmitSend`;
+- `SendRequested` reserves exactly one submission: a second `SendRequested`
+  while `send_submitting` cannot emit another `SubmitSend`, and both
+  `SendSubmitted(Ok)` and `(Err)` clear `send_submitting`;
+- a `SendSubmitted` (or other `*Submitted`) without its reservation publishes
+  `Internal` and cannot mark the stream in progress;
+- an immediate `SendSubmitted(Err)` publishes sticky `Failed(status)` (unless a
+  peer/connection terminal wins), so a later `poll_ready` does not report ready;
+- a method input arriving while a submission reservation is set publishes
+  `Internal` and issues no second native command;
+- poisoned adapter mutex state cannot panic an MsQuic callback;
+- the send reducer emits `SubmitGraceful` once across repeated finish polls and
+  emits one `SubmitReset(code)` for reset;
+- the send reducer never sets `send_inprogress` on an immediate
+  `SendSubmitted { Err }`, and sets it exactly once on `SendSubmitted { Ok }`;
+- successful `send_data` (empty or submitted non-empty) returns `Ok(())` via
+  `ReturnSent`, and `SendSubmitted(Ok)` never emits `ReturnReady`;
+- `GracefulSubmitted(Ok)` emits `RepollFinish`: a synchronously-queued
+  `FinishComplete(true)` is consumed in the same `poll_finish` call, and when no
+  finish event is queued the repoll registers the waker before returning
+  `Pending` (works both after an idle pending channel and after a ready
+  `SendComplete`);
+- a `FinishComplete{graceful:true}` queued ahead of a later `TerminalWake`
+  returns success and stays absorbing, while a terminal queued first returns the
+  terminal;
+- a callback-published `Stopped(code)` (or connection terminal) wins over a
+  concurrent local `Failed(ABORTED)` / `LocalReset` candidate: the reducer
+  surfaces the shared-slot winner fed back via `TerminalPublished`, and every
+  later `send_data`/`poll_ready`/`poll_finish` returns that same terminal class;
+- a lone `TerminalWake` with no shared winner publishes and returns `Internal`;
+- a `SendPoll::Closed` with no shared winner publishes and returns `Internal`;
+  with an existing winner it returns that winner, and an idle `poll_ready` never
+  reports `ReturnReady` from a closed channel;
+- a connection terminal racing with `ResetSubmitted` clears `reset_submitting`
+  and returns normally (`NoOp`) from infallible `reset`; a peer stop racing with
+  `GracefulSubmitted` clears `finish_submitting` and is returned by
+  `poll_finish`; a `*Submitted` input arriving without its reservation yields
+  `Internal` rather than a panic;
+- `poll_finish` observes a cancelled send `Complete` and returns the exact peer
+  stop / connection reason when available, otherwise `Failed(ABORTED)`; a lone
+  `TerminalWake` through `poll_finish` becomes `Internal`;
+- `poll_ready` after `finish_started` returns nested `InternalError` and issues
+  no native call;
+- stream IDs are cached before exposure and remain available after native
+  shutdown;
+- immediate graceful-shutdown failure is sticky and is not retried;
+- successful finish stays successful after a later connection shutdown;
+- out-of-range reset and stop-sending codes are clamped to the QUIC 62-bit
+  maximum before FFI;
+
+Required loopback tests:
+
+- peer `RESET_STREAM` and `STOP_SENDING` propagate exact HTTP/3 codes end to
+  end;
+- peer connection close propagates its HTTP/3 application code;
+- idle timeout is visible as `ConnectionErrorIncoming::Timeout`;
+- local h3 cancellation submits `ABORT_SEND` with the expected reset code and
+  keeps the process alive;
+- a synthetic accepted-stream attachment failure rejects the individual native
+  stream and causes the h3 connection to close with `H3_INTERNAL_ERROR`;
+- dropping all frontend stream owners while a send is still outstanding drives
+  the send-allocation count back to zero (exactly-once `SendBuffer` reclamation)
+  with no callback panic. This directly guards the close-time inline-drain
+  assumption the ownership model relies on, against whichever `libmsquic` is
+  linked. The test must be made deterministically outstanding, because with
+  MsQuic send buffering the `SendComplete` usually fires inline during
+  `Stream::send`: configure `Settings::set_SendBufferingEnabled(false)`, use a
+  peer/flow-control setup that does not acknowledge the send before the drop,
+  increment an allocation counter before native submission, assert it is exactly
+  one immediately before dropping the final frontend owner, and assert it
+  returns to zero after drop and callback completion. Because Rust's test
+  harness has no "inconclusive" outcome, make the setup deterministic and
+  self-checking: retry the controlled setup a bounded number of times, and if no
+  live outstanding send can be produced, **fail** with a setup-specific message
+  (do not pass or `#[ignore]`, since the compatibility requirement was not
+  exercised). With buffering disabled and flow-control credit withheld, a setup
+  failure indicates a real test-environment problem. Run it for every native
+  MsQuic configuration declared supported.
+
+## Implementation order
+
+1. Introduce conversion helpers, scoped terminal enums, and the shared
+  connection terminal slot with unit tests.
+2. Fix connection shutdown propagation and incoming-stream channels, including
+  the stream-callback fallback publication path.
+3. Split receive data, FIN, reset, and connection failure into explicit events.
+4. Introduce `OpeningStream` and cache stream IDs before returning `H3Stream`.
+5. Replace `H3Buff` with the owned `Bytes` send allocation, then split send
+  completion, peer stop, finish, and connection failure into explicit events.
+6. Implement `reset`, make finish flush and idempotent, and remove
+  callback/polling panics.
+7. Add loopback conformance tests, including native reset and finish behavior,
+   before changing downstream users. Keep event conversion and transition logic
+   in pure helpers so the remaining cases stay unit-testable without a native
+   operation abstraction.
+
+This order fixes the error vocabulary first, then moves each callback path onto
+it while keeping changes reviewable.

--- a/docs/error-propagation.md
+++ b/docs/error-propagation.md
@@ -84,6 +84,13 @@ let _ = self
   .shutdown(StreamShutdownFlags::ABORT_SEND, reset_code);
 ```
 
+`reset_code` must be clamped to the 62-bit varint maximum before this FFI call,
+exactly as the detailed design requires for every outgoing application code (see
+the `reset(code)` handling and the `clamp_application_code`/`MAX_QUIC_VARINT`
+discussion under [Send-side transitions](#send-side-transitions) below). This
+snippet is illustrative of the trait shape only; do not implement the unclamped
+path directly from it.
+
 As in the Quinn and s2n adapters, the trait returns no result, so an immediate
 local failure can only be ignored or recorded for the next stream poll.
 
@@ -138,14 +145,18 @@ legitimately have been dropped. Examples include:
 - connection shutdown cancels a pending stream start;
 - a finish waiter is dropped before `SendShutdownComplete`;
 - the listener accept receiver or shutdown waiter is dropped before
-  [`listener_callback`](../msquic-h3/src/listener.rs) delivers.
+  [`listener_callback`](../msquic-h3/src/listener.rs#L49) delivers.
 
 An FFI callback must not panic for these lifecycle races. This audit covers all
 three callback surfaces — connection, stream, **and listener**. The listener
 path is currently unsafe in the same way: `listener.rs` uses
 `unbounded_send(...).expect("cannot send")` for new connections and end-of-accept,
 `tx.send(()).expect("cannot send")` for the shutdown waiter, and
-`ctx.shutdown.lock().unwrap()` (panics on a poisoned mutex). All of these must
+`ctx.shutdown.lock().unwrap()` (panics on a poisoned mutex). The same class of
+frontend panic also appears outside the callback at `listener.rs:144`
+(`self.conn.shutdown.lock().unwrap()`) and `listener.rs:310`
+(`sht_tx.send(()).unwrap()`), which this general statement is likewise meant to
+cover. All of these must
 become fallible, non-panicking sends and poison-recovering locks
 (`PoisonError::into_inner`), because the design already relies on the binding's
 close model for `Listener` as well. Ordinary sender/receiver loss must never
@@ -156,7 +167,7 @@ ownership constraint for `SendComplete`: the submitted allocation must be
 reclaimed even if its receiver is gone.
 
 Do not retain the current generic erasure. It would require at least
-`B: Send + 'static`, and [`H3Buff::new`](../msquic-h3/src/buffer.rs) assumes
+`B: Send + 'static`, and [`H3Buff::new`](../msquic-h3/src/buffer.rs#L14) assumes
 that advancing an arbitrary `Buf` does not invalidate chunks returned before
 the advance. Neither property is part of h3's `B: Buf` contract.
 
@@ -166,7 +177,10 @@ representation while `B` is still on the caller's thread. The callback-owned
 allocation is concrete:
 
 ```rust
-struct SendBuffer {
+// `pub` so the crate-private `mod buffer` can expose a public copy entry point
+// (see MF-4); the module is never `pub` and its name is never re-exported, so
+// `SendBuffer` stays effectively crate-internal and cannot be named by consumers.
+pub struct SendBuffer {
   buffers: [BufferRef; 1],
   _bytes: Bytes,
 }
@@ -197,9 +211,11 @@ before the request is queued. Relying on that native limit alone is a poor
 ceiling for an *owned-copy* design: a near-`u32::MAX` `send_data` would allocate
 a second near-4 GiB buffer before MsQuic is called, and a Rust allocation
 failure there can abort the process rather than return an error. The adapter
-therefore imposes its own finite ceiling `MAX_ADAPTER_SEND` (initial decision:
-`16 * 1024 * 1024`, i.e. 16 MiB — comfortably above normal HTTP/3 frame sizes,
-well below any dangerous allocation), named separately from the native
+therefore imposes its own finite ceiling `MAX_ADAPTER_SEND` (**provisional**
+decision pending the aggregate-memory / async-blocking analysis recorded under
+"MF-5 / T2" in the review-resolutions section: `16 * 1024 * 1024`, i.e. 16 MiB —
+comfortably above normal HTTP/3 frame sizes, well below any dangerous
+allocation), named separately from the native
 `u32::MAX` protocol maximum and tunable later. A `send_data` above the ceiling
 is rejected with `OversizedSend` **before** any allocation. Partitioning a
 larger payload across multiple `BufferRef` entries is intentionally not done —
@@ -217,9 +233,12 @@ remaining > MAX_ADAPTER_SEND       -> Err(StreamErrorIncoming::Unknown(Oversized
                                       BufferRef, submit one native send
 ```
 
-`OversizedSend` is a small adapter-owned `Debug + Display + Error` type. An
-oversized send is a stream-operation limitation, not a connection failure or a
-peer termination, so `StreamErrorIncoming::Unknown` is the closest h3 class.
+`OversizedSend` is a small adapter-owned `Debug + Display + Error + Send + Sync`
+type. The `Send + Sync` bounds are required because h3 boxes it into
+`StreamErrorIncoming::Unknown(Box<dyn std::error::Error + Send + Sync>)`
+(`h3-0.0.8/src/quic.rs:74`); without them it cannot be boxed into that variant.
+An oversized send is a stream-operation limitation, not a connection failure or
+a peer termination, so `StreamErrorIncoming::Unknown` is the closest h3 class.
 
 Construct `_bytes` first, then construct the `BufferRef` from its slice and put
 both in the box. Moving `Bytes` does not move its referenced byte storage, so
@@ -253,16 +272,22 @@ memory. The `MAX_ADAPTER_SEND` ceiling (above) bounds that doubling and removes
 the near-4 GiB double-allocation / allocation-abort hazard: a request above the
 ceiling is rejected with `OversizedSend` before any allocation.
 
-This is a sound choice (it does not justify retaining the unsound generic
-`H3Buff` erasure). The remaining **release-gate** work is measurement, not the
-ceiling decision: add a benchmark for header-only, small-body, and large
-contiguous-body sends up to the ceiling, document peak-memory behavior, and
-revisit `MAX_ADAPTER_SEND` if the benchmarks justify a different value or motivate
+The per-`send_data` copy is a sound choice (it does not justify retaining the
+unsound generic `H3Buff` erasure). `MAX_ADAPTER_SEND = 16 MiB` is **provisional**,
+not a committed ceiling: it bounds a single operation's doubling but **not**
+aggregate memory across concurrent streams, because the cap is per-operation and
+allocation is infallible/abort-on-OOM. Ratifying any concrete value is therefore
+**gated on multi-stream measurement first**. Before a value is committed, add
+benchmarks for header-only, small-body, and large contiguous-body sends up to the
+candidate cap **and** multi-stream aggregate retained-bytes / concurrent-latency
+measurements (per MF-5/T2), then either ratify the value, lower the cap, or adopt
 internal chunking (a separate future design that would make the reducer track
-multiple native sends per `send_data`). The
-allocation crossing FFI contains only owned `Bytes` plus pointer metadata, and
-the callback knows its concrete destructor. The old generic `H3Buff` can be
-deleted after its remaining uses are removed.
+multiple native sends per `send_data`). Until those measurements are in, 16 MiB
+is a provisional working value, not a decided ceiling; see MF-5/T2 for the
+decision table and the appendix constant note. The allocation crossing FFI
+contains only owned `Bytes` plus pointer metadata, and the callback knows its
+concrete destructor. The old generic `H3Buff` can be deleted after its remaining
+uses are removed.
 
 ### 6. Pending stream open can panic on connection close (medium)
 
@@ -272,8 +297,13 @@ making the one-shot return `Err(Canceled)`. The subsequent `expect("cannot
 receive")` panics.
 
 A connection-caused cancellation should be
-`StreamErrorIncoming::ConnectionErrorIncoming`. If no connection reason is
-available, it should be `Unknown`, never a panic.
+`StreamErrorIncoming::ConnectionErrorIncoming`. If the start channel is
+cancelled without any published connection reason, it should map to the nested
+`ConnectionErrorIncoming::InternalError` (the same "channel closed without a
+recorded reason" classification used at lines 296-297 and by the required
+mapping), never `Unknown` and never a panic. (Resolves review C-1: the earlier
+"should be `Unknown`" wording is superseded by `InternalError` so the prose,
+the mapping table, and the appendix agree.)
 
 `poll_open_inner` checks the shared connection terminal before creating a
 native stream and again before polling an existing `OpeningStream`. A published
@@ -284,7 +314,7 @@ cancelled without a published reason, it returns
 
 ### 7. Send state has two contract hazards (medium)
 
-[`send_data`](../msquic-h3/src/lib.rs#L621) panics when called before the prior
+[`send_data`](../msquic-h3/src/lib.rs#L622) panics when called before the prior
 send becomes ready. Quinn and s2n classify this as an adapter/h3 contract
 failure using `StreamErrorIncoming::ConnectionErrorIncoming` containing
 `ConnectionErrorIncoming::InternalError`; that is safer than unwinding.
@@ -322,7 +352,7 @@ normal.
 
 ### 10. Stream ID access can panic after shutdown (medium)
 
-[`get_id`](../msquic-h3/src/lib.rs#L675) queries a native parameter and unwraps
+[`get_id`](../msquic-h3/src/lib.rs#L678) queries a native parameter and unwraps
 both the MsQuic result and h3 conversion from the infallible `send_id` and
 `recv_id` trait methods. A late ID query after shutdown can therefore panic,
 and these trait methods have no error channel.
@@ -331,13 +361,20 @@ Cache a validated `h3::quic::StreamId` before exposing an `H3Stream`. For local
 streams, replace the temporary `H3Stream` in `poll_open_inner` with an
 `OpeningStream`; `StartComplete` sends `Result<u64, Status>`, and a successful
 poll validates the ID before constructing `H3Stream` with concrete ID fields in
-both halves. A local-stream ID that fails h3 validation is an adapter/internal
-error surfaced as nested `ConnectionErrorIncoming::InternalError`, not
-`Unknown(Status)`.
+both halves. Note that `StreamEvent::StartComplete` already carries an
+`id: u62` field (`u62 = u64`, verified in `msquic-2.5.1-beta/src/rs/types.rs`),
+which the current code discards via `StartComplete { status, .. }` at
+[`lib.rs:475`](../msquic-h3/src/lib.rs#L475); the `Result<u64, Status>` payload
+can source the local-stream ID directly from that field, so no native ID query
+is needed for locally-opened streams. A local-stream ID that fails h3
+validation is an adapter/internal error surfaced as nested
+`ConnectionErrorIncoming::InternalError`, not `Unknown(Status)`.
 
 For accepted streams, ownership of the native handle is the load-bearing detail.
-`PEER_STREAM_STARTED` delivers a `StreamRef` (a borrow); the current adapter
-takes ownership eagerly with `Stream::from_raw(stream.as_raw())`. **Validate
+`PEER_STREAM_STARTED` delivers a `StreamRef` (a borrow) with only `stream`/`flags`
+and no ID field, so — unlike local streams — an accepted stream genuinely needs
+the borrowed `get_stream_id` query. The current adapter takes ownership eagerly
+with `Stream::from_raw(stream.as_raw())`. **Validate
 before taking ownership**, because a native close through Rust *and* a failed
 callback return would double-close the same handle: MsQuic's `stream_set.c` runs
 `if (QUIC_FAILED(Status)) { QuicStreamClose(Stream); Stream = NULL; }` on the
@@ -348,8 +385,20 @@ against the **borrowed** handle:
 
 1. `get_stream_id` against the borrowed `StreamRef`/raw handle
    (`Result<u64, Status>`) — do not create an owning `Stream` merely to query.
-   If the binding lacks a borrowed query, add one or use the public parameter
-   API on the raw handle.
+   **Committed binding decision (no `msquic` patch required):** the existing
+   `msquic` 2.5.1-beta binding already exposes `Stream::get_stream_id(&self) ->
+   Result<u64, Status>` (`msquic-2.5.1-beta/src/rs/lib.rs:1230`), and
+   `StreamRef` derefs to `Stream` (`define_quic_handle_ref!(Stream, StreamRef)`
+   at `lib.rs:1236` produces `impl Deref<Target = Stream> for StreamRef`). The
+   `stream: StreamRef` delivered by `ConnectionEvent::PeerStreamStarted`
+   (`types.rs:117`) therefore answers the query directly through auto-deref —
+   `stream.get_stream_id()` — with **no owning `Stream` created, no raw
+   `Api::get_param` call, and no new binding method or dependency patch**. The
+   query is `Api::get_param_auto::<u64>(handle, QUIC_PARAM_STREAM_ID)` internally,
+   whose failure surfaces as `Err(Status)`. Do not use the raw parameter API and
+   do not fork on adding a borrowed query; the deref query is the single chosen
+   implementation. See the [Accepted-stream ID query](#accepted-stream-id-query)
+   appendix for the exact signature and safety contract.
 2. `u64::try_into::<h3::quic::StreamId>() -> Result<_, h3::quic::InvalidStreamId>`
    — MsQuic IDs are 62-bit so this is impossible by contract, but still handled.
 
@@ -478,8 +527,13 @@ Conversion helpers implement these exact terminal mappings:
 | `SendTerminal::Failed(status)` | `StreamErrorIncoming::Unknown(Box::new(status))` |
 
 `MsQuicTransportError`, `LocalConnectionClose`, and `LocalStreamReset` are
-small adapter-owned `Debug + Display + Error` types. The transport error's
-display includes both the status and wire transport code.
+small adapter-owned `Debug + Display + Error + Send + Sync` types. The
+`Send + Sync` bounds are mandatory: h3 stores these behind
+`ConnectionErrorIncoming::Undefined(Arc<dyn std::error::Error + Send + Sync>)`
+and `StreamErrorIncoming::Unknown(Box<dyn std::error::Error + Send + Sync>)`
+(`h3-0.0.8/src/quic.rs:34,74`), so a type lacking them cannot be `Arc`'d or
+boxed into those variants. The transport error's display includes both the
+status and wire transport code.
 
 ## Proposed adapter state
 
@@ -511,7 +565,7 @@ enum SendEvent {
     Complete {
         cancelled: bool,
     },
-  TerminalWake,
+    TerminalWake,
     FinishComplete {
         graceful: bool,
     },
@@ -608,14 +662,14 @@ Because connection and stream callbacks may execute concurrently, they also
 need this deterministic fallback when the shared slot is still empty:
 
 1. `connection_shutdown_by_app && connection_closed_remotely` becomes
-  `PeerApplication(connection_error_code)`.
+   `PeerApplication(connection_error_code)`.
 2. `connection_shutdown_by_app && !connection_closed_remotely` becomes
-  `LocalClose`.
+   `LocalClose`.
 3. A timeout `connection_close_status` becomes `Timeout`.
 4. Any other connection close becomes `Transport { status:
-  connection_close_status, error_code: connection_error_code }`.
+   connection_close_status, error_code: connection_error_code }`.
 5. A `ShutdownComplete` event with `connection_shutdown == false` does not
-  publish a connection terminal reason; it represents stream-local shutdown.
+   publish a connection terminal reason; it represents stream-local shutdown.
 
 This ordering follows MsQuic's implementation: `ConnectionShutdownByApp` is
 derived from the connection's `AppClosed` state, which is used for application
@@ -755,11 +809,18 @@ normalization.
 **Support policy.** The adapter keeps direct final-owner drop: the native
 `msquic::Stream` lives behind an `Arc` shared by both public halves, and
 dropping the last owner runs the binding's `Drop`, which calls `StreamClose`.
-This is memory-safe and leak-free for send-buffer reclamation (argued below),
-and is treated as a *tested compatibility expectation* — asserted by the
-outstanding-send teardown test — rather than as a universal guarantee extracted
-from MsQuic's documentation. Strict deferred-until-`ShutdownComplete` ownership
-is explicitly not adopted.
+This is memory-safe and leak-free for send-buffer reclamation, argued **from the
+v2.5.1 native `QuicStreamClose` source and the binding's uniform
+inline-drain-on-close contract** (both below) — *not* from an adapter unit test,
+because the public API cannot deterministically hold a real native send
+outstanding across a drop-triggered `StreamClose` (see
+[Native-test mechanisms](#native-test-mechanisms)). What the adapter *does*
+unit-test is its own exactly-once `Box<SendBuffer>` reclamation on the production
+`SendComplete` callback path (the `CountingExec` seam test); the native
+inline-drain-on-close behavior that makes the drain safe is a *documented
+compatibility expectation* on the linked library, not a guarantee the adapter
+asserts with a test it cannot make deterministic. Strict
+deferred-until-`ShutdownComplete` ownership is explicitly not adopted.
 
 Dropping the last owner calls `StreamClose` without an explicit prior shutdown.
 For reclamation this is well-defined. MsQuic's public stream documentation
@@ -823,13 +884,21 @@ be used"). The binding already assumes, for all of `Connection`, `Listener`, and
 callback inline before it returns. A `libmsquic` that violated that — delivering
 an outstanding `SendComplete` asynchronously *after* close returns — would
 deliver into a freed callback context and break the binding wholesale, not
-merely this adapter. This is therefore treated as a **tested compatibility
-expectation** — asserted by the outstanding-send teardown test below against
-whatever library is linked — rather than an ironclad guarantee extracted from
-every MsQuic distribution's documentation. Adopting strict deferred-until-
+merely this adapter. This is therefore treated as a **documented compatibility
+expectation** on whatever library is linked — argued from the v2.5.1
+`QuicStreamClose` source above and the binding's uniform `close_inner` contract,
+**not** asserted by an adapter unit test: the public API cannot deterministically
+hold a native send outstanding across `StreamClose` (per
+[Native-test mechanisms](#native-test-mechanisms)), so no such native teardown
+test exists. The release-gate loopback conformance suite still exercises the
+accepted-send `SendComplete`/reclaim-once ordering, and the `CountingExec` seam
+test proves the adapter's own exactly-once reclamation bookkeeping — but neither
+substitutes for the native inline-drain guarantee, which stands on the source and
+binding-contract argument rather than an ironclad statement in every MsQuic
+distribution's documentation. Adopting strict deferred-until-
 `ShutdownComplete` ownership (a connection-owned close queue with cross-callback
 lifetime coordination) is rejected: it adds substantial machinery for no
-memory-safety or leak benefit over this tested expectation.
+memory-safety or leak benefit over this documented expectation.
 
 A later review then proposed a lighter `NativeStream { Drop -> shutdown(ABORT |
 INLINE) }` wrapper instead of a deferred-close queue. That does not work either
@@ -857,26 +926,47 @@ Two smaller points from those reviews are retained but deferred, not blocking:
    (and the `find` dev feature can link a system `libmsquic.so.2`), so the
    linked library may not be the bundled v2.5.1 source. This is acceptable
    because the reclamation behavior relied upon is the general MsQuic close
-   model already assumed by the binding for every handle type, and it is
-   asserted directly by the outstanding-send teardown test below rather than
-   taken on faith.
+   model already assumed by the binding for every handle type. It is argued
+   from the `QuicStreamClose` inline-`SendComplete`-drain source and the
+   binding's uniform `close_inner` contract (per ~793–805/~862–881), **not**
+   from an adapter drop-triggered `StreamClose` teardown test — no such test
+   exists, because the public API cannot deterministically hold a native send
+   outstanding across the close (see
+   [Native-test mechanisms](#native-test-mechanisms)). The available send
+   conformance tests — the `CountingExec` seam tests
+   (`accepted_send_reclaims_via_callback_exactly_once`,
+   `immediate_send_failure_reclaims_without_completion`) and the loopback
+   accepted-send `SendComplete`/reclaim-once ordering — exercise the adapter's
+   own exactly-once bookkeeping, not the native inline drain.
 
-**Supported native configuration.** The tested compatibility expectation is
+**Supported native configuration.** The documented compatibility expectation is
 scoped to the configurations CI actually exercises, so a downstream user linking
 a system library is not silently assumed supported:
 
 - Supported = the exact native MsQuic versions and platform builds listed in the
   CI matrix (the version the `msquic` crate binds, plus any others explicitly
-  added), each having passed the outstanding-send teardown conformance test.
+  added), each having passed the available send conformance tests — the
+  `CountingExec` seam tests (outstanding-send retain/reclaim via
+  `accepted_send_reclaims_via_callback_exactly_once`, immediate-failure reclaim
+  via `immediate_send_failure_reclaims_without_completion`, exactly-once
+  `SendComplete`) and the loopback accepted-send `SendComplete`/reclaim-once
+  ordering suite. There is no drop-triggered `StreamClose` inline-drain teardown
+  test to pass, because the public API cannot deterministically hold a native
+  send outstanding across the close; the inline-drain guarantee for that path is
+  established by native-source review, not by a test (see below).
 - Any other library — a different patch/minor `v2.5.x`, a different major, or a
-  system `libmsquic.so.2` — is unsupported until it is added to CI and passes
-  that test; such users must run the named test against their library before
+  system `libmsquic.so.2` — is unsupported until it is added to CI, passes the
+  available send conformance tests, and has its `QuicStreamClose` inline
+  `SendComplete` drain re-confirmed by source review; such users must run the
+  conformance tests against their library and perform that review before
   deployment. A floating "all v2.5.x" claim is intentionally avoided.
 - Bumping the `msquic` crate or the native library version requires rerunning
-  the teardown test and re-reviewing `StreamClose` and send-cancellation
-  behavior.
+  the available send conformance tests and re-reviewing the `QuicStreamClose`
+  inline-drain source plus send-cancellation behavior; the inline-drain
+  compatibility argument must be re-confirmed by that source review, not by a
+  teardown test.
 - A conformance failure is reported as an unsupported native environment, not as
-  an adapter test flake. The exact matrix and test command live in the
+  an adapter test flake. The exact matrix and test commands live in the
   development documentation once the tests exist.
 - **Verify the loaded library, not the requested package.** The current CI
   installs mismatched native builds (Linux apt package `2.5.8`, Windows vcpkg
@@ -896,10 +986,15 @@ a system library is not silently assumed supported:
   support" as separate claims.
 
 **Release gate.** Before release, record the exact supported native
-versions/platforms, provenance, and the teardown test command in
+versions/platforms, provenance, and the send conformance test commands in
 [`docs/Development.md`](Development.md) — at least OS, architecture, Rust binding
-version, native library version, provenance, and command — and link that matrix
-from this teardown section. Until that list exists, "supported" has no auditable
+version, native library version, provenance, and commands — and link that matrix
+from this teardown section. The gate requires the available send conformance
+tests (the `CountingExec` seam tests and the loopback reclaim-once ordering
+suite) to pass, and, when the native library version is bumped, the
+`QuicStreamClose` inline-`SendComplete`-drain behavior to be re-confirmed by
+source review; it does **not** require a drop-triggered `StreamClose` teardown
+test, which does not exist. Until that list exists, "supported" has no auditable
 configuration and the release is gated (this is a documentation gate, not an
 additional state-machine change).
 
@@ -1139,14 +1234,16 @@ Request and event inputs:
 | `PollReady`/`PollFinish` while a submission reservation is set | any | none | `PublishTerminal{Internal, <caller>}` (impossible under serialized callers) |
 | `PollReady` / `PollFinish` `Closed` | any, no winner | none | `PublishTerminal{Internal("send channel closed without a terminal"), <caller>}` |
 | `PollReady` / `PollFinish` `Closed` | winner present | none | error(winner) via caller continuation |
-| `PollReady` after `finish_started` | any | none | `ReturnError(Internal)` (h3 misuse; no native call) |
+| `PollReady(_)` | terminal winner present (after reservation check) | `send_inprogress=false` | `ReturnError(winner)` (method-terminal step, before event handling) |
+| `PollReady` after `finish_started` | any, no winner | none | `ReturnError(Internal)` (h3 misuse; no native call) |
 | `PollReady(Event(Complete{cancelled:false}))` | send pending | `send_inprogress=false` | `ReturnReady` |
 | `PollReady(Event(Complete{cancelled:true}))` | send pending | `send_inprogress=false` | `PublishTerminal{winner or Failed(ABORTED), PollReady}` |
 | `PollReady(Event(TerminalWake))` | any | none | `PublishTerminal{winner or Internal, PollReady}` |
 | `PollReady(Pending)` | send pending | none | `Pending` |
 | `PollReady(Pending)` | idle | none | `ReturnReady` |
 | `PollFinish(_)` | `finish_complete` | none | `ReturnFinished` (absorbing) |
-| `PollFinish(Event(Complete{cancelled:false}))` | send pending, not finishing | `send_inprogress=false`, `finish_submitting=true` | `SubmitGraceful` |
+| `PollFinish(_)` | terminal winner present, not `finish_complete`, not a completed graceful finish | `send_inprogress=false` | `ReturnError(winner)` (method-terminal step, before event handling) |
+| `PollFinish(Event(Complete{cancelled:false}))` | send pending, not finishing, no winner | `send_inprogress=false`, `finish_submitting=true` | `SubmitGraceful` |
 | `PollFinish(Event(Complete{cancelled:true}))` | send pending, not finishing | `send_inprogress=false` | `PublishTerminal{winner or Failed(ABORTED), PollFinish}` |
 | `PollFinish(Event(TerminalWake))` | any (not complete) | none | `PublishTerminal{winner or Internal, PollFinish}` |
 | `PollFinish(Pending)` | `send_inprogress`, not finishing | none | `Pending` (waiting for the in-flight data send; no graceful submit yet) |
@@ -1158,12 +1255,18 @@ Request and event inputs:
 
 Notes: submitted-result bookkeeping (top table) always runs before the winner is
 applied, so a raced terminal cannot leave a reservation stale or force
-infallible `reset` down an error path. Successful finish is absorbing \u2014 the
+infallible `reset` down an error path. Successful finish is absorbing — the
 `finish_complete` row precedes any terminal row; additionally a *queued*
 `FinishComplete{graceful:true}` (while `finish_started`) is processed before
 method-terminal handling, so if that success event was enqueued ahead of a later
 `TerminalWake`, finish wins on channel order (graceful finish only; a terminal
-wake or non-graceful finish still lets the shared winner win).
+wake or non-graceful finish still lets the shared winner win). **Method-terminal
+step:** after the reservation check (both methods) and the two finish exceptions
+(`PollFinish` only — absorbing `finish_complete` and a just-completed graceful
+finish), a present shared winner is surfaced as `ReturnError(winner)` *before* any
+ordinary event handling. This is why a `Pending` poll can never linger past a
+terminal and why `PollFinish(Pending)` can never submit graceful shutdown once a
+terminal has won.
 `GracefulSubmitted(Ok)` returns `RepollFinish`, never `Pending` directly:
 because `futures` mpsc registers the receiver waker only on a `Pending` poll, a
 synchronously-queued `FinishComplete` must be drained (or the waker re-armed) by
@@ -1312,10 +1415,10 @@ Required unit tests:
 - FIN from both `ReceiveFlags::FIN` and `PeerSendShutdown` is published once;
 - a borrowed, non-`Send` `Buf` is copied before `send_data` returns and is not
   retained across FFI;
-- a send length validation helper accepts exactly `u32::MAX`, rejects
-  `u32::MAX + 1` as `OversizedSend`, and performs that rejection before any
-  materialization or native submission (exercise the pure helper with synthetic
-  lengths, not real multi-gigabyte allocations);
+- a send length validation helper accepts exactly `MAX_ADAPTER_SEND`, rejects
+  `MAX_ADAPTER_SEND + 1` as `OversizedSend`, and performs that rejection before
+  any materialization or native submission (exercise the pure helper with
+  synthetic lengths, no real allocation);
 - an accepted non-empty send constructs exactly one `BufferRef` whose length
   equals the owned byte length;
 - empty `send_data` input is a no-op that does not set `send_inprogress` or wait
@@ -1395,45 +1498,2547 @@ Required loopback tests:
   keeps the process alive;
 - a synthetic accepted-stream attachment failure rejects the individual native
   stream and causes the h3 connection to close with `H3_INTERNAL_ERROR`;
-- dropping all frontend stream owners while a send is still outstanding drives
-  the send-allocation count back to zero (exactly-once `SendBuffer` reclamation)
-  with no callback panic. This directly guards the close-time inline-drain
-  assumption the ownership model relies on, against whichever `libmsquic` is
-  linked. The test must be made deterministically outstanding, because with send
-  buffering enabled `SendComplete` may occur too quickly for the test to retain
-  an observably outstanding allocation after `Stream::send` returns. (MsQuic does
-  **not** invoke recursive application callbacks for ordinary API down-calls by
-  default — that only happens with an explicit `QUIC_STREAM_SHUTDOWN_FLAG_INLINE`
-  shutdown, which this design does not use — but a completion can still be
-  processed on the connection worker before the caller's next observation, or
-  race a call from another thread.) Disabling send buffering is not possible
-  through the current `msquic` 2.5.1-beta safe API: `set_SendBufferingEnabled` is
-  an enable-only bitflag macro (`fn set_SendBufferingEnabled(self) -> Self` that
-  always sets the value to `1`). **Selected mechanism:** extend the `msquic`
-  binding with a `set_SendBufferingEnabled(bool)` setter that sets `IsSet` and
-  the given value — it exposes an existing native setting without adapter-local
-  `QUIC_SETTINGS` layout manipulation, and is the design's committed dependency
-  (not an implementation-time fork). If that upstream change is unavailable, the
-  fallback is a narrowly scoped, reviewed, test-only raw-settings helper that
-  documents the exact `QUIC_SETTINGS` field, `IsSet` bit, and platform ABI
-  assumptions.
-  The test must prove four distinct facts, in order: (1) buffering was actually
-  disabled (or another deterministic blocking condition was established);
-  (2) exactly one adapter allocation remained outstanding after `Stream::send`
-  returned; (3) final-owner drop caused exactly one callback reclamation; and
-  (4) the count returned to zero before native close returned / the test's
-  explicit completion point. Because Rust's test harness has no "inconclusive"
-  outcome, make the setup deterministic and self-checking: bounded retries may
-  tolerate scheduling variation only **after** the setup is proven — they must
-  not be the mechanism that occasionally creates the condition — and if no live
-  outstanding send can be produced, **fail** with a setup-specific message (do
-  not pass or `#[ignore]`). Run it for every native MsQuic configuration declared
-  supported;
-- native `SendComplete` ownership contract, both directions: an **accepted** send
+- accepted-send reclamation *ordering* over a real loopback connection: an
+  accepted send yields exactly one native `SendComplete`, its `Box<SendBuffer>`
+  is reclaimed exactly once, and dropping all frontend stream owners after that
+  completion causes no callback panic. This is the genuinely available loopback
+  send test. It does **not** hold a send observably outstanding at the instant
+  the allocation count is read, and it does **not** exercise `StreamClose`'s
+  inline `SendComplete` drain: a **real** loopback send cannot be held observably
+  outstanding through the public API — send buffering cannot be disabled through
+  the safe `msquic 2.5.1-beta` builder (`set_SendBufferingEnabled` is an
+  enable-only bitflag — `fn set_SendBufferingEnabled(self) -> Self` always sets
+  `1`, `settings.rs:133`), and a *buffered* send is copied into an internal
+  buffer and completed with an immediate `SEND_COMPLETE` regardless of peer
+  flow-control backpressure (`msquic-2.5.1-beta/src/core/stream_send.c:478-534`,
+  `QuicStreamSendBufferRequest`).
+
+The observably-outstanding retain/reclaim transition and the exactly-once
+`SendComplete` ownership contract are therefore proven by **seam tests, not
+loopback tests** — the deterministic `CountingExec` send seam described in the
+[Native-test mechanisms](#native-test-mechanisms) appendix:
+
+- outstanding-send retain/reclaim: the seam retains the submitted
+  `Box<SendBuffer>` in a test-held `client_context` slot, so the reclamation
+  counter reads exactly 1 until the test explicitly feeds a `SendComplete` back
+  through the callback path (counter → 0). This requires **no binding extension,
+  no `[patch.crates.io]` entry, and no raw `set_param` helper**; the earlier
+  "extend the binding with a `set_SendBufferingEnabled(bool)` setter" and
+  "test-only raw-settings fallback" requirements are withdrawn in favor of the
+  appendix's public-API decision. The seam test proves four distinct facts, in
+  order: (1) the deterministic blocking condition was established (the seam
+  retained the buffer without a `SendComplete`); (2) exactly one adapter
+  allocation remained outstanding after the submit call returned; (3) feeding the
+  completion caused exactly one callback reclamation; and (4) the count returned
+  to zero before the test's explicit completion point. Because Rust's test
+  harness has no "inconclusive" outcome, the setup is deterministic and
+  self-checking: if the outstanding allocation cannot be read as 1, the test
+  **fails** with a setup-specific message (it is never passed or `#[ignore]`d)
+  (`accepted_send_reclaims_via_callback_exactly_once`);
+- `SendComplete` ownership contract, both directions: an **accepted** send
   returns its context in exactly one completion; a **rejected** send (controlled
   immediate `Stream::send` failure) produces **no** completion. A callback
   counter asserts the exactly-once allocation invariant across supported native
-  versions.
+  versions (`immediate_send_failure_reclaims_without_completion`).
+
+The drop-triggered `StreamClose` inline `SendComplete` drain itself has **no**
+native or loopback test — the public API cannot hold a send outstanding while
+forcing that drop path — so close-time / inline-drain compatibility is **not**
+asserted by any test here. It rests on native-source review (`QuicStreamClose`
+inline `SendComplete` drain) plus the binding's uniform `close_inner` close
+contract (per ~793–805/~862–881 and the
+[Native-test mechanisms](#native-test-mechanisms) appendix, ~3092–3099).
+
+## Society-of-thought review resolutions (round 13)
+
+This section is the stable, authoritative record of how the round-13
+society-of-thought review (7 Must-Fix, 10 Should-Fix, 5 Trade-offs, 9 Consider)
+is resolved. It supersedes the appendix below wherever they differ (see the
+appendix banner). Trade-offs are decided with the fixed priority hierarchy
+**Correctness > Security > Reliability > Performance > Maintainability >
+Developer Experience**. Code-level claims below were re-verified against the real
+repo (`Cargo.toml`, `msquic-h3/src/*`, `.github/workflows/build.yaml`) and the
+vendored crates (`~/.cargo/registry/src/*/{msquic-2.5.1-beta,h3-0.0.8,
+h3-quinn-0.0.10}`).
+
+### MF-1 — one ordered source for order-sensitive send events
+
+**Problem.** The narrative makes chronological enqueue order the tiebreaker
+between graceful `FinishComplete` and a later `TerminalWake` ("Send-side
+transitions" and the send transition table), but the appendix routes
+`FinishComplete` through a separate `shutdown` one-shot (`StreamSendCtx.shutdown`
+/ `SendStreamReceiveCtx.shutdown`) while `TerminalWake` and data `Complete` ride
+the `send` mpsc, and `poll_send_channel` always drains the mpsc first. A
+`FinishComplete` produced before a later `TerminalWake` is therefore observed
+*after* the terminal, contradicting the normative "finish already completed
+wins" rule.
+
+**Decision (Correctness > Developer Experience; keeps the data-before-finish
+guarantee).** Put **all** order-sensitive send events on **one** total-order
+source. Remove the separate finish one-shot: `FinishComplete { graceful }`
+becomes an ordinary `SendEvent` enqueued on the same `mpsc::UnboundedSender<
+SendEvent>` as `Complete { cancelled }` and `TerminalWake`. The callback and
+frontend then share a single FIFO, so "finish completed before a later terminal
+was enqueued" is preserved by construction, and the existing rationale that a
+data `Complete` must precede the `FinishComplete` that follows it still holds
+because both are on the same FIFO in submission order. (If a future revision must
+keep two channels, attach a monotonic `seq: u64` at callback publication and
+merge by `seq`; the single-queue form is preferred as simpler.)
+
+Concretely: delete the `shutdown: Option<oneshot::Sender<SendEvent>>` field from
+`StreamSendCtx`, the `shutdown: oneshot::Receiver<SendEvent>` field from
+`SendStreamReceiveCtx`, and the second `Pin::new(&mut self.sctx.shutdown)` arm in
+`poll_send_channel`; `poll_send_channel` becomes a single `poll_next_unpin` on
+the one mpsc.
+
+**Tests (acceptance criteria for the reducer/executor design, see T1).** Two
+deterministic reducer tests that preload **both** orders before the frontend
+polls: (a) `FinishComplete { graceful:true }` enqueued, then `TerminalWake` —
+assert the finish result wins and is absorbing; (b) `TerminalWake` enqueued, then
+`FinishComplete` — assert the terminal wins. Both run with no network by feeding
+the single mpsc.
+
+### MF-2 — a cancelled `SendComplete` must not sticky-mask a richer cause
+
+**Problem.** A cancelled `Complete { cancelled:true }` can be observed before a
+separate **connection**-level shutdown callback publishes `Connection(reason)`.
+The reducer synthesizes sticky `Failed(QUIC_STATUS_ABORTED)` and the immutable
+first-writer slot then blocks refinement to the more specific
+`Stopped(code)`/`Connection(reason)`. The documented MsQuic STOP_SENDING ordering
+(`PeerReceiveAborted` before send cancellation) already covers the **peer-stop**
+half, but the **connection-callback** race has no such ordering.
+
+**Decision (Correctness > implementation simplicity).** A cancelled completion
+with no already-published stream/connection cause is **provisional**, not sticky:
+1. If `StreamState::send_terminal` already holds `Stopped`/`Connection`, return
+   it (unchanged from today).
+2. Otherwise consult the **shared connection terminal** slot
+   (`ConnectionTerminal`, already cloned into every stream per "Connection
+   terminal publication"); if a connection reason exists there, publish and
+   return `Connection(reason)`.
+3. Otherwise **retain a provisional cancellation** in `SendState` (do not write
+   the sticky slot yet) and refine on the paired terminal callback; only fall
+   back to `Failed(ABORTED)` at a clearly specified closure point (finish/reset
+   completion or stream drop) when no richer cause has appeared. An unclassified
+   abort must never irreversibly outrank a later specific cause.
+
+**Tests.** For **both** callback orders — (cancelled completion first, then
+connection/peer terminal) and (terminal first, then cancelled completion) — with
+an **outstanding send** in flight: peer-stop (`STOP_SENDING`) yields
+`Stopped(code)`; connection shutdown yields `Connection(reason)`; only the truly
+no-cause case yields `Failed(ABORTED)`. The loopback callback-order tests must
+hold a send outstanding (the deterministic `CountingExec` seam can script this
+without a network).
+
+### MF-3 — reproducible, attesting native support gate
+
+**Problem.** The unsafe close-time reclamation premise depends on the *actual
+loaded* binary's inline-drain / exactly-once behavior, but the preflight only
+compares `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` to `[2,5,1]`; provenance is a
+`find`↔`src` edit inside `[dev-dependencies]` (an uncommitted manifest change,
+not a committed CI dimension); and the `teardown` substring test filter may match
+none of the named seam tests.
+
+**Decision (Security/Reliability).**
+1. **Two committed clean-checkout CI jobs, one per provenance row, selected by a
+   committed feature — no working-tree manifest edit.** The `msquic` crate exposes
+   mutually-exclusive `find` and `src` build features (verified:
+   `~/.cargo/registry/src/index.crates.io-*/msquic-2.5.1-beta/Cargo.toml`
+   `[features] find = [] / src = ["dep:cmake"]`; `scripts/build.rs` panics on
+   `all(feature = "src", feature = "find")`). Today the root `Cargo.toml` hard-wires
+   provenance by enabling `msquic/find` unconditionally in `[dev-dependencies]`,
+   which cannot be overridden from the command line. Replace that with **two
+   committed pass-through Cargo features** in `msquic-h3`'s manifest plus a plain
+   `default-features = false` dev-dependency:
+
+   ```toml
+   [features]
+   native-find = ["msquic/find"]   # system-package libmsquic (find::find symlinks it)
+   native-src  = ["msquic/src"]    # crate-built from vendored source via cmake
+
+   [dev-dependencies]
+   msquic = { version = "2.5.1-beta", default-features = false }
+   ```
+
+   and a committed CI matrix dimension `provenance: [native-find, native-src]`,
+   with every build/test step run as
+   `--no-default-features --features ${{ matrix.provenance }}` so exactly one
+   provenance is selected per job by committed config, never by an uncommitted
+   `Cargo.toml` edit. The `native-find` job installs the pinned system `libmsquic`
+   package before building; the `native-src` job builds the vendored source via the
+   crate's cmake path (`scripts/build.rs` `cmake_build`). The two features are
+   mutually exclusive, so a job that accidentally enables both fails fast in
+   `build.rs`.
+2. **Attest the library actually loaded by the running test process, not merely an
+   installed package.** Both provenance rows link `libmsquic` **dynamically**
+   (verified in `scripts/build.rs`: the `find` path symlinks the resolved
+   `/usr/lib/x86_64-linux-gnu/libmsquic.so.2` to `$OUT_DIR/libmsquic.so`; the `src`
+   path installs the shared library under `$OUT_DIR/lib`; neither is static unless
+   the `static` feature is set, which these jobs do not set). The preflight
+   attests the **loaded** binary two ways:
+   - **Live-handle identity (primary).** Query, through the live MsQuic handle the
+     test process is using, `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (must equal
+     `[2,5,1]`) **and** `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH` (param id `8`,
+     `char[64]` null-terminated). Both values are produced by code inside the
+     actually-loaded image, so they attest the running library regardless of file
+     path (verified: `msquic-2.5.1-beta/src/core/library.c`
+     `case QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH`; `src/inc/msquic.h`
+     `#define QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH 0x01000008`; ffi const
+     `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH = 16777224` in
+     `src/rs/ffi/linux_bindings.rs`; `docs/Settings.md` row 8). The captured
+     version + git hash are recorded as the job's attestation for **both** rows.
+   - **Loaded-artifact digest (secondary).** Resolve the shared object the process
+     actually mapped — parse `/proc/self/maps` for the `libmsquic.so*` entry
+     (Windows: enumerate the loaded module path) — and record that file's SHA-256.
+     This ties the digest to the image the loader resolved, closing the gap the
+     reviewer flagged: an installed-package digest alone does not prove the process
+     loaded that file. For `native-src` the digest is the crate-built
+     `$OUT_DIR/lib/libmsquic.so*`; for `native-find` it is the symlink target under
+     `/usr/lib/...`, i.e. exactly what the loader resolved.
+3. **Exact test targets with count/list assertions**, replacing the `teardown`
+   substring filter, so a green job cannot silently run zero seam tests:
+
+   Each command carries the committed provenance selection
+   (`--no-default-features --features ${{ matrix.provenance }}`) required by the
+   CI decision above, so exactly one clean-checkout provenance row is chosen per
+   job — never both, never neither:
+
+   ```sh
+   cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} accepted_send_reclaims_via_callback_exactly_once -- --exact
+   cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} immediate_send_failure_reclaims_without_completion -- --exact
+   cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} native_version_preflight -- --exact
+   ```
+
+   Each job asserts each named test ran exactly once (`--exact`, non-zero result
+   line), and fails if any is filtered out or absent.
+
+The security residual is scoped to *attestation and CI support claims*, not a new
+runtime pointer-validation mechanism (a non-conforming library breaks the binding
+generally; see Dissent Log 4).
+
+### MF-4 — a buildable, invoked send-copy benchmark gate
+
+**Problem.** `benches/send_copy.rs` is a separate crate and cannot call the
+private `SendBuffer::new`; the release commands run only `cargo test`, never the
+`harness = false` Criterion target; and the 10 ms threshold is absolute.
+
+**Decision (Reliability/Correctness of the gate).**
+1. **One buildable arrangement: a feature-gated PUBLIC bench entry point.** A
+   Criterion bench (`benches/send_copy.rs`) is a separate crate and can reach only
+   `pub` items, so a `pub(crate)` helper, a separate integration-test target, and
+   an in-crate `#[bench]` are all rejected as the Criterion target. Instead, the
+   copy path lives in the library as an **always-compiled helper** used by
+   production `send_data` — `pub fn copy_into_send_buffer(src: impl Buf) -> SendBuffer`,
+   declared **`pub` inside the crate-private `mod buffer`** (the module itself is
+   never `pub`, so the helper is not externally reachable on its own). This is the
+   *single* copy the reducer performs — production `send_data` calls
+   `copy_into_send_buffer(&mut wb)` and the benchmark calls
+   `copy_into_send_buffer(&src[..])`, so both drive the identical
+   `src.copy_to_bytes(remaining)` allocation — and the library re-exports the helper
+   **publicly only under a committed bench feature**. A `pub use` can only re-export
+   an item that is itself `pub`, so the helper must be `pub` (not `pub(crate)`)
+   within its private module. Its return type must also be `pub` or the public
+   re-export trips `private_interfaces` under the repo's `-D warnings`; the type is
+   made `pub struct SendBuffer` **without** re-exporting its name, so it is legal in
+   the public signature yet remains unnameable outside the crate (a bench can *bind*
+   the returned value by inference but cannot write the path `buffer::SendBuffer`):
+
+   ```rust
+   // msquic-h3/src/buffer.rs — `mod buffer;` is crate-private, but both the helper
+   // and its return type are `pub` so a gated `pub use` can re-export the helper
+   // (a `pub(crate)`/private `fn`, or a `pub fn` returning a private type, could
+   // NOT be re-exported publicly by bench_support without a `private_interfaces`
+   // error under `-D warnings`).
+   use bytes::Buf;
+
+   pub struct SendBuffer { /* buffers: [BufferRef; 1], _bytes: Bytes */ }
+
+   /// The ONE production copy path: consume the complete `Buf` into owned `Bytes`.
+   /// `&mut WriteBuf<B>` (production) and `&[u8]` (bench) both implement `Buf`, so
+   /// both callers run the identical `copy_to_bytes` allocation.
+   pub fn copy_into_send_buffer(mut src: impl Buf) -> SendBuffer {
+       let n = src.remaining();
+       SendBuffer::new(src.copy_to_bytes(n))   // fresh owned allocation copy
+   }
+
+   // msquic-h3/src/lib.rs
+   mod buffer;   // private module (no `pub`): helper + type stay unreachable by default
+   #[cfg(feature = "bench-internals")]
+   pub mod bench_support {
+       // Re-exports ONLY the function; `SendBuffer`'s name is never re-exported.
+       pub use crate::buffer::copy_into_send_buffer;
+   }
+   ```
+
+   with the feature, the Criterion dev-dependency, and the bench target declared in
+   the committed manifest:
+
+   ```toml
+   [features]
+   bench-internals = []
+
+   [dev-dependencies]
+   criterion = "0.5"
+
+   [[bench]]
+   name = "send_copy"
+   harness = false
+   required-features = ["bench-internals"]
+   ```
+
+   The production `send_data` path always calls the same private helper
+   `copy_into_send_buffer(&mut wb)` (no feature needed) — so the benchmark measures
+   the identical copy code, not a second implementation; the public surface appears
+   **only** when `bench-internals` is enabled, so the bench compiles against a `pub`
+   entry point without leaking bench-only API into the default build.
+   `required-features` keeps the bench out of ordinary `cargo test`/`cargo bench`
+   runs that do not opt in.
+2. **Exact blocking CI invocation.** Add a dedicated CI step (today
+   `.github/workflows/build.yaml` runs only `check`/`fmt`/`clippy`/`test`). The
+   benchmark job runs under the same `provenance` matrix as the other conformance
+   steps, so its command carries **both** the matrix provenance **and**
+   `bench-internals` (cargo accepts a comma-separated feature list), never a
+   provenance-less build:
+
+   ```sh
+   cargo bench -p msquic-h3 --no-default-features --features ${{ matrix.provenance }},bench-internals --bench send_copy -- --noplot
+   ```
+3. **Split the gates.** Keep the deterministic allocation/peak-resident bound
+   (`peak_delta <= 2*payload + 1 MiB`) as a blocking in-crate **`#[test]`** (private
+   access, no feature needed), so correctness does not depend on Criterion timing.
+   The blocking Criterion bench therefore carries **no hard timing assertion**:
+   treat copy **timing** as *informational / relative to a same-run baseline* unless
+   the runner is concretely pinned and isolated; the median-of-64 policy is retained
+   as partial scheduler-noise control, but the absolute 10 ms number is advisory
+   until a pinned runner exists.
+
+### MF-5 / T2 — resolve the 16 MiB ceiling before ratifying it
+
+**Problem.** The 16 MiB cap bounds one allocation but not (a) synchronous
+executor blocking — the copy runs on the polling thread
+(`copy_into_send_buffer(&mut wb)`, i.e. `wb.copy_to_bytes(n)`) — nor (b) aggregate
+memory across concurrent streams, since the cap is per-operation and allocation is
+infallible/abort-on-OOM. A single-copy 10 ms benchmark cannot establish a safe
+default under concurrency.
+
+**Decision (Reliability + Performance > compatibility convenience). 16 MiB is
+PROVISIONAL and is not ratified from the single-copy benchmark alone.** Prefer
+**internal chunking** with an explicit **per-connection in-flight byte budget**;
+if chunking stays deferred, **lower the cap** and document + test a maximum
+concurrent-memory assumption. The decision table below must be filled with real
+multi-stream measurements before a value is committed:
+
+| Option | Per-op cap | Aggregate bound | Scheduler latency | Complexity | Compatibility |
+| --- | --- | --- | --- | --- | --- |
+| Keep 16 MiB (current) | 16 MiB | **unbounded** across N streams | up to one 16 MiB copy on the poll thread | low | best (one native send per `send_data`) |
+| Lower cap (e.g. 1 MiB) | 1 MiB | N × 1 MiB (still per-stream) | small | low | may split large app frames |
+| Internal chunking + per-conn budget | small chunk | **bounded** by the budget | bounded per chunk | high (reducer tracks many native sends per `send_data`) | transparent to callers |
+
+Measurements to add before committing: multi-stream latency (concurrent large
+sends) and aggregate retained bytes, not only the single 16 MiB copy. Until the
+table is filled and a value chosen, `MAX_ADAPTER_SEND` is documented as
+provisional (see the finding-5 text and the appendix constant note).
+
+### MF-6 — release, versioning, migration, and rollback
+
+**Problem.** The change removes public `H3Buff`, adds an `OversizedSend`
+rejection, and changes downstream-visible terminal classifications, but the
+implementation order had no compatibility/version decision, changelog, migration
+note, or rollback path. Verified: `H3Buff` is `pub` (`msquic-h3/src/buffer.rs`
+`pub struct H3Buff`), the crate is `version = "0.0.6"` (`Cargo.toml`).
+
+**Decision (scoped for a pre-1.0 `0.0.x` crate: the first two items are
+blocking; consumer-validation and formal rollback are recommended, not
+blocking).**
+1. **Version decision.** Removing `pub H3Buff` and adding new runtime errors are
+   breaking API/behavior changes. Under Cargo pre-1.0 semantics, `0.0.z` bumps
+   are all breaking, so publish as **`0.0.7`** and record the decision. (Note:
+   `msquic-h3-0.0.5` and `-0.0.6` already exist in the local registry, so `0.0.7`
+   is the next free slot.)
+2. **Changelog + migration notes.** Add a `CHANGELOG.md` entry documenting:
+   removal of `pub H3Buff` (consumers must stop naming it; the owned `SendBuffer`
+   is internal), the new `StreamErrorIncoming::Unknown(OversizedSend)` for sends
+   above `MAX_ADAPTER_SEND`, and the changed terminal classifications (peer
+   reset → `StreamTerminated`, connection close → specific
+   `ConnectionErrorIncoming` instead of `ApplicationClose { 0 }`, peer
+   `STOP_SENDING` surfaced). Migration note: callers relying on the old
+   "reset-as-EOF" or "always application-close-0" behavior must update error
+   handling.
+3. **Recommended (non-blocking at 0.0.x):** prerelease validation against a
+   representative h3 consumer, and a rollback note — revert to `0.0.6` and the
+   last-known-good native/config matrix row if a regression is found. These are
+   proportionate to record but not gates for an unstable-API crate with no
+   evident external consumers.
+
+### MF-7 / T5 — the appendix is a temporary scaffold, not a second source of truth
+
+**Decision (Maintainability, once code exists).** The ~1,800-line appendix
+(lines 1536–end) is demoted from "normative / takes precedence" to a **temporary
+pre-implementation scaffold** with an explicit expiry banner and cleanup
+checklist (added at the head of the appendix) and a release-gate item
+(implementation-order item 10). The living design of record is the narrative
+above plus this resolutions section — invariants, interfaces, mappings, and
+rationale. No depended-on invariant is deleted: the cleanup checklist requires
+promoting any such invariant into the narrative before the appendix is removed.
+
+### SF-1 — name `StreamExecutor` as the send-half owner
+
+Resolved in place: the `H3SendStream` ownership comment now states that the
+production `StreamExecutor` (held by `exec`) owns the send-side
+`Arc<msquic::Stream>` **independently** of the recv half, and that dropping
+`H3RecvStream` first does not invalidate the send side (each half holds its own
+`Arc` clone). **Test:** drop `H3RecvStream`, then use and drop `H3SendStream`;
+assert send-side verbs still function and the native handle is released only when
+the last owner drops.
+
+### SF-2 — guard `finish_started` before the destructive poll
+
+**Problem.** `poll_ready` polls the event sources (consuming the one-shot
+`FinishComplete`) *before* the reducer rejects the call for `finish_started`, so
+a misuse `poll_ready`-after-finish destroys the only finish completion and a
+later `poll_finish` hangs. (Note: with MF-1's single queue there is no separate
+finish one-shot, but the same destructive-consume hazard applies to any consumed
+event.)
+
+**Decision (Correctness/liveness).** Check the non-consuming state guard
+**before** polling:
+
+```rust
+if self.sctx.reducer.finish_started {
+    return Poll::Ready(Err(poll_ready_after_finish_error()));
+}
+let poll = self.poll_send_channel(cx);
+```
+
+Alternatively, retain any consumed event until the method that owns it processes
+it. **Test:** call `poll_ready` after finish has started, then `poll_finish`, and
+assert `poll_finish` still completes (no lost `FinishComplete`, no hang).
+
+### SF-3 — prove exactly-once `SendBuffer` destruction on the real path
+
+**Decision.** Factor production boxing/reclamation into a package-private helper
+used by **both** `StreamExecutor` and `CountingExec` (removing the hand-mirrored
+allocation in `CountingExec`), and add a `#[cfg(test)]` drop counter carried by
+`SendBuffer` (e.g. an `Arc<AtomicUsize>` incremented in `Drop`). **Tests:** after
+callback-replayed `SendComplete`, assert `drops == 1`; after immediate
+`Stream::send` failure reclamation, assert `drops == 1`. This observes the real
+destructor, not queue behavior.
+
+### SF-4 — the appendix is not claimed compilable
+
+Resolved via MF-7/T5: the appendix banner no longer claims "concrete,
+**compilable**, normative" Rust; it is labeled a scaffold. If any fragment is
+later promoted to a checked fixture, it must compile under the repo's `clippy -D
+warnings` policy (fixing the transitive `Debug` derives and the unused `start_rx`
+in `stream_ctx_channel`). Until then the compilability claim is dropped rather
+than asserted.
+
+### SF-5 — document the unbounded-receive trust/resource assumption
+
+**Decision (down-scoped per critic: document, do not redesign).** Receive
+buffering remains governed by the existing unbounded-`mpsc` model plus available
+transport/stream flow control; this is a **pre-existing** property the current
+adapter already has (`msquic-h3/src/lib.rs` uses unbounded `mpsc`), not a
+regression introduced by this error-propagation change. **Documented assumption:**
+a peer can enqueue peer-controlled bytes ahead of a stalled h3 reader, bounded
+only by transport/stream flow control, so deployments that need a hard memory
+bound must treat bounded/deferred receive consumption (byte budget + re-enable
+behavior + overload tests) as **future work** outside this design's scope.
+
+### SF-6 — define the post-`stop_sending` polling contract
+
+**Decision (edge-cases; the contract is required and is fixed to `Ok(None)`).**
+After local `stop_sending` (which submits `ABORT_RECEIVE` and, per the
+`stop_sending(code)` rule above, injects **no** receive terminal), the retained
+receive half sets a **local, sticky `receive_closed` flag** that is distinct from
+the stored `StreamErrorIncoming` terminal-reason slot — that slot is left
+untouched. Any subsequent `poll_data` returns `Poll::Ready(Ok(None))`, the
+verified end-of-stream signal: `h3::quic::RecvStream::poll_data` returns
+`Poll<Result<Option<Self::Buf>, StreamErrorIncoming>>` and its doc comment states
+that `None` means "the receiving side will no longer receive more data" (checked in
+`~/.cargo/registry/src/index.crates.io-*/h3-0.0.8/src/quic.rs`). `Ok(None)` is
+deliberately **not** a `StreamErrorIncoming` variant, so this contract injects no
+receive terminal and stays consistent with the earlier "do not attempt to inject a
+receive terminal" rule at the `stop_sending(code)` paragraph above. A
+`StreamTerminated { error_code }` would be the wrong choice here: that variant is
+documented in `h3-0.0.8/src/quic.rs` as "Stream side was closed by the peer"
+(a peer reset / peer `stop_sending`), not our local decision. Polling after
+`stop_sending` is therefore neither an indefinite hang (`Pending`) nor treated as
+misuse: it is a defined clean end-of-stream. **Test:** call `stop_sending`, then
+`poll_data` with no peer FIN/reset and an open connection; assert
+`Poll::Ready(Ok(None))` (not `Pending`, not `Err`), and assert the stored
+receive terminal-reason slot remains empty (no terminal was injected).
+
+### SF-7 / T4 — precedence/refinement for connection terminal, not first-observed
+
+**Problem.** "First writer wins" is first-*observed* by callback scheduling, not
+first-*caused* or most-specific; a provisional `LocalClose` published before the
+shutdown downcall can permanently mask a nearly-simultaneous peer/transport
+cause.
+
+**Decision (Correctness > simplicity).** Define an explicit
+precedence/refinement rule: **provisional** classes (`LocalClose`, generic
+fallback) may be **refined** to a **specific** peer/transport cause
+(`PeerApplication`, `Timeout`, `Transport`) until the terminal becomes
+**externally observable** (delivered to h3 via a poll or an accept frontend);
+after that freeze point the winner is immutable. Specific causes never refine to
+provisional ones. **Test:** a controlled simultaneous-close test (local close
+racing a peer/transport shutdown callback) asserting the specific cause wins when
+it is available before external observation, and immutability after.
+
+### SF-8 — a real contention test for the first-writer invariant
+
+**Decision.** Add a real-thread (or `loom` model) test that releases **two**
+publishers simultaneously against the poison-safe publication helper, repeats
+enough iterations to cover both winners, and asserts: exactly one immutable
+winner per scope, all readers observe the same value, and send/receive scopes
+remain independent. This complements the sequential reducer tests (which cannot
+exercise contention or poison recovery).
+
+### SF-9 — one authoritative connection-terminal representation
+
+**Decision.** Declare the **shared mutex slot** (`ConnectionTerminal` behind the
+`Arc<Mutex<Option<..>>>`) **authoritative for identity**. The
+`IncomingStream::Terminal` channel payloads and each receiver's sticky cache are
+**derived**: channel entries act only as ordered wake/barrier markers that
+preserve the queued-stream-before-terminal ordering, and per-receiver caches are
+immutable snapshots of the shared winner taken at first observation (avoiding
+relocking). Documented invariant: a cache/payload is only ever populated from the
+shared winner, never independently, so the three representations cannot diverge;
+the queue-order contract (streams queued before the terminal are delivered first)
+is why the payload copy exists (see Dissent Log 5).
+
+### SF-10 — version + symbol anchors for vendored citations
+
+**Decision (maintainability hygiene, applied going forward).** New vendored-source
+evidence names the **symbol/function + pinned version** and treats bare line
+numbers as secondary, matching the doc's existing good practice (the versioned
+h3/h3-quinn doc links and the v2.5.1 `StreamClose.md` permalink). Example
+conversions for the called-out spots: cite
+`msquic 2.5.1-beta: QuicStreamSendBufferRequest` (in `src/core/stream_send.c`)
+and `msquic 2.5.1-beta: QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (in
+`ffi/linux_bindings.rs`) rather than bare line numbers; line numbers stay only as
+a local convenience. This applies to all citations added by future edits; the
+existing in-tree vendored line numbers are stable until the vendored copy is
+bumped, so they are updated opportunistically, not en masse.
+
+### Trade-offs (adopted AUTO decisions)
+
+- **T1 — keep the reducer/executor design.** Correctness and Reliability outrank
+  structural consistency and Developer Experience. The abstraction is retained
+  **only** with MF-1, MF-2, SF-2, and SF-8 as explicit acceptance-test criteria
+  (this section defines them). Decision record: the reducer/executor seam earns
+  its divergence from the current inline style by giving a testable boundary for
+  synchronous callbacks, lost-waker handling, and exactly-once native commands.
+- **T2 — 16 MiB not approved from the benchmark alone;** prefer chunking, else
+  lower the cap. Recorded under MF-5 above.
+- **T3 / C-9 — retain `SendBuffer`.** Correctness and Security outrank the copy
+  reduction. Removing the owned copy is a **future optimization** gated on
+  proving, for **every** supported binary, provenance row, configuration, and
+  accepted payload path: (1) native copies synchronously for all supported send
+  modes, (2) completion ordering is stable, (3) loaded-artifact identity is
+  attested (MF-3), and (4) zero-copy lifetime tests cover every support row; the
+  native identity and teardown gates must be re-run before removal. Verified
+  context: buffered sends copy into an internal buffer and indicate
+  `SEND_COMPLETE` synchronously (`msquic 2.5.1-beta: QuicStreamSendBufferRequest`),
+  but this holds only for the examined buffered path, so it is not yet a proof
+  across the matrix.
+- **T4 — refine toward the specific peer/transport cause.** Recorded under SF-7
+  above.
+- **T5 — appendix is a temporary artifact.** Recorded under MF-7 above.
+
+### Consider (C-1..C-9)
+
+- **C-1 — resolved in place:** no-reason stream-start cancellation maps to nested
+  `ConnectionErrorIncoming::InternalError` (not `Unknown`); the finding-6 prose
+  was corrected.
+- **C-2 — add a local-close mapping test:** assert local connection close maps to
+  `Undefined(LocalConnectionClose)`, is **not** `ApplicationClose { 0 }`, and
+  preserves the adapter-owned error's display text. (Guards the exact current bug
+  where every close became `ApplicationClose { 0 }`.)
+- **C-3 — add stream-ID boundary tests:** `validate_stream_id` over `0`,
+  `(1<<62)-1`, `1<<62`, and `u64::MAX`, plus separate accepted-stream query
+  failure vs. conversion failure cases.
+- **C-4 — loopback determinism controls:** specify the Tokio runtime flavor,
+  ephemeral-port allocation, per-test deadlines, a no-retry failure policy, and
+  which race-sensitive tests (idle-timeout, callback-order) require serialization
+  or per-connection controls.
+- **C-5 — keep invariant tests independent of table rows:** retain a small
+  invariant suite (exactly-once submission, absorbing success, terminal
+  consistency) whose expectations are authored independently of the transition
+  table so a wrong row and its derived test cannot agree.
+- **C-6 — clarify opener clone with a pending start:** document reachability. If
+  cloning a `StreamOpener` while an `OpeningStream` owns a started native stream
+  is unreachable in the h3 usage model, state that (one-line "not reachable
+  because…"); if reachable, prohibit it, share the pending op, or cancel with a
+  meaningful code (not silent abort-code-0) and test the path.
+- **C-7 — add an h3 dependency-bump gate:** before changing `h3 = "0.0.8"`,
+  require semantic review of the QUIC traits/error variants, the
+  `i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature
+  exposure (verified present in `h3-0.0.8/Cargo.toml`), mapping tests, and
+  compile checks — symmetric with the MsQuic bump gate.
+- **C-8 — add a sanitizer/leak signal:** add an available ASan/LSan (or
+  platform leak-check) job around loopback teardown and the seam tests, clearly
+  documented as **complementary** evidence, not a substitute for the native
+  source review of the exact inline-drain path.
+- **C-9 — consolidated into T3** (proof obligations for removing `SendBuffer`).
+
+## Implementation-ready definitions (round 6)
+
+> **⚠ TEMPORARY IMPLEMENTATION SCAFFOLD — remove or replace when implementation
+> lands (resolves MF-7 / T5).** Everything from this banner to the end of the
+> document (the ~1,800-line Rust appendix that follows) is a *generated,
+> pre-implementation scaffold*, not living design. It is **no longer normative
+> and no longer takes precedence** over the narrative above: where the appendix
+> and the stable design (the sections above plus "Society-of-thought review
+> resolutions (round 13)") disagree, **the narrative and the resolutions section
+> win**, and the appendix is presumed stale. The stable, long-lived design of
+> record is: the review findings, the required mapping, "Proposed adapter
+> state", the send/receive/terminal transition rules, and the round-13
+> resolutions — i.e. invariants, interfaces, and rationale, not full method
+> bodies.
+>
+> **Expiry condition / cleanup checklist (owner: implementer of the send
+> redesign):**
+> 1. When the production code lands in `msquic-h3/src/`, delete this appendix
+>    (or move it to a throwaway branch / `docs/archive/`), leaving only links to
+>    the checked production modules and tests.
+> 2. Replace any invariant that the design genuinely depends on (e.g. the send
+>    transition table, the single-ordered-send-event-queue rule, the exactly-once
+>    reclamation contract) with a short prose statement in the narrative above,
+>    so no design dependency is silently lost.
+> 3. Do not fix bugs by editing this appendix once code exists; fix the code and
+>    update the narrative invariants. CI already checks the real code
+>    (`cargo check --all-targets --all-features` + `clippy -D warnings`, see
+>    `.github/workflows/build.yaml`), so this appendix must not become a second
+>    maintained source of truth.
+> 4. Implementation-order item 10 (below) enforces this cleanup as a release
+>    gate.
+
+This appendix gives concrete Rust definitions, exact signatures, one committed
+choice at every former decision point, and precise per-site callback outcomes,
+to reduce implementation-time ambiguity. It is a scaffold only (see banner
+above). All constants keep their earlier values: `MAX_ADAPTER_SEND: u64 = 16 *
+1024 * 1024` (16 MiB, **provisional** per MF-5/T2), `MAX_QUIC_VARINT: u64 = (1 <<
+62) - 1`, and the native per-send `u32::MAX` protocol maximum. Where any listing
+below still shows a `FinishComplete` one-shot separate from the send mpsc, an
+`Unknown` no-reason cancellation, or an unqualified 16 MiB default, it is
+superseded by the round-13 resolutions.
+
+### Revised adapter structs and constructors
+
+All new fields carry the shared terminal state and cached IDs described above.
+`ConnectionState`/`StreamState` are the exact types from
+[Proposed adapter state](#proposed-adapter-state); the `Arc` ownership below is
+the load-bearing addition.
+
+```rust
+// ── Connection handle: unchanged fields, no terminal here (it lives in the
+//    Arc<ConnectionState> that ConnHandle also carries so callback + frontend
+//    share one slot). Field order (inner before _guard before state) is kept.
+#[derive(Debug)]
+pub(crate) struct ConnHandle {
+    inner: msquic::Connection,
+    state: Arc<ConnectionState>,   // NEW: shared, cloned into callback + streams
+    _guard: RundownGuard,
+}
+
+impl ConnHandle {
+    pub(crate) fn new(
+        inner: msquic::Connection,
+        state: Arc<ConnectionState>,
+        guard: RundownGuard,
+    ) -> Self {
+        Self { inner, state, _guard: guard }
+    }
+    pub(crate) fn state(&self) -> &Arc<ConnectionState> { &self.state }
+    pub(crate) fn inner(&self) -> &msquic::Connection { &self.inner }
+}
+
+#[derive(Debug)]
+pub struct Connection {
+    conn: Arc<ConnHandle>,
+    ctx: ConnCtxReceiver,
+    opener: StreamOpener,
+}
+
+// ── Callback → frontend. `bidi`/`uni` now carry IncomingStream<H3Stream>
+//    (stream OR terminal), not Option<H3Stream>. The callback clones the shared
+//    ConnectionState to derive/publish terminals and to seed accepted streams.
+#[derive(Debug)]
+struct ConnCtxSender {
+    state: Arc<ConnectionState>,            // NEW: publish/read shared terminal
+    connected: Option<oneshot::Sender<Result<(), Status>>>,  // was Sender<()>
+    shutdown: Option<oneshot::Sender<()>>,
+    bidi: Option<mpsc::UnboundedSender<IncomingStream<H3Stream>>>,
+    uni: Option<mpsc::UnboundedSender<IncomingStream<H3Stream>>>,
+}
+
+#[derive(Debug)]
+struct ConnCtxReceiver {
+    connected: Option<oneshot::Receiver<Result<(), Status>>>, // was Receiver<()>
+    shutdown: Option<oneshot::Receiver<()>>,
+    // Sticky accept-side terminal: first Terminal seen is stored and replayed by
+    // every later poll_accept_* on that side without re-polling the channel.
+    bidi: mpsc::UnboundedReceiver<IncomingStream<H3Stream>>,
+    uni: mpsc::UnboundedReceiver<IncomingStream<H3Stream>>,
+    bidi_terminal: Option<ConnectionTerminal>,  // NEW sticky accept state
+    uni_terminal: Option<ConnectionTerminal>,   // NEW sticky accept state
+}
+
+// Constructor now seeds both halves with the shared state clone.
+fn conn_ctx_channel(state: Arc<ConnectionState>) -> (ConnCtxSender, ConnCtxReceiver) {
+    let (conn_tx, conn_rx) = oneshot::channel::<Result<(), Status>>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (bidi_tx, bidi_rx) = mpsc::unbounded();
+    let (uni_tx, uni_rx) = mpsc::unbounded();
+    (
+        ConnCtxSender {
+            state,
+            connected: Some(conn_tx),
+            shutdown: Some(shutdown_tx),
+            bidi: Some(bidi_tx),
+            uni: Some(uni_tx),
+        },
+        ConnCtxReceiver {
+            connected: Some(conn_rx),
+            shutdown: Some(shutdown_rx),
+            bidi: bidi_rx,
+            uni: uni_rx,
+            bidi_terminal: None,
+            uni_terminal: None,
+        },
+    )
+}
+```
+
+```rust
+// ── Stream side. StreamSendCtx (callback-owned) publishes terminals and events;
+//    both receive contexts cache the resolved StreamId and sticky terminals.
+struct StreamSendCtx {
+    state: Arc<StreamState>,                         // NEW: shared send terminal
+    start: Option<oneshot::Sender<Result<u64, Status>>>,   // was Result<(), Status>; now carries id
+    // Explicit send events (buffer reclaimed by callback before enqueue).
+    send: Option<mpsc::UnboundedSender<SendEvent>>,  // was (bool, BufPtr)
+    // Explicit receive events replace channel-closure signalling.
+    receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,  // was Bytes
+    receive_terminal_sent: bool,                     // NEW: first Fin/Reset/Conn wins
+    shutdown: Option<oneshot::Sender<SendEvent>>,    // finish completion channel
+}
+
+// Frontend receive half.
+#[derive(Debug)]
+struct RecvStreamReceiveCtx {
+    id: h3::quic::StreamId,                           // NEW cached id
+    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
+    terminal: Option<ReceiveTerminal>,               // NEW sticky recv terminal
+    // SF-6: local, sticky end-of-stream flag set by OUR OWN stop_sending. Distinct
+    // from `terminal` (which holds a peer/connection-caused reason); `terminal` is
+    // left untouched when this is set. When true, poll_data returns
+    // Ready(Ok(None)) and NO receive terminal is injected.
+    receive_closed: bool,                            // NEW SF-6 sticky local flag
+}
+
+// Frontend send half. `state` is the shared Arc; the reducer's own bookkeeping
+// is SendState (see below); the sticky winner is StreamState::send_terminal.
+#[derive(Debug)]
+struct SendStreamReceiveCtx {
+    id: h3::quic::StreamId,                           // NEW cached id
+    state: Arc<StreamState>,                          // NEW shared send terminal
+    send: mpsc::UnboundedReceiver<SendEvent>,
+    reducer: SendState,                               // was `send_inprogress: bool`
+    // Finish completion channel; the reducer treats it as a SendEvent source.
+    shutdown: oneshot::Receiver<SendEvent>,
+}
+
+#[derive(Debug)]
+pub struct H3SendStream {
+    // No `stream` field: every native send-side verb goes through `exec`, and the
+    // production `StreamExecutor` (held by `exec`) owns the `Arc<msquic::Stream>`
+    // that keeps the send half's native handle alive. This ownership is
+    // independent of the recv half: `H3RecvStream` holds its own `Arc` clone, so
+    // dropping the recv half first does NOT invalidate the send side (see the
+    // recv-drop-then-send test required by the resolutions section). This is also
+    // what lets `with_exec` build a send half with no live connection.
+    sctx: SendStreamReceiveCtx,   // carries cached id + Arc<StreamState>
+    exec: Box<dyn SendExec>,      // replaceable send-side seam (below); prod =
+                                  // StreamExecutor, tests = CountingExec
+}
+
+#[derive(Debug)]
+pub struct H3RecvStream {
+    stream: Arc<msquic::Stream>,
+    rctx: RecvStreamReceiveCtx,   // carries cached id
+}
+
+#[derive(Debug)]
+pub struct H3Stream {
+    send: H3SendStream,
+    recv: H3RecvStream,
+}
+
+// Constructor returns the callback-owned sender plus the two frontend halves.
+// It takes the shared per-stream state so the callback and both halves agree.
+fn stream_ctx_channel(
+    state: Arc<StreamState>,
+    id: h3::quic::StreamId,
+) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
+    let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
+    let (send_tx, send_rx) = mpsc::unbounded::<SendEvent>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<SendEvent>();
+    let (receive_tx, receive_rx) = mpsc::unbounded::<ReceiveEvent>();
+    (
+        StreamSendCtx {
+            state: state.clone(),
+            start: Some(start_tx),
+            send: Some(send_tx),
+            receive: Some(receive_tx),
+            receive_terminal_sent: false,
+            shutdown: Some(shutdown_tx),
+        },
+        SendStreamReceiveCtx {
+            id, state, send: send_rx,
+            reducer: SendState::new(),   // all-false; see reducer section
+            shutdown: shutdown_rx,
+        },
+        RecvStreamReceiveCtx { id, receive: receive_rx, terminal: None, receive_closed: false },
+    )
+}
+```
+
+The retained receive half implements the SF-6 post-`stop_sending` contract with the
+new `receive_closed` flag: our own `stop_sending` submits `ABORT_RECEIVE` (no receive
+terminal injected) and sets the sticky flag, so every subsequent `poll_data` is a
+defined `Poll::Ready(Ok(None))` end-of-stream rather than `Pending` — and the
+`terminal` slot is left untouched. `h3::quic::RecvStream::poll_data` returns
+`Poll<Result<Option<Self::Buf>, StreamErrorIncoming>>` and `stop_sending(&mut self,
+error_code: u64)` (verified in `h3-0.0.8/src/quic.rs`):
+
+```rust
+// SF-6: post-`stop_sending` polling contract on the retained recv half.
+impl h3::quic::RecvStream for H3RecvStream {
+    type Buf = bytes::Bytes;
+
+    fn poll_data(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
+        use std::task::Poll;
+        // SF-6: our OWN stop_sending already ended the receive half locally. This is a
+        // clean end-of-stream, NOT a terminal: `terminal` stays whatever it was
+        // (normally None) and no receive terminal is injected.
+        if self.rctx.receive_closed {
+            return Poll::Ready(Ok(None));
+        }
+        // Normal path: drain one ReceiveEvent. Data -> Ok(Some(bytes)); a sticky
+        // terminal (Fin/Reset/Connection/Internal) is stored in `self.rctx.terminal`
+        // and mapped by `convert_recv` (Fin -> Ok(None), else Err(..)); no event yet
+        // and channel open -> Pending. (Full drain logic elided; see convert_recv.)
+        drain_one_receive_event(&mut self.rctx, cx)
+    }
+
+    fn stop_sending(&mut self, error_code: u64) {
+        // Submit ABORT_RECEIVE with the clamped code (per the stop_sending(code) rule
+        // above, inject NO receive terminal), then set the sticky local flag so every
+        // subsequent poll_data is a defined Ready(Ok(None)) rather than Pending.
+        self.stream
+            .shutdown(msquic::StreamShutdownFlags::ABORT_RECEIVE, clamp_application_code(error_code));
+        self.rctx.receive_closed = true;              // sticky; `terminal` untouched
+    }
+
+    fn recv_id(&self) -> h3::quic::StreamId {
+        self.rctx.id
+    }
+}
+
+#[test]
+fn poll_data_after_local_stop_sending_is_ok_none() {
+    use std::task::Poll;
+    // Open connection, no peer FIN/reset, empty terminal slot.
+    let mut recv = test_recv_stream_open_no_terminal();
+    recv.stop_sending(0);
+    let mut cx = noop_context();
+    // Defined clean end-of-stream: not Pending, not Err.
+    assert!(matches!(recv.poll_data(&mut cx), Poll::Ready(Ok(None))));
+    // No terminal was injected: the sticky recv terminal slot remains empty.
+    assert!(recv.rctx.terminal.is_none());
+    assert!(recv.rctx.receive_closed);
+}
+```
+
+Accepted streams already have a validated `StreamId` (queried from the borrowed
+`StreamRef`, see below), so they call `stream_ctx_channel` above, which builds
+both id-bearing frontend halves immediately. Locally opened streams have **no
+id** until `StartComplete`, so they *cannot* call `stream_ctx_channel`. They use
+a distinct **pre-ID constructor** that builds only the callback-owned
+`StreamSendCtx` (the senders) plus a bundle of the four matching receiver ends.
+The id-bearing frontend halves are built later, by `OpeningStream::finalize`,
+once `StartComplete` yields the id:
+
+```rust
+// Frontend receiver ends held by an OpeningStream until the id is known. These
+// are the *receiver* halves whose *sender* halves live in the callback-owned
+// StreamSendCtx. Holding them keeps every channel open (so callback sends never
+// fail) and lets finalize move them into the H3Stream halves unchanged.
+#[derive(Debug)]
+struct PreIdReceivers {
+    start: oneshot::Receiver<Result<u64, Status>>,
+    send: mpsc::UnboundedReceiver<SendEvent>,
+    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
+    shutdown: oneshot::Receiver<SendEvent>,
+}
+
+/// Pre-ID variant of stream_ctx_channel: no StreamId is required or produced.
+/// Used only by locally opened streams. It builds the callback-owned
+/// StreamSendCtx (senders) and returns the matching receiver ends bundled, so
+/// an OpeningStream can hold them until StartComplete yields the id.
+fn stream_ctx_channel_pre_id(state: Arc<StreamState>) -> (StreamSendCtx, PreIdReceivers) {
+    let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
+    let (send_tx, send_rx) = mpsc::unbounded::<SendEvent>();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<SendEvent>();
+    let (receive_tx, receive_rx) = mpsc::unbounded::<ReceiveEvent>();
+    (
+        StreamSendCtx {
+            state,
+            start: Some(start_tx),
+            send: Some(send_tx),
+            receive: Some(receive_tx),
+            receive_terminal_sent: false,
+            shutdown: Some(shutdown_tx),
+        },
+        PreIdReceivers {
+            start: start_rx,
+            send: send_rx,
+            receive: receive_rx,
+            shutdown: shutdown_rx,
+        },
+    )
+}
+```
+
+```rust
+// ── StreamOpener: same shape; its temp holders are OpeningStream, and it owns
+//    the connection-scoped open seam (OpenExec, executor section) so tests can
+//    substitute the native open/start.
+#[derive(Debug)]
+pub struct StreamOpener {
+    conn: Arc<ConnHandle>,
+    bidi_temp: Option<OpeningStream>,   // was Option<H3Stream>
+    uni_temp: Option<OpeningStream>,    // was Option<H3Stream>
+    open_exec: Box<dyn OpenExec>,       // prod = StreamOpenExecutor (see below)
+}
+// Clone (used by Connection::opener) resets both temps and installs a fresh
+// production StreamOpenExecutor, since an in-flight OpeningStream is not shared.
+
+/// A locally opened stream whose native handle is started but whose h3 StreamId
+/// is not yet known. Private to StreamOpener; the only stream form allowed to
+/// exist without a cached id. On a successful StartComplete it is consumed into
+/// an H3Stream with concrete id fields in both halves.
+#[derive(Debug)]
+struct OpeningStream {
+    stream: Arc<msquic::Stream>,
+    state: Arc<StreamState>,
+    // Frontend *receiver* ends (senders live in the callback's StreamSendCtx),
+    // held until finalize so callback sends keep working and the ends can be
+    // moved into the H3Stream halves unchanged.
+    recv: PreIdReceivers,
+}
+
+impl OpeningStream {
+    /// Consume into an H3Stream once StartComplete has yielded a validated id.
+    /// `start` has already been polled to completion by poll_open_inner and is
+    /// dropped here; the remaining three receivers move into the two halves.
+    fn finalize(self, id: h3::quic::StreamId) -> H3Stream {
+        let OpeningStream { stream, state, recv } = self;
+        let PreIdReceivers { start: _done, send, receive, shutdown } = recv;
+        H3Stream {
+            send: H3SendStream {
+                exec: Box::new(StreamExecutor { stream: stream.clone() }),
+                sctx: SendStreamReceiveCtx {
+                    id,
+                    state,
+                    send,
+                    reducer: SendState::new(),   // all-false; see reducer section
+                    shutdown,
+                },
+            },
+            recv: H3RecvStream {
+                stream,
+                rctx: RecvStreamReceiveCtx { id, receive, terminal: None, receive_closed: false },
+            },
+        }
+    }
+}
+```
+
+Exact constructor/finalizer **bodies** (accepted-connection state creation, the
+`OpeningStream` finalizer, and the pre-ID open path threaded through `attach`):
+
+```rust
+impl Connection {
+    // Accepted connection: the *caller path is the listener callback*, but the
+    // shared ConnectionState is created here (not by the caller), then cloned
+    // into the callback and into ConnHandle — exactly like connect(). This is
+    // the single place accepted-connection state is created and threaded.
+    pub(crate) fn attach(inner: msquic::Connection, guard: RundownGuard) -> Self {
+        // 1. Shared connection terminal slot, created before the callback runs.
+        let state = Arc::new(ConnectionState {
+            terminal: std::sync::Mutex::new(None),
+        });
+        // 2. Ctx channel is seeded with a clone (conn_ctx_channel takes state).
+        let (mut ctx, rx) = conn_ctx_channel(state.clone());
+        // 3. Install the callback BEFORE returning from the listener callback;
+        //    the closure owns `ctx`, which owns the second state clone and is the
+        //    clone PeerStreamStarted uses to seed accepted streams.
+        let handler =
+            move |_: msquic::ConnectionRef, ev: msquic::ConnectionEvent| connection_callback(&mut ctx, ev);
+        inner.set_callback_handler(handler);
+        // 4. ConnHandle owns the third clone alongside the native handle + guard.
+        let conn = Arc::new(ConnHandle::new(inner, state, guard));
+        Connection { conn: conn.clone(), ctx: rx, opener: StreamOpener::new(conn) }
+    }
+    // connect() is unchanged in shape but likewise builds ConnectionState before
+    // msquic::Connection::open, passes state.clone() to conn_ctx_channel, and to
+    // ConnHandle::new; its `connected` await now yields Result<(), Status>.
+}
+
+impl H3Stream {
+    // Accepted stream: id already validated from the borrowed StreamRef (below),
+    // and the shared connection terminal is threaded into the new StreamState.
+    pub(crate) fn attach(
+        stream: msquic::Stream,
+        conn_state: Arc<ConnectionState>,
+        id: h3::quic::StreamId,
+    ) -> Self {
+        let state = Arc::new(StreamState {
+            connection: conn_state,
+            send_terminal: std::sync::Mutex::new(None),
+        });
+        // id is known, so build both id-bearing halves directly.
+        let (mut ctx, sctx, rctx) = stream_ctx_channel(state, id);
+        let handler =
+            move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
+        stream.set_callback_handler(handler);
+        let s = Arc::new(stream);
+        H3Stream {
+            send: H3SendStream {
+                exec: Box::new(StreamExecutor { stream: s.clone() }),
+                sctx,
+            },
+            recv: H3RecvStream { stream: s, rctx },
+        }
+    }
+
+    // Locally opened: takes &ConnHandle (not &msquic::Connection) so it can copy
+    // the shared ConnectionState into the new StreamState, and returns the
+    // pre-id OpeningStream rather than a temporary H3Stream. The native open+start
+    // are the production body of OpenExec::submit_open_start.
+    fn open_and_start(conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
+        let state = Arc::new(StreamState {
+            connection: conn.state().clone(),   // copy the shared connection terminal
+            send_terminal: std::sync::Mutex::new(None),
+        });
+        let (mut ctx, recv) = stream_ctx_channel_pre_id(state.clone());
+        let handler =
+            move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
+        let flag = if uni { StreamOpenFlags::UNIDIRECTIONAL } else { StreamOpenFlags::NONE };
+        let stream = msquic::Stream::open(conn.inner(), flag, handler)?;
+        stream.start(StreamStartFlags::NONE)?;   // id arrives later via StartComplete
+        Ok(OpeningStream { stream: Arc::new(stream), state, recv })
+    }
+}
+
+impl StreamOpener {
+    fn new(conn: Arc<ConnHandle>) -> Self {
+        Self { conn, bidi_temp: None, uni_temp: None, open_exec: Box::new(StreamOpenExecutor) }
+    }
+
+    // Check shared connection terminal first; create the OpeningStream via the
+    // open seam; await StartComplete; on Ok(id) validate and finalize.
+    fn poll_open_inner(
+        conn: &Arc<ConnHandle>,
+        open_exec: &dyn OpenExec,
+        uni: bool,
+        holder: &mut Option<OpeningStream>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<H3Stream, StreamErrorIncoming>> {
+        use std::task::Poll;
+        // 1. Fail fast if the connection already published a terminal.
+        if let Some(reason) = conn.state().load_terminal() {
+            *holder = None;   // drop any in-flight OpeningStream
+            return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: convert_conn(reason),
+            }));
+        }
+        // 2. Create + start the native stream if none is in flight.
+        if holder.is_none() {
+            match open_exec.submit_open_start(conn, uni) {
+                Ok(opening) => *holder = Some(opening),
+                Err(status) => {
+                    // A shutdown may have raced the open; prefer the conn terminal.
+                    return Poll::Ready(Err(match conn.state().load_terminal() {
+                        Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
+                            connection_error: convert_conn(reason),
+                        },
+                        None => StreamErrorIncoming::Unknown(Box::new(status)),
+                    }));
+                }
+            }
+        }
+        // 3. Await StartComplete on the OpeningStream's `start` receiver.
+        let opening = holder.as_mut().expect("holder populated in step 2");
+        let raw = match Pin::new(&mut opening.recv.start).poll(cx) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Ok(raw)) => raw,   // Result<u64, Status> from StartComplete
+            Poll::Ready(Err(oneshot::Canceled)) => {
+                // Sender dropped by ShutdownComplete without a StartComplete.
+                *holder = None;
+                let connection_error = match conn.state().load_terminal() {
+                    Some(reason) => convert_conn(reason),
+                    None => ConnectionErrorIncoming::InternalError(
+                        "stream start cancelled without a terminal reason".into()),
+                };
+                return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming { connection_error }));
+            }
+        };
+        // 4. StartComplete carried a status; classify it.
+        let opening = holder.take().expect("holder populated in step 2");
+        match raw {
+            Err(status) => Poll::Ready(Err(match conn.state().load_terminal() {
+                Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
+                    connection_error: convert_conn(reason),
+                },
+                None => StreamErrorIncoming::Unknown(Box::new(status)),
+            })),
+            Ok(raw_id) => match validate_stream_id(raw_id) {   // (below)
+                Ok(id) => Poll::Ready(Ok(opening.finalize(id))),
+                Err(_) => Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                    connection_error: ConnectionErrorIncoming::InternalError(
+                        "local stream ID is invalid".into()),
+                })),
+            },
+        }
+    }
+}
+```
+
+The lone `expect("holder populated in step 2")` calls are internal invariants on
+a value this function set on the immediately preceding lines, not FFI-reachable
+callback code; they can equally be written as `let Some(..) = .. else { return
+Poll::Pending }`. No `expect` touches a channel result, a native handle, or a
+lock, so no callback path can unwind through FFI. `poll_open_bidi`/`poll_open_send`
+call `Self::poll_open_inner(&self.conn, &*self.open_exec, uni, &mut self.bidi_temp
+/ self.uni_temp, cx)`.
+
+### Adapter-owned error types
+
+Compilable definitions with derives, `Display`, and `From` conversions. `Status`,
+`u64` codes, and `&'static str` messages are the only stored data. All four are
+`Send + Sync` because `QUIC_STATUS` (an integer alias) and the primitives are.
+
+```rust
+use std::fmt;
+use crate::msquic::Status;
+
+/// send_data payload above MAX_ADAPTER_SEND. One-shot; never stored in the
+/// shared send-terminal slot (see SendOperationError below).
+#[derive(Debug)]
+pub struct OversizedSend {
+    /// Requested payload length in bytes (the `remaining()` that was rejected).
+    pub len: usize,
+}
+impl fmt::Display for OversizedSend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "send_data payload of {} bytes exceeds MAX_ADAPTER_SEND ({} bytes)",
+            self.len, MAX_ADAPTER_SEND
+        )
+    }
+}
+impl std::error::Error for OversizedSend {}
+
+/// Non-application transport shutdown. Both the QUIC status and the wire
+/// transport error code are retained for diagnostics.
+#[derive(Debug)]
+pub struct MsQuicTransportError {
+    pub status: Status,
+    pub error_code: u64,
+}
+impl fmt::Display for MsQuicTransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "QUIC transport shutdown: status {} (transport error_code {})",
+            self.status, self.error_code
+        )
+    }
+}
+impl std::error::Error for MsQuicTransportError {}
+
+/// Local (application-initiated) connection close. Carries no peer code — see
+/// the mapping table row: "do not invent a peer code".
+#[derive(Debug)]
+pub struct LocalConnectionClose;
+impl fmt::Display for LocalConnectionClose {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("connection closed locally by the application")
+    }
+}
+impl std::error::Error for LocalConnectionClose {}
+
+/// Local reset via SendStream::reset(code). Distinct from a peer
+/// StreamTerminated: h3 should not poll a reset send stream.
+#[derive(Debug)]
+pub struct LocalStreamReset {
+    pub code: u64,
+}
+impl fmt::Display for LocalStreamReset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "send stream reset locally with code {}", self.code)
+    }
+}
+impl std::error::Error for LocalStreamReset {}
+```
+
+`From` conversions used at the polling boundary (these are the *only* places that
+mint h3 errors, keeping the two similarly named `OversizedSend` uses consistent):
+
+```rust
+// ConnectionTerminal -> ConnectionErrorIncoming
+fn convert_conn(t: ConnectionTerminal) -> ConnectionErrorIncoming {
+    use ConnectionTerminal as C;
+    match t {
+        C::PeerApplication(code) => ConnectionErrorIncoming::ApplicationClose { error_code: code },
+        C::Timeout => ConnectionErrorIncoming::Timeout,
+        C::Transport { status, error_code } =>
+            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(
+                MsQuicTransportError { status, error_code })),
+        C::LocalClose =>
+            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(LocalConnectionClose)),
+        C::Internal(msg) => ConnectionErrorIncoming::InternalError(msg.to_string()),
+    }
+}
+
+// SendTerminal -> StreamErrorIncoming
+fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
+    use SendTerminal as S;
+    match t {
+        S::Stopped(code) => StreamErrorIncoming::StreamTerminated { error_code: code },
+        S::Connection(reason) =>
+            StreamErrorIncoming::ConnectionErrorIncoming { connection_error: convert_conn(reason) },
+        S::LocalReset(code) =>
+            StreamErrorIncoming::Unknown(Box::new(LocalStreamReset { code })),
+        S::Failed(status) => StreamErrorIncoming::Unknown(Box::new(status)),
+        S::Internal(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
+        },
+    }
+}
+
+// ReceiveTerminal -> Result<Option<Bytes>, StreamErrorIncoming>
+fn convert_recv(t: ReceiveTerminal) -> Result<Option<bytes::Bytes>, StreamErrorIncoming> {
+    use ReceiveTerminal as R;
+    match t {
+        R::Fin => Ok(None),
+        R::Reset(code) => Err(StreamErrorIncoming::StreamTerminated { error_code: code }),
+        R::Connection(reason) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: convert_conn(reason) }),
+        R::Internal(msg) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()) }),
+    }
+}
+```
+
+`SendOperationError` → h3 error mapping is the disambiguation the reviewer asked
+for. `SendOperationError` is the **one-shot** `send_data` result and is *never*
+stored in `StreamState::send_terminal`; the sticky `SendTerminal` path
+(`convert_send`) is separate:
+
+```rust
+// send_data's ReturnImmediateError(SendOperationError) is converted here, and
+// nowhere else, so `SendOperationError::OversizedSend { len }` and the final
+// boxed `OversizedSend` cannot diverge:
+fn convert_send_op(e: SendOperationError) -> StreamErrorIncoming {
+    match e {
+        SendOperationError::OversizedSend { len } =>
+            StreamErrorIncoming::Unknown(Box::new(OversizedSend { len })),
+        SendOperationError::Misuse(_msg) =>
+            StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(
+                    "send_data called while a send is in progress or after finish".into()),
+            },
+    }
+}
+```
+
+Thus `SendOperationError::OversizedSend { len }` maps 1:1 to the boxed
+`OversizedSend { len }` (`StreamErrorIncoming::Unknown`), and
+`SendOperationError::Misuse` maps to nested `InternalError` — the same class the
+reference adapters use for send-while-busy. No other site constructs these
+errors.
+
+### Accepted-stream ID query
+
+Committed, no `msquic` dependency change:
+
+```rust
+/// Pure, unit-testable id validation. MsQuic ids are 62-bit so this never fails
+/// for a live peer, but the InvalidStreamId branch is still handled.
+fn validate_stream_id(raw: u64) -> Result<h3::quic::StreamId, h3::quic::InvalidStreamId> {
+    h3::quic::StreamId::try_from(raw)   // impl TryFrom<u64>, h3-0.0.8 proto/stream.rs:147
+}
+```
+
+Accepted-stream attachment in `connection_callback`, `PeerStreamStarted { stream:
+StreamRef, flags }`:
+
+```rust
+// stream: &StreamRef (borrowed; Drop nulls the handle so it never closes it).
+// StreamRef: Deref<Target = Stream>, so this calls Stream::get_stream_id via
+// auto-deref against the BORROWED handle. No owning Stream is created here.
+// Safety: get_stream_id issues Api::get_param_auto::<u64>(handle,
+// QUIC_PARAM_STREAM_ID) on the still-native-owned handle; we hold only a
+// borrow, take no ownership, and never StreamClose it on this failure path.
+let raw_id: u64 = match stream.get_stream_id() {   // Result<u64, Status>
+    Ok(id) => id,
+    Err(status) => {
+        // pre-ownership failure: publish Internal terminal, wake acceptors,
+        // return `status` so MsQuic closes the rejected stream itself.
+        publish_conn_internal(&ctx.state, "accepted stream ID query failed");
+        wake_acceptors(ctx);
+        return Err(status);
+    }
+};
+let id = match validate_stream_id(raw_id) {
+    Ok(id) => id,
+    Err(_) => {
+        publish_conn_internal(&ctx.state, "accepted stream ID is invalid");
+        wake_acceptors(ctx);
+        return Err(Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR));
+    }
+};
+// Success: only now take ownership and attach.
+let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
+let h3 = H3Stream::attach(owned, ctx.state.clone(), id);
+// post-ownership delivery failure -> drop/close via Rust, return Ok (below).
+```
+
+`get_stream_id` lives on `msquic::Stream` (`lib.rs:1230`) and is reached through
+`StreamRef: Deref<Target = Stream>` (`lib.rs:1236`). No borrowed-query helper is
+added to the binding, no raw `Api::get_param` call is written in the adapter, and
+no dependency patch/version bump is required.
+
+### Reducer: exhaustive `match` form
+
+`SendState::new()` is all-false:
+
+```rust
+impl SendState {
+    fn new() -> Self {
+        SendState {
+            send_submitting: false,
+            send_inprogress: false,
+            finish_submitting: false,
+            finish_started: false,
+            finish_complete: false,
+            reset_submitting: false,
+        }
+    }
+}
+```
+
+Named predicates (exact boolean expressions the transition arms use):
+
+```rust
+impl SendState {
+    /// A native submission is reserved but its *Submitted result has not arrived.
+    fn submission_reserved(&self) -> bool {
+        self.send_submitting || self.finish_submitting || self.reset_submitting
+    }
+    /// "idle": accepting a new send_data — nothing in flight, not finishing,
+    /// no reservation outstanding.
+    fn idle(&self) -> bool {
+        !self.send_inprogress && !self.finish_started && !self.finish_complete
+            && !self.submission_reserved()
+    }
+    /// "send pending": a data send is committed and awaiting its SendComplete.
+    fn send_pending(&self) -> bool { self.send_inprogress }
+    /// "finishing": graceful finish reserved or committed, not yet complete.
+    fn finishing(&self) -> bool {
+        (self.finish_submitting || self.finish_started) && !self.finish_complete
+    }
+}
+```
+
+Guard-set membership by frontend method (which reservation flags each checks):
+
+| Guard | Flags it inspects | Meaning |
+| --- | --- | --- |
+| `send_data` misuse | `send_inprogress \|\| send_submitting \|\| finish_submitting \|\| finish_started \|\| finish_complete` | any in-flight/finishing state rejects a new `send_data` |
+| `poll_ready` reservation block | `submission_reserved()` (all three) | a method arriving mid-submission is `Internal` |
+| `poll_ready`-after-finish misuse | `finish_started` (regardless of `finish_complete`) | non-sticky nested `InternalError` |
+| `poll_finish` reservation block | `submission_reserved()` (all three) | same as above |
+| `reset` no-op | `finish_complete \|\| terminal_present` | infallible `NoOp` |
+| `reset` impossible | `submission_reserved()` | `PublishTerminal{Internal, Reset}` |
+
+`TerminalPublished` arms (previously implicit) are now enumerated: after the
+first-writer helper returns the `winner`, the reducer emits exactly one command
+per `continuation`, and mutates no state (the winner is already in the shared
+slot):
+
+| `TerminalPublished { winner, continuation }` | Command |
+| --- | --- |
+| `continuation = SendData` | `ReturnError(winner)` → `Err(convert_send(winner))` from `send_data` |
+| `continuation = PollReady` | `ReturnError(winner)` → `Poll::Ready(Err(convert_send(winner)))` |
+| `continuation = PollFinish` | `ReturnError(winner)` → `Poll::Ready(Err(convert_send(winner)))` |
+| `continuation = Reset` | `NoOp` (infallible method; winner stored for a later poll) |
+
+The "impossible combination" is no longer a prose wildcard: because every
+`SendInput` variant and every inner `SendPoll`/`SendPayload`/`SendEvent` case is
+matched, the reducer is one exhaustive `match` with no outer `_` arm. Each
+formerly-implicit "impossible" pairing is encoded as an explicit
+`PublishTerminal { candidate: SendTerminal::Internal(..), continuation }` arm
+that mutates no committed flag and never panics. The complete body, directly
+translatable:
+
+```rust
+fn transition(state: &mut SendState, input: SendInput) -> SendCommand {
+    use SendCommand::*;
+    use SendInput::*;
+    use TerminalContinuation as K;
+    let aborted = || SendTerminal::Failed(Status::new(StatusCode::QUIC_STATUS_ABORTED));
+
+    match input {
+        // ── Precedence 1: *Submitted bookkeeping. Always clears its reservation
+        //    before any winner is applied; a missing reservation is internal.
+        SendSubmitted { result, terminal } => {
+            if !state.send_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("SendSubmitted without reservation"),
+                    continuation: K::SendData,
+                };
+            }
+            state.send_submitting = false;
+            match result {
+                Ok(()) => {
+                    state.send_inprogress = true;
+                    match terminal {
+                        Some(w) => ReturnError(w),   // a winner raced in
+                        None => ReturnSent,          // send_data's Ok(())
+                    }
+                }
+                // Buffer already reclaimed by the caller on the Err path.
+                Err(status) => PublishTerminal {
+                    candidate: terminal.unwrap_or(SendTerminal::Failed(status)),
+                    continuation: K::SendData,
+                },
+            }
+        }
+        GracefulSubmitted { result, terminal } => {
+            if !state.finish_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("GracefulSubmitted without reservation"),
+                    continuation: K::PollFinish,
+                };
+            }
+            state.finish_submitting = false;
+            match result {
+                Ok(()) => { state.finish_started = true; RepollFinish }  // never Pending directly
+                Err(status) => PublishTerminal {
+                    candidate: terminal.unwrap_or(SendTerminal::Failed(status)),
+                    continuation: K::PollFinish,
+                },
+            }
+        }
+        ResetSubmitted { code, result, terminal } => {
+            if !state.reset_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("ResetSubmitted without reservation"),
+                    continuation: K::Reset,
+                };
+            }
+            state.reset_submitting = false;
+            let candidate = match result {
+                Ok(()) => terminal.unwrap_or(SendTerminal::LocalReset(code)),
+                Err(status) => terminal.unwrap_or(SendTerminal::Failed(status)),
+            };
+            PublishTerminal { candidate, continuation: K::Reset }
+        }
+
+        // ── Consume the resolved winner (no state mutation).
+        TerminalPublished { winner, continuation } => match continuation {
+            K::SendData | K::PollReady | K::PollFinish => ReturnError(winner),
+            K::Reset => NoOp,   // infallible method; winner stored for a later poll
+        },
+
+        // ── send_data request. Terminal wins; else misuse if busy/finishing.
+        SendRequested { payload, terminal } => {
+            if let Some(w) = terminal { return ReturnError(w); }
+            if state.send_inprogress || state.send_submitting
+                || state.finish_submitting || state.finish_started || state.finish_complete {
+                return ReturnImmediateError(SendOperationError::Misuse("send_data while busy/finishing"));
+            }
+            match payload {                                              // idle, no winner
+                SendPayload::Empty => ReturnSent,                        // no-op, no reservation
+                SendPayload::Oversized { len } =>
+                    ReturnImmediateError(SendOperationError::OversizedSend { len }),  // state unchanged
+                SendPayload::NonEmpty { .. } => { state.send_submitting = true; SubmitSend }
+            }
+        }
+
+        // ── reset request (infallible; at most one native SubmitReset).
+        Reset { code, terminal } => {
+            if state.finish_complete || terminal.is_some() {
+                return NoOp;   // already terminal; nothing to submit
+            }
+            if state.submission_reserved() {
+                return PublishTerminal {   // impossible under serialized callers
+                    candidate: SendTerminal::Internal("reset during submission reservation"),
+                    continuation: K::Reset,
+                };
+            }
+            state.reset_submitting = true;   // otherwise, incl. incomplete finish
+            SubmitReset(code)
+        }
+
+        // ── poll_ready request. A present shared terminal is surfaced first.
+        PollReady { poll, terminal } => {
+            if state.submission_reserved() {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("poll_ready during submission reservation"),
+                    continuation: K::PollReady,
+                };
+            }
+            // Method-terminal step: a winner already in the shared slot is returned
+            // before ordinary event handling, so a `Pending` poll can never linger
+            // past a terminal.
+            if let Some(w) = terminal {
+                state.send_inprogress = false;
+                return ReturnError(w);
+            }
+            if state.finish_started {   // h3 misuse; no native call, non-sticky
+                return ReturnError(SendTerminal::Internal("poll_ready after finish"));
+            }
+            match poll {
+                // Terminal handled above, so a closed channel here has no winner.
+                SendPoll::Closed => PublishTerminal {
+                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Event(SendEvent::Complete { cancelled: false }) => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {   // impossible idle-state completion
+                            candidate: SendTerminal::Internal("SendComplete without an outstanding send"),
+                            continuation: K::PollReady,
+                        };
+                    }
+                    state.send_inprogress = false; ReturnReady
+                }
+                SendPoll::Event(SendEvent::Complete { cancelled: true }) => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {   // impossible idle-state completion
+                            candidate: SendTerminal::Internal("cancelled SendComplete without an outstanding send"),
+                            continuation: K::PollReady,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    // No shared winner (handled above): synthesize the abort terminal.
+                    PublishTerminal { candidate: aborted(), continuation: K::PollReady }
+                }
+                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
+                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Event(SendEvent::FinishComplete { .. }) => PublishTerminal {
+                    candidate: SendTerminal::Internal("finish event observed on poll_ready"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Pending => if state.send_inprogress { Pending } else { ReturnReady },
+            }
+        }
+
+        // ── poll_finish request. Absorbing finish and a completed graceful finish
+        //    both precede the method-terminal step and ordinary event handling.
+        PollFinish { poll, terminal } => {
+            if state.finish_complete { return ReturnFinished; }   // absorbing
+            if state.submission_reserved() {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("poll_finish during submission reservation"),
+                    continuation: K::PollFinish,
+                };
+            }
+            // Documented successful-finish exception: a graceful finish that
+            // actually completed wins even over a present terminal.
+            if let SendPoll::Event(SendEvent::FinishComplete { graceful }) = poll {
+                if !state.finish_started {
+                    return PublishTerminal {
+                        candidate: SendTerminal::Internal("finish complete without a started finish"),
+                        continuation: K::PollFinish,
+                    };
+                }
+                if graceful {
+                    state.finish_complete = true;
+                    return ReturnFinished;
+                }
+                // graceful == false while finishing: abort (winner wins if present).
+                return PublishTerminal {
+                    candidate: terminal.unwrap_or_else(aborted),
+                    continuation: K::PollFinish,
+                };
+            }
+            // Method-terminal step: after the finish exceptions, a present winner is
+            // surfaced before any Pending/SubmitGraceful, so PollFinish(Pending) can
+            // never submit graceful shutdown once a terminal has won.
+            if let Some(w) = terminal {
+                state.send_inprogress = false;
+                return ReturnError(w);
+            }
+            match poll {
+                SendPoll::Closed => PublishTerminal {
+                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Event(SendEvent::Complete { cancelled: false }) if !state.finish_started => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {   // impossible idle-state completion
+                            candidate: SendTerminal::Internal("SendComplete without an outstanding send"),
+                            continuation: K::PollFinish,
+                        };
+                    }
+                    state.send_inprogress = false; state.finish_submitting = true; SubmitGraceful
+                }
+                SendPoll::Event(SendEvent::Complete { cancelled: true }) if !state.finish_started => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {   // impossible idle-state completion
+                            candidate: SendTerminal::Internal("cancelled SendComplete without an outstanding send"),
+                            continuation: K::PollFinish,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    PublishTerminal { candidate: aborted(), continuation: K::PollFinish }
+                }
+                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
+                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Pending if state.finish_started => Pending,
+                SendPoll::Pending if state.send_inprogress => Pending,     // wait for in-flight data send
+                SendPoll::Pending => { state.finish_submitting = true; SubmitGraceful }  // idle, not finishing
+                // Any remaining event/state pair (e.g. a data completion while
+                // finishing) is adapter-internal, never a panic.
+                SendPoll::Event(_) => PublishTerminal {
+                    candidate: SendTerminal::Internal("impossible poll_finish event/state"),
+                    continuation: K::PollFinish,
+                },
+            }
+        }
+    }
+}
+```
+
+The guard order inside each arm follows the precedence stated earlier
+(submitted-result bookkeeping is discharged by the outer variant match itself;
+absorbing `finish_complete` precedes reservation/method handling in `PollFinish`;
+`submission_reserved()` precedes method-specific handling in `PollReady`). Reducer
+tests are table-driven from the rows above and need no executor or native handle.
+
+### Command-executor boundary and per-method loops
+
+The reducer touches MsQuic only through two seams, split by lifetime because one
+*acts on* an existing stream and the other *creates* one:
+
+```rust
+/// Send-side seam: acts on an already-open stream. Stored behind a trait object
+/// in H3SendStream so a test double replaces it without a live connection. The
+/// reducer never names it.
+trait SendExec: std::fmt::Debug + Send {
+    /// Materialize the already-validated non-zero payload's SendBuffer,
+    /// Box::into_raw it as client_context, and call Stream::send. On an immediate
+    /// Err the box is reconstructed and dropped here, before returning.
+    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status>;
+    fn submit_graceful(&mut self) -> Result<(), Status>;   // Stream::shutdown(GRACEFUL)
+    fn submit_reset(&mut self, code: u64) -> Result<(), Status>;  // shutdown(ABORT_SEND)
+}
+
+#[derive(Debug)]
+struct StreamExecutor { stream: Arc<msquic::Stream> }   // production send seam
+impl SendExec for StreamExecutor {
+    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
+        // Box the self-referential SendBuffer and hand its raw pointer to native as
+        // client_context. `buf.buffers` (a [BufferRef; 1]) points into `buf._bytes`
+        // and stays valid because the box is never moved again until SendComplete.
+        let cc: *mut SendBuffer = Box::into_raw(Box::new(buf));
+        // SAFETY: buffers memory is valid until the SendComplete callback
+        // reconstructs+drops the box (Stream::send's contract). FIN is not set on a
+        // data send; graceful finish is a separate shutdown call.
+        let res = unsafe {
+            self.stream.send(&(*cc).buffers, msquic::SendFlags::NONE, cc as *const std::ffi::c_void)
+        };
+        if let Err(status) = res {
+            // Immediate failure: MsQuic took no ownership, so reclaim the box here
+            // (mirroring the SendComplete drop) before returning.
+            drop(unsafe { Box::from_raw(cc) });
+            return Err(status);
+        }
+        Ok(())
+    }
+    fn submit_graceful(&mut self) -> Result<(), Status> {
+        // GRACEFUL FIN; error_code is ignored for a graceful shutdown.
+        self.stream.shutdown(msquic::StreamShutdownFlags::GRACEFUL, 0)
+    }
+    fn submit_reset(&mut self, code: u64) -> Result<(), Status> {
+        // ABORT_SEND with the already-clamped application code (<= MAX_QUIC_VARINT).
+        self.stream.shutdown(msquic::StreamShutdownFlags::ABORT_SEND, code)
+    }
+}
+
+/// Open seam: *creates and starts* the native stream, returning the OpeningStream
+/// (which carries the start receiver). Separate from SendExec because it cannot
+/// act on an Arc<Stream> that does not exist yet. Stored in StreamOpener.
+trait OpenExec: std::fmt::Debug {
+    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status>;
+}
+
+#[derive(Debug)]
+struct StreamOpenExecutor;   // production open seam
+impl OpenExec for StreamOpenExecutor {
+    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
+        H3Stream::open_and_start(conn, uni)   // real Stream::open + Stream::start
+    }
+}
+```
+
+This resolves the earlier contradiction: `submit_open_start` now creates the
+stream and returns it (not `Result<(), Status>`), and `H3SendStream` stores
+`Box<dyn SendExec>` (not a concrete `StreamExecutor`), so a `CountingExec` is
+injectable in wiring tests.
+
+**Construction interface.** Production builds `H3SendStream` via
+`OpeningStream::finalize` / `H3Stream::attach` (which install
+`Box::new(StreamExecutor { stream })`). Tests use an internal constructor that
+takes only the injected seam and the send-side context — **no `Arc<msquic::Stream>`**,
+because the send half has no `stream` field and the production stream lives inside
+`StreamExecutor`:
+
+```rust
+impl H3SendStream {
+    /// Test/internal constructor: inject any SendExec (incl. CountingExec) plus the
+    /// send-side context whose channel senders the test retains. No live connection
+    /// or native stream is required — the reducer and loops touch only `exec` and
+    /// `sctx`.
+    fn with_exec(exec: Box<dyn SendExec>, sctx: SendStreamReceiveCtx) -> Self {
+        H3SendStream { exec, sctx }
+    }
+}
+```
+
+For a pure wiring test the caller builds `sctx` with `stream_ctx_channel(state, id)`
+(keeping the `StreamSendCtx` senders so it can feed `SendEvent`s and the finish
+one-shot by hand) and passes `Box::new(CountingExec::new(handle.clone(), script))`.
+
+`CountingExec` must stay inspectable **after** it is moved behind
+`Box<dyn SendExec>`, and it must actually **retain** the submitted buffer while the
+send is outstanding (so the test can later replay the production reclamation). Both
+are achieved with a cloneable, shared handle the test keeps, plus a real
+`Box::into_raw` `client_context` slot the test feeds back through the real
+`stream_callback`:
+
+```rust
+use std::collections::VecDeque;
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use std::sync::{Arc, Mutex, PoisonError};
+
+/// Shared, inspectable counters + client_context slots. The test keeps a clone of
+/// this handle, so every counter is readable AFTER the CountingExec is moved into
+/// H3SendStream behind Box<dyn SendExec>.
+#[derive(Clone, Debug, Default)]
+struct CountingHandle {
+    sends: Arc<AtomicUsize>,
+    gracefuls: Arc<AtomicUsize>,
+    resets: Arc<AtomicUsize>,
+    allocs: Arc<AtomicUsize>,                  // total Box<SendBuffer> created (Box::into_raw)
+    reclaims: Arc<AtomicUsize>,                // in-exec reclamations (immediate-failure arm only)
+    client_ctx: Arc<Mutex<VecDeque<usize>>>,   // raw ptrs "native" holds; the test replays each
+                                               // through stream_callback (the production reclaim path)
+}
+
+#[derive(Debug)]
+struct CountingExec {
+    h: CountingHandle,
+    script: VecDeque<Result<(), Status>>,      // scripted submit_send results
+}
+impl CountingExec {
+    fn new(h: CountingHandle, script: VecDeque<Result<(), Status>>) -> Self { Self { h, script } }
+}
+impl SendExec for CountingExec {
+    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
+        self.h.sends.fetch_add(1, Relaxed);
+        // Mirror StreamExecutor EXACTLY: box the buffer and produce its raw
+        // client_context pointer BEFORE inspecting the scripted result, so both arms
+        // model the real allocation.
+        let cc = Box::into_raw(Box::new(buf));
+        self.h.allocs.fetch_add(1, Relaxed);
+        match self.script.pop_front().unwrap_or(Ok(())) {
+            Ok(()) => {
+                // Native accepted ownership: retain the pointer so the test can replay
+                // the native SendComplete through stream_callback. The box is NOT
+                // dropped here; it is outstanding until that callback reclaims it.
+                self.h.client_ctx.lock().unwrap_or_else(PoisonError::into_inner).push_back(cc as usize);
+                Ok(())
+            }
+            Err(status) => {
+                // Immediate failure: MsQuic takes no ownership and delivers no
+                // SendComplete, so the caller reclaims here and now — exactly as
+                // StreamExecutor's immediate-Err arm does (`Box::from_raw` + drop).
+                drop(unsafe { Box::from_raw(cc) });
+                self.h.reclaims.fetch_add(1, Relaxed);
+                Err(status)
+            }
+        }
+    }
+    fn submit_graceful(&mut self) -> Result<(), Status> { self.h.gracefuls.fetch_add(1, Relaxed); Ok(()) }
+    fn submit_reset(&mut self, _c: u64) -> Result<(), Status> { self.h.resets.fetch_add(1, Relaxed); Ok(()) }
+}
+// Reclamation of an accepted send's `Box<SendBuffer>` is NOT a test-only helper: the
+// test replays the retained `client_context` through the production `stream_callback`
+// as a synthesized `StreamEvent::SendComplete`, which is the exact reconstruct+drop
+// path the binding invokes. There is deliberately no separate `reclaim_client_context`
+// shim, so the seam test verifies the real callback code and its exactly-once event.
+```
+
+`test_send_ctx` builds a send-side context with **no live connection**: a fresh
+`StreamState`, an arbitrary cached id, and the id-bearing halves from
+`stream_ctx_channel`. It returns the frontend `SendStreamReceiveCtx` together with
+the callback-owned `StreamSendCtx`; the test keeps the latter so it can both drive
+`stream_callback` and observe the `SendEvent`s it emits. Constructing a non-empty
+`WriteBuf<Bytes>` uses h3's real `From<Frame<B>>` impl (`h3` `stream.rs:181`) — the
+only public way to build a data-carrying `WriteBuf`, since `WriteBuf`'s fields are
+private and its `From` sources (`Frame`, `StreamType`, `UniStreamHeader`) are h3
+internals. h3 exposes them to backend implementers behind the
+`i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature, enabled
+in `[dev-dependencies]` (see the release-gate wiring) so these tests can write
+`WriteBuf::<Bytes>::from(Frame::Data(..))` exactly as h3's own frontend does:
+
+```rust
+use bytes::Bytes;
+use std::ffi::c_void;
+use h3::proto::frame::Frame;            // gated by the backend dev-feature (see wiring)
+use h3::quic::SendStream;
+
+/// No live connection or native stream: fresh shared state + id-bearing halves.
+/// Returns (frontend send ctx, callback-owned senders). The recv half is unused.
+fn test_send_ctx() -> (SendStreamReceiveCtx, StreamSendCtx) {
+    let state = Arc::new(StreamState {
+        connection: Arc::new(ConnectionState { terminal: std::sync::Mutex::new(None) }),
+        send_terminal: std::sync::Mutex::new(None),
+    });
+    let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
+    let (ctx, sctx, _rctx) = stream_ctx_channel(state, id);
+    (sctx, ctx)
+}
+
+#[test]
+fn accepted_send_reclaims_via_callback_exactly_once() {
+    let h = CountingHandle::default();
+    let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new())); // all-Ok script
+    let (sctx, mut ctx) = test_send_ctx();                              // ctx keeps the senders
+    let mut s = H3SendStream::with_exec(exec, sctx);
+
+    // Valid WriteBuf<Bytes>: an h3 DATA frame carrying the payload, built via the
+    // real From<Frame<B>> impl. send_data classifies it NonEmpty and submits.
+    SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"hello world"))).unwrap();
+    assert_eq!(h.sends.load(Relaxed), 1);
+    assert_eq!(h.allocs.load(Relaxed), 1);              // one Box<SendBuffer> created
+    assert_eq!(h.reclaims.load(Relaxed), 0);            // not the immediate-failure arm
+    assert_eq!(h.client_ctx.lock().unwrap().len(), 1);  // outstanding: "native" holds the box
+
+    // Replay the native SendComplete through the PRODUCTION callback path: the exact
+    // stream_callback the binding invokes, fed the retained client_context pointer.
+    let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+    stream_callback(&mut ctx, StreamEvent::SendComplete {
+        cancelled: false,
+        client_context: cc as *const c_void,
+    }).unwrap();
+
+    // The callback reconstructed+dropped the Box<SendBuffer> once and enqueued
+    // exactly one Complete; a second poll is empty -> exactly-once callback count.
+    assert!(matches!(s.sctx.send.try_next(), Ok(Some(SendEvent::Complete { cancelled: false }))));
+    assert!(s.sctx.send.try_next().is_err());           // no second event
+    assert_eq!(h.reclaims.load(Relaxed), 0);            // reclaim happened in the callback
+}
+
+#[test]
+fn immediate_send_failure_reclaims_without_completion() {
+    let h = CountingHandle::default();
+    let mut script = VecDeque::new();
+    script.push_back(Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER)));
+    let exec = Box::new(CountingExec::new(h.clone(), script));
+    let (sctx, _ctx) = test_send_ctx();
+    let mut s = H3SendStream::with_exec(exec, sctx);
+
+    // submit_send returns Err; send_data surfaces the error.
+    assert!(SendStream::<Bytes>::send_data(
+        &mut s, Frame::Data(Bytes::from_static(b"hello world"))).is_err());
+
+    // One allocation, one immediate in-exec reclamation, nothing left outstanding,
+    // and ZERO SendComplete callbacks (native took no ownership, emitted no event).
+    assert_eq!(h.sends.load(Relaxed), 1);
+    assert_eq!(h.allocs.load(Relaxed), 1);
+    assert_eq!(h.reclaims.load(Relaxed), 1);
+    assert!(h.client_ctx.lock().unwrap().is_empty());   // no outstanding box
+    assert!(s.sctx.send.try_next().is_err());           // no Complete event ever enqueued
+}
+```
+
+The reducer and its inputs reference neither trait nor either impl, so reducer
+unit tests need no executor at all; executor-wiring tests read the `CountingHandle`
+counters directly. Open-count coverage uses a `CountingOpenExec` that delegates to
+`StreamOpenExecutor` while incrementing a counter, exercised by the loopback
+conformance test (an `OpeningStream` requires a real `HQUIC`, so it cannot be
+fabricated in a pure unit test).
+
+Ownership of bytes during immediate feedback. `SendInput::SendRequested` carries
+only the payload *classification* (`SendPayload`), never `B`. The original
+generic `WriteBuf<B>` is **not** moved into the reducer; the frontend keeps it on
+its own stack. When the reducer returns `SubmitSend`, the frontend — still on the
+caller thread, still owning `WriteBuf<B>` — runs `wb.copy_to_bytes(n)` (which
+takes `&mut wb`) into `Bytes`, builds `SendBuffer`, and hands it to
+`exec.submit_send(buf)`. The `Box<SendBuffer>` (which owns the `Bytes`) is
+`Box::into_raw`'d as `client_context` inside `submit_send`. On an immediate
+`Err(status)`, `submit_send` reconstructs and drops that box before returning, so
+exactly one owner exists at all times and the reducer's `SendSubmitted(Err)`
+bookkeeping runs with the buffer already reclaimed. On `Ok`, ownership is with
+MsQuic until `SendComplete`. Thus `Bytes`/`Box<SendBuffer>` lives on the frontend
+stack until `submit_send`, then in native `client_context`; it is never inside
+`SendState` or `SendInput`.
+
+Every loop below is driven by a single mutable `input` value; `feed(x)` means
+`input = x`, so each `transition` result is fed straight back within the same
+call. `wb` is `mut` because `Buf::copy_to_bytes(&mut self, ..)` consumes it.
+
+Normative `send_data` loop:
+
+```rust
+fn send_data<T: Into<WriteBuf<B>>>(&mut self, data: T) -> Result<(), StreamErrorIncoming> {
+    use SendCommand::*;
+    let mut wb: WriteBuf<B> = data.into();               // owned on the frontend stack
+    let payload = classify(wb.remaining());              // Empty | NonEmpty{len} | Oversized{len}
+    let mut input = SendInput::SendRequested {
+        payload, terminal: load_winner(&self.sctx.state),
+    };
+    loop {
+        match transition(&mut self.sctx.reducer, input) {
+            ReturnSent              => return Ok(()),                       // Ok(()) / empty no-op
+            ReturnImmediateError(e) => return Err(convert_send_op(e)),      // oversized / misuse
+            ReturnError(t)          => return Err(convert_send(t)),         // sticky winner
+            SubmitSend => {
+                // The ONE production copy path, shared verbatim with the benchmark:
+                // `&mut wb` is a `Buf`, so this runs the identical `copy_to_bytes`.
+                let buf = buffer::copy_into_send_buffer(&mut wb);         // consumes wb's bytes
+                let res = self.exec.submit_send(buf);                     // reclaims box on Err
+                input = SendInput::SendSubmitted { result: res, terminal: load_winner(&self.sctx.state) };
+            }
+            PublishTerminal { candidate, continuation } => {
+                let winner = publish(&self.sctx.state, candidate);         // first-writer helper
+                input = SendInput::TerminalPublished { winner, continuation };
+            }
+            // The reducer never returns these for a send_data-rooted input.
+            NoOp | ReturnReady | ReturnFinished | Pending
+            | SubmitGraceful | SubmitReset(_) | RepollFinish =>
+                return Err(convert_send(SendTerminal::Internal("unexpected send_data command"))),
+        }
+    }
+}
+```
+
+`poll_ready` loop:
+
+```rust
+fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+    use SendCommand::*;
+    // First input polls the channel; subsequent inputs are fed results.
+    let mut input = SendInput::PollReady {
+        poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
+    };
+    loop {
+        match transition(&mut self.sctx.reducer, input) {
+            Pending        => return Poll::Pending,                        // waker already registered
+            ReturnReady    => return Poll::Ready(Ok(())),
+            ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
+            PublishTerminal { candidate, continuation } => {
+                let winner = publish(&self.sctx.state, candidate);
+                input = SendInput::TerminalPublished { winner, continuation };
+            }
+            NoOp | ReturnSent | ReturnFinished | ReturnImmediateError(_)
+            | SubmitSend | SubmitGraceful | SubmitReset(_) | RepollFinish =>
+                return Poll::Ready(Err(convert_send(SendTerminal::Internal("unexpected poll_ready command")))),
+        }
+    }
+}
+```
+
+`reset` loop (infallible; stores the terminal, never returns to h3):
+
+```rust
+fn reset(&mut self, code: u64) {
+    use SendCommand::*;
+    let mut input = SendInput::Reset {
+        code: clamp_application_code(code), terminal: load_winner(&self.sctx.state),
+    };
+    loop {
+        match transition(&mut self.sctx.reducer, input) {
+            NoOp => return,                                                // already terminal
+            SubmitReset(c) => {
+                let res = self.exec.submit_reset(c);
+                input = SendInput::ResetSubmitted { code: c, result: res, terminal: load_winner(&self.sctx.state) };
+            }
+            PublishTerminal { candidate, continuation } => {
+                let winner = publish(&self.sctx.state, candidate);        // stored for a later poll
+                input = SendInput::TerminalPublished { winner, continuation };
+            }
+            // reset consumes any terminal; there is nothing to surface to h3 now.
+            ReturnError(_) | ReturnReady | ReturnFinished | ReturnSent
+            | ReturnImmediateError(_) | Pending | SubmitSend | SubmitGraceful | RepollFinish => return,
+        }
+    }
+}
+```
+
+The undefined `publish_result` from the earlier sketch is gone: the first-writer
+`publish(..)` return value is bound to `_winner` and fed straight back as
+`TerminalPublished { winner: _winner, .. }`.
+
+`poll_finish` loop (complete, with `RepollFinish` re-polling in the same call):
+
+```rust
+fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
+    use SendCommand::*;
+    let mut input = SendInput::PollFinish {
+        poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
+    };
+    loop {
+        match transition(&mut self.sctx.reducer, input) {
+            Pending        => return Poll::Pending,
+            ReturnFinished => return Poll::Ready(Ok(())),
+            ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
+            SubmitGraceful => {
+                let res = self.exec.submit_graceful();
+                input = SendInput::GracefulSubmitted { result: res, terminal: load_winner(&self.sctx.state) };
+            }
+            RepollFinish => {
+                // Re-poll the channel in THIS call so a synchronously-queued
+                // FinishComplete is drained (or the waker re-armed) — never defer.
+                input = SendInput::PollFinish {
+                    poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
+                };
+            }
+            PublishTerminal { candidate, continuation } => {
+                let winner = publish(&self.sctx.state, candidate);
+                input = SendInput::TerminalPublished { winner, continuation };
+            }
+            NoOp | ReturnReady | ReturnSent | ReturnImmediateError(_)
+            | SubmitSend | SubmitReset(_) =>
+                return Poll::Ready(Err(convert_send(SendTerminal::Internal("unexpected poll_finish command")))),
+        }
+    }
+}
+```
+
+**Load-bearing helper bodies.** The loops above call six helpers; their exact
+bodies (so callback/channel ordering is not left to the implementer):
+
+```rust
+/// send_data length classification, against MAX_ADAPTER_SEND (not native u32::MAX).
+fn classify(remaining: usize) -> SendPayload {
+    if remaining == 0 {
+        SendPayload::Empty
+    } else if remaining as u64 > MAX_ADAPTER_SEND {
+        SendPayload::Oversized { len: remaining }
+    } else {
+        // 0 < remaining <= 16 MiB, so the u32 cast never truncates.
+        SendPayload::NonEmpty { len: remaining as u32 }
+    }
+}
+
+/// Read the current sticky send winner (poison-safe clone; None if unset).
+fn load_winner(state: &StreamState) -> Option<SendTerminal> {
+    state.send_terminal.lock().unwrap_or_else(PoisonError::into_inner).clone()
+}
+
+/// First-writer publish: install `candidate` only if the slot is empty, and return
+/// whichever value now owns the slot. Poison-safe; never overwrites an earlier
+/// winner (the callback and the frontend race into the same slot).
+fn publish(state: &StreamState, candidate: SendTerminal) -> SendTerminal {
+    let mut slot = state.send_terminal.lock().unwrap_or_else(PoisonError::into_inner);
+    slot.get_or_insert(candidate).clone()
+}
+
+/// Construct the self-referential SendBuffer from already-validated non-empty owned
+/// bytes. `BufferRef::from(&bytes[..])` casts the (<= 16 MiB) length to u32 without
+/// truncation; moving `Bytes` into the struct does not move its heap storage, so
+/// the BufferRef pointer stays valid for the box's lifetime.
+impl SendBuffer {
+    fn new(bytes: Bytes) -> SendBuffer {
+        let bref = BufferRef::from(&bytes[..]);   // points into `bytes`'s heap storage
+        SendBuffer { buffers: [bref], _bytes: bytes }
+    }
+}
+
+/// Clamp an outgoing application error code to the QUIC 62-bit varint maximum.
+/// Matches the clamp used for connection close and stop_sending: (1<<62)-1 passes
+/// unchanged, 1<<62 clamps down.
+fn clamp_application_code(code: u64) -> u64 {
+    code.min(MAX_QUIC_VARINT)   // MAX_QUIC_VARINT = (1 << 62) - 1
+}
+
+impl H3SendStream {
+    /// Poll the two send-side event sources into a single SendPoll, with a defined
+    /// priority: the send-event mpsc (data `Complete`, `TerminalWake`) is polled
+    /// FIRST, because a data completion must be observed before the graceful-finish
+    /// completion that follows it; the finish one-shot is polled only when the mpsc
+    /// yields nothing. Both wakers are registered on a `Pending` result, so no
+    /// wakeup is lost, and the priority is deterministic (no `select!` fairness).
+    fn poll_send_channel(&mut self, cx: &mut Context<'_>) -> SendPoll {
+        use futures::StreamExt;                 // poll_next_unpin (Receiver: Unpin)
+        use std::future::Future;                // oneshot::Receiver: Future + Unpin
+        match self.sctx.send.poll_next_unpin(cx) {
+            // (1) A send event is always taken ahead of the finish one-shot.
+            Poll::Ready(Some(ev)) => SendPoll::Event(ev),
+            // mpsc closed: no further send events. A finish may still be
+            // deliverable, so consult the one-shot before declaring the channel
+            // closed (a closed channel with no terminal is an adapter-internal error).
+            Poll::Ready(None) => match Pin::new(&mut self.sctx.shutdown).poll(cx) {
+                Poll::Ready(Ok(ev)) => SendPoll::Event(ev),
+                Poll::Ready(Err(_canceled)) => SendPoll::Closed,
+                Poll::Pending => SendPoll::Pending,
+            },
+            // (2) No send event yet; poll the finish one-shot.
+            Poll::Pending => match Pin::new(&mut self.sctx.shutdown).poll(cx) {
+                Poll::Ready(Ok(ev)) => SendPoll::Event(ev),     // FinishComplete
+                // No finish yet; the mpsc waker is armed, so keep waiting.
+                Poll::Ready(Err(_canceled)) | Poll::Pending => SendPoll::Pending,
+            },
+        }
+    }
+}
+```
+
+**Routing `open` through the seam.** Stream *open/start* is outside the send
+reducer (it has no `SendState`); it goes through `OpenExec::submit_open_start`,
+whose production body is `Stream::open` + `Stream::start` and whose result — the
+`OpeningStream` carrying the start receiver — is finalized by `poll_open_inner`.
+This keeps all four native verbs (`open` / `send` / `shutdown(GRACEFUL)` /
+`shutdown(ABORT_SEND)`) behind the two seams whose test doubles count them,
+replacing the earlier "private call table or small test-only probe suffices"
+language.
+
+### Callback-safety: exact per-site outcomes
+
+Every site below becomes fallible/non-panicking. "Outcome" is what the callback
+does; none may unwind through FFI.
+
+| Site (`lib.rs`/`listener.rs`/`registration.rs`) | Current | Exact outcome |
+| --- | --- | --- |
+| `connection_callback` `Connected` sender (`lib.rs:113`) | `take().unwrap().send().unwrap()` | `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Ok(())); }` — a **duplicate** `Connected` (slot already `None`) is ignored; a **missing** receiver (send `Err`) is dropped silently |
+| `connection_callback` `ShutdownInitiatedByTransport { status, .. }` / `ShutdownInitiatedByPeer { error_code }` (new arms, currently `_ => {}` at `lib.rs:137`) | none (pending `connected` only resolved by `Connected` or dropped at `ShutdownComplete`) | resolve the pending connect one-shot as a failure **before** `ShutdownComplete`: `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Err(status)); }` for transport (carries a real `Status`), and `Err(Status::new(StatusCode::QUIC_STATUS_ABORTED))` for peer (only an `error_code`). Also publish the connection terminal via the first-writer helper. Absent/duplicate → no-op |
+| `connection_callback` `PeerStreamStarted` delivery (`lib.rs:120,124`) | `.expect("cannot send")` | on `unbounded_send` `Err` after taking native ownership: drop/close the owned `H3Stream` through Rust and **return `Ok`** from the callback (post-ownership delivery failure path), so MsQuic's `HandleClosed` branch does not double-close |
+| `connection_callback` `ShutdownComplete` shutdown one-shot (`lib.rs:133`) | already `let _ =`; but pending `connected` is dropped via `ctx.connected.take()` at `lib.rs:130` | keep the waiter send as a no-op-safe `let _ =`. For `connected`: if it is *still* pending here (neither `Connected` nor a `ShutdownInitiated*` arm resolved it — e.g. a bare local close), resolve it as failure instead of a bare drop: `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Err(Status::new(StatusCode::QUIC_STATUS_ABORTED))); }`, so `connect()`'s await returns `Err` deterministically rather than mapping a `Canceled` drop |
+| `stream_callback` `StartComplete` sender (`lib.rs:476-481`) | `take().unwrap()...expect` | `if let Some(tx) = ctx.start.take() { let _ = tx.send(result); }` — duplicate `StartComplete` ignored, dropped `OpeningStream` receiver ignored |
+| `stream_callback` `Receive` delivery (`lib.rs:505`) | `.expect("cannot send")` (split-receive drop panic) | this is one of the split-receive-drop panics the design removes. On a non-empty buffer, deliver `ReceiveEvent::Data(bytes)`: `if let Some(tx) = ctx.receive.as_ref() { if tx.unbounded_send(ReceiveEvent::Data(b)).is_err() { ctx.receive.take(); } }` — a **failed** delivery (frontend `H3RecvStream` dropped) drops the receiver sender so no further receive events are attempted, and **returns `Ok`**. FIN handling is gated on `flags.contains(ReceiveFlags::FIN)` (`msquic types.rs:544`): only when FIN is set does the callback publish the sticky `ReceiveEvent::Fin` (after any same-notification `Data`) and then `ctx.receive.take()`, so the reader observes the terminal rather than a bare channel close. An **empty, non-FIN** notification (zero-length buffer, `!flags.contains(FIN)`) is **non-terminal**: it publishes no event and does not take the sender, consistent with the approved rule ("Empty non-FIN receive notifications produce no event", ~line 675) |
+| `stream_callback` `SendComplete` (`lib.rs:487-492`) | `.expect("cannot send")` / `debug_assert!(false,"mem leak")` | reconstruct+drop `Box<SendBuffer>` **first** (buffer reclaimed even if receiver gone), then `if let Some(tx) = ctx.send.as_ref() { let _ = tx.unbounded_send(SendEvent::Complete{..}); }` |
+| `stream_callback` `SendShutdownComplete` (`lib.rs:518-519`) | `.expect` | `if let Some(tx) = ctx.shutdown.take() { let _ = tx.send(SendEvent::FinishComplete{graceful}); }` |
+| `listener_callback` `NewConnection` config validation (`listener.rs:65-69`) | `from_raw` → `set_configuration` → on `Err`, `drop(ConnHandle::new(inner, guard))` (closes) **and** `return Err(e)` — a **close-then-reject** that trips native `listener.c:676-680` `CXPLAT_FRE_ASSERTMSG(!HandleClosed, "App MUST not close and reject connection!")` | do `set_configuration` through the **borrowed** `ConnectionRef` *before* `from_raw`: `if let Err(e) = connection.set_configuration(config) { return Err(e); }` (the `ConnectionRef` derefs to `Connection`, `lib.rs:944`, and its `Drop` only nulls the handle — it never closes). Because ownership was **not** taken, the callback returns `Err` without any close, and native `listener.c` performs the single close via `QuicConnTransportError`. Only **after** `set_configuration` succeeds is ownership taken: `let inner = unsafe { Connection::from_raw(connection.as_raw()) };` then `Connection::attach(inner, guard)` |
+| `listener_callback` `NewConnection` delivery (`listener.rs:73`) | `.expect("cannot send")` | on `unbounded_send` `Err` **after** ownership was taken (`Connection::attach` owns the handle): drop the owned `Connection` (its `ConnHandle`/`ConnectionClose` runs — a single close) and **return `Ok`**, so the callback does not *also* return `Err` (which combined with the close would trip the same `listener.c:676-680` assert) |
+| `listener_callback` `StopComplete` end marker (`listener.rs:79`) | `.expect` | `let _ = tx.unbounded_send(None);` |
+| `listener_callback` shutdown lock+send (`listener.rs:81-85`) | `.lock().unwrap()` + `.expect` | poison-safe lock (`into_inner`), then `if let Some(tx) = lk.take() { let _ = tx.send(()); }` |
+| `Listener::shutdown` frontend (`listener.rs:144,148`) | `.lock().unwrap()` + `rx.await.expect` | poison-safe lock; on cancellation `rx.await` `Err` → treat as already-shutdown and **return** (no panic). Calling `shutdown` twice is a no-op because the receiver was taken |
+| `ConnectionShutdownWaiter::wait` (`lib.rs:217-221`) | `.expect("failed to wait...")` | `let _ = self.rx.await;` — a dropped sender (connection torn down without a clean `ShutdownComplete`) resolves the wait rather than panicking |
+| listener frontend `poll_accept` (`listener.rs:133`) | `unwrap_or(None)` | keep (already non-panicking) |
+| test-harness `sht_tx.send(()).unwrap()` (`listener.rs:310`) | `.unwrap()` | test-only; change to `let _ = sht_tx.send(());` for consistency, not FFI-reachable |
+
+Corrected `NewConnection` body (single close/accept outcome, guard preserved):
+
+```rust
+ListenerEvent::NewConnection { info: _, connection } => {
+    // `connection` is the borrowed ConnectionRef; the native handle already
+    // holds a registration rundown ref, so reserve our count now.
+    let guard = RundownGuard::new(state.clone());
+    // Validate/configure through the BORROWED ref, before taking ownership.
+    if let Err(e) = connection.set_configuration(config) {
+        // No from_raw, no close: native listener.c closes on our Err (single close).
+        drop(guard);            // release our reserved rundown count
+        return Err(e);
+    }
+    // set_configuration succeeded: NOW take ownership.
+    let inner = unsafe { msquic::Connection::from_raw(connection.as_raw()) };
+    let conn = crate::Connection::attach(inner, guard);
+    if let Some(tx) = ctx.conn.as_ref() {
+        if let Err(send_err) = tx.unbounded_send(Some(conn)) {
+            // Delivery failed after ownership: drop (single close) and return Ok,
+            // never Err — returning Err here while owned would trip the assert.
+            drop(send_err.into_inner());   // drops the owned Connection
+        }
+    }
+    Ok(())
+}
+```
+
+**`RundownState::waiters` poisonable locks (`registration.rs:62,142,159`).** The
+reviewer is correct that these remain FFI-reachable even after phase one, because
+`RundownGuard::drop` runs *inside* a native `*Close` call, and a native close can
+run while a listener/connection callback is dropping an undeliverable handle
+(the post-ownership-delivery-failure paths above call `drop(ConnHandle)` /
+`drop(Connection)` from within the callback, which triggers `ConnectionClose` →
+`RundownGuard::drop`). A poisoned `waiters` mutex would then unwind
+`self.state.waiters.lock().unwrap()` at `registration.rs:62` through FFI. All
+three sites must therefore recover poison:
+
+```rust
+// registration.rs:62  (RundownGuard::drop)
+let woken: Vec<Waker> = {
+    let mut w = self.state.waiters.lock().unwrap_or_else(PoisonError::into_inner);
+    w.map.drain().map(|(_, waker)| waker).collect()
+};
+// registration.rs:142 (WaitIdle::deregister) and :159 (WaitIdle::poll) identically:
+let mut w = this.state.waiters.lock().unwrap_or_else(PoisonError::into_inner);
+```
+
+`Waiters` holds only a `u64` and a `HashMap<u64, Waker>`; recovering the inner
+value after a poisoned poll is always safe (no torn invariant). This is added in
+implementation phase one alongside the other callback-safety edits, and a test
+poisons `waiters` (panic while holding it) then drops a `RundownGuard` to prove
+no unwind. `WaitIdle::poll`/`deregister` run on the frontend, not in a callback,
+but are converted too so a poisoned mutex never turns `wait_idle` into a panic.
+
+### Native-test mechanisms
+
+Both mechanisms below use only the **already-published `msquic 2.5.1-beta`
+public API** (the counting `SendExec` seam). They
+require **no binding change, no `[patch.crates.io]` entry, and no git-pinned
+revision** — resolving the earlier dev/test-only-vs-global-replacement
+contradiction by removing the dependency change entirely. The workspace
+`Cargo.toml` is unchanged; the only test-side additions are `#[cfg(test)]` code
+and the dev-dependencies listed in the release-gate section.
+
+**(a) Keeping a send observably outstanding.** A **real** loopback send cannot be
+held observably outstanding through the public API. Send buffering is on by default
+and cannot be disabled through the safe `Settings` builder
+(`set_SendBufferingEnabled` is enable-only, `settings.rs:133`), and MsQuic copies a
+*buffered* send into an internal buffer and immediately indicates `SEND_COMPLETE` —
+**before the submit call returns** and irrespective of peer flow-control
+backpressure (`msquic-2.5.1-beta/src/core/stream_send.c:478-534`:
+`QuicStreamSendBufferRequest` allocates an internal buffer, `CxPlatCopyMemory`s the
+payload, sets `QUIC_SEND_FLAG_BUFFERED`, and calls
+`QuicStreamIndicateEvent(SEND_COMPLETE)` synchronously). A small stream receive
+window therefore does **not** keep a buffered send outstanding. The design commits
+to a single, fully deterministic mechanism that depends on neither buffering nor
+timing:
+
+*The deterministic `CountingExec` seam (required, no native).* Drive the send-side
+seam with the `CountingExec` defined in the executor section. On an `Ok` script
+entry its `submit_send` `Box::into_raw`s the `SendBuffer` (incrementing
+`CountingHandle::allocs`) into a **retained** `client_context` slot (the shared
+`CountingHandle::client_ctx` queue) and does **not** drop the box — modelling native
+taking ownership. Because no native stream exists, no `SendComplete` ever fires on
+its own, so the slot holds **exactly one** outstanding pointer the instant the submit
+call returns and keeps it. The test then takes that retained pointer and feeds it
+back **through the production `stream_callback`, as a synthesized
+`StreamEvent::SendComplete { cancelled: false, client_context }`** — the exact
+reclamation path the binding invokes (`NonNull` check → reconstruct+drop
+`Box<SendBuffer>` → enqueue one `SendEvent::Complete`). The callback reclaims the box
+once and emits exactly one `Complete`; a second channel poll is empty, proving
+exactly-once. The outstanding→reclaimed transition is caused solely by the test's own
+step ordering; there is no loopback, no ACK, and no race. Test body:
+`accepted_send_reclaims_via_callback_exactly_once` in the executor section.
+
+*Why no loopback variant.* Because the public API cannot suppress the immediate
+buffered `SendComplete`, there is no public-API loopback configuration that keeps a
+real send outstanding at the moment the count is read. The previous "flow-control
+backpressure with a small recv window" variant is **withdrawn**: it left buffering
+enabled and would complete synchronously. The loopback conformance suite still
+covers end-to-end reclamation *ordering* (an accepted send yields exactly one
+`SendComplete`, box reclaimed once), but the *observably-outstanding* guarantee is
+proven only by the seam test.
+
+*Expected counts.* The seam test proves, in order: (1) after the submit call
+returns, `allocs` reads **1** and `client_ctx` holds exactly **one** outstanding
+pointer (one `SendBuffer` outstanding; in-exec `reclaims` still **0**); (2) feeding
+the retained `client_context` through `stream_callback` drives exactly **one**
+callback reclamation and **one** `SendEvent::Complete`; (3) a second channel poll is
+empty afterward (exactly once). If step (1) cannot read one outstanding pointer, the
+test **fails** with a setup-specific message — it is never skipped or `#[ignore]`d.
+
+**(b) Controlled immediate `Stream::send` failure.** The earlier "single
+`BufferRef` reporting `Length = u32::MAX` over a small backing allocation" idea is
+**removed**: it violates the `BufferRef` validity contract (the pointer must be
+valid for the reported length) and is UB. The async `ABORT_SEND`-then-send race is
+**removed** too, because `Stream::shutdown(ABORT_SEND)` is queued asynchronously,
+so an immediately following `Stream::send` can still succeed. The design commits to
+one safe mechanism per half:
+
+*Reducer/ownership half (required, deterministic — no native).* Script the
+`CountingExec` to return `Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER))`
+from `submit_send`. Mirroring `StreamExecutor`, `submit_send` still boxes the buffer
+(`allocs` → **1**) and then, on the scripted `Err`, reclaims it in place via
+`Box::from_raw` + drop (`reclaims` → **1**) before returning, so no pointer is ever
+retained (`client_ctx` stays empty) and **zero** `SendComplete` callbacks fire
+(native took no ownership, so no `SendEvent::Complete` is ever enqueued). `send_data`
+surfaces the error and the reducer records `SendSubmitted(Err)` with the buffer
+already reclaimed. Test body: `immediate_send_failure_reclaims_without_completion`
+in the executor section (`allocs == 1`, `reclaims == 1`, `client_ctx` empty, and the
+send-event channel yields nothing).
+
+*Loopback half (deterministic via synchronized shutdown, not a race).* Fully shut
+the connection down and **await `ShutdownComplete`** on the connection's shutdown
+one-shot, *then* call `Stream::send` on the now-dead stream. `MsQuicStreamSend`
+rejects synchronously with `QUIC_STATUS_INVALID_STATE`/`QUIC_STATUS_ABORTED`
+(connection gone), takes no ownership, and produces no `SendComplete`. Because the
+send happens strictly after the observed `ShutdownComplete`, there is no timing
+window. With the production `StreamExecutor`, `submit_send` `Box::into_raw`s the
+box, `Stream::send` returns `Err`, and `submit_send` reconstructs+drops it before
+returning: net reclamation **0** at return, **zero** `SendComplete`.
+
+Exact counts summary: accepted send → `allocs` **1**, exactly **one** `SendComplete`
+reclaiming the box once via `stream_callback`; rejected send (either half) → `allocs`
+**1**, **zero** `SendComplete`, box reclaimed in place by the immediate-failure path
+(`reclaims` **1**) within the call.
+
+### Release-gate resolution
+
+**Supported native matrix and its provenance/command coupling.** *Superseded by
+the MF-3 narrative resolution above ("MF-3 — a stronger native-version attestation
+gate"); that resolution is authoritative.* Provenance is selected by the committed
+CI matrix dimension `provenance: [native-find, native-src]`, where `native-find`
+(`= ["msquic/find"]`) and `native-src` (`= ["msquic/src"]`) are **msquic-h3**
+features and **every** build/test step runs
+`--no-default-features --features ${{ matrix.provenance }}`, so exactly one
+provenance is chosen by committed config rather than by an uncommitted
+`[dev-dependencies]`/`Cargo.toml` edit. Both provenance rows pin the **same** exact
+native version, **2.5.1** (major.minor.patch), so the `native_version_preflight`
+expected value is a single constant `[2, 5, 1]` for both. The runtime preflight
+below queries `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (`= 16777220`, `0x01000004`,
+`ffi/linux_bindings.rs:169`) into `[u32; 4]` (`[major, minor, patch, build]`) and
+**fails** the conformance job if the loaded library's first three components differ
+from the pin (the build-id component is ignored):
+
+```rust
+// tests/native_version_preflight.rs — fails the conformance job on version drift.
+const EXPECTED_MSQUIC_VERSION: [u32; 3] = [2, 5, 1];   // major, minor, patch (matrix pin)
+
+#[test]
+fn native_version_preflight() {
+    // Open a registration so the library is loaded and Api::ffi_ref() is ready.
+    let _reg = msquic::Registration::new(&msquic::RegistrationConfig::new())
+        .expect("open msquic registration");
+    // Global param; null handle. Buffer is [major, minor, patch, build].
+    let v: [u32; 4] = unsafe {
+        msquic::Api::get_param_auto::<[u32; 4]>(
+            std::ptr::null_mut(),
+            msquic::ffi::QUIC_PARAM_GLOBAL_LIBRARY_VERSION,   // 16777220
+        )
+    }
+    .expect("query GLOBAL_LIBRARY_VERSION");
+    assert_eq!(
+        [v[0], v[1], v[2]],
+        EXPECTED_MSQUIC_VERSION,
+        "linked libmsquic {:?} != pinned matrix version {:?} (build id v[3]={} ignored)",
+        v, EXPECTED_MSQUIC_VERSION, v[3],
+    );
+}
+```
+
+Test commands — the exact per-row conformance targets are the MF-3 commands above,
+each carrying the committed provenance feature so exactly one clean-checkout row is
+selected (the msquic native library is pulled in transitively by that feature, so no
+separate `--features find` is needed):
+
+```sh
+# conformance jobs (per matrix row); provenance = committed native-find/native-src
+cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} accepted_send_reclaims_via_callback_exactly_once -- --exact
+cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} immediate_send_failure_reclaims_without_completion -- --exact
+cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} native_version_preflight -- --exact
+```
+
+Record OS, arch, native version, provenance (which committed `native-find`/
+`native-src` feature), and the exact command in `docs/Development.md` and link it from
+the teardown section; until that table exists the release stays gated (documentation
+gate).
+
+**`MAX_ADAPTER_SEND` benchmark harness and acceptance criterion.** The retain/
+adjust decision is a measurement. `MAX_ADAPTER_SEND = 16 MiB` is **PROVISIONAL**
+per the MF-5/T2 resolution above and is **not** ratified from the single-copy
+benchmark alone; the harness below is defined concretely, but ratification also
+requires the multi-stream measurements the MF-5/T2 decision table demands:
+
+- Harness split across TWO targets that share the ONE copy helper: (a) a Criterion
+  benchmark (`benches/send_copy.rs`) over the pure copy path
+  `bench_support::copy_into_send_buffer(&src[..])` (the gated public entry point;
+  `&[u8]` is a `Buf`, so it runs the same `copy_to_bytes` allocation production runs
+  on `&mut WriteBuf<B>`), plus a loopback throughput bench that sends N frames of
+  each size to a local echo; and (b) the deterministic peak-resident **`#[test]`**
+  below, an in-crate test with private access to `buffer::copy_into_send_buffer` (no
+  bench feature needed).
+- Payload sizes: header-only (~32 B), small body (1 KiB), medium (64 KiB), large
+  contiguous body at 1 MiB, 8 MiB, and 16 MiB (`MAX_ADAPTER_SEND`).
+- Reported metrics, per size: wall-clock per copy (source buffer prebuilt once
+  **outside** the timed window, so only `copy_into_send_buffer(&src[..])` is timed),
+  throughput (MiB/s) — **informational/relative**, no hard timing assertion in the
+  bench — and **peak resident bytes** attributable to one in-flight send, asserted
+  by the in-crate `#[test]` via `measure_peak_resident` below (a global-allocator
+  counter reset immediately before the single copy and read immediately after, so
+  the harness and all earlier allocations are excluded), since the owned-copy design
+  transiently doubles peak payload memory.
+- Acceptance criteria (all **necessary**, and NOT sufficient on their own to
+  ratify 16 MiB). (1) *Copy-time (informational)*: reported by the Criterion bench
+  relative to a same-run baseline. With the source prebuilt **once outside** the
+  timed window, the **median** of 64 timed copies is tracked against the ~10 ms
+  reference target, but that number is **advisory only** and the bench carries **no
+  hard fail** until a pinned/isolated runner exists (see MF-4 point 3). (2)
+  *Peak-resident gate (BLOCKING, in-crate `#[test]`)*: measured with source and
+  destination deliberately coexisting so the transient doubling is visible, the
+  `peak_delta` must satisfy the computable bound `peak_delta <= 2 * payload + 1 MiB`
+  (no unexpected extra copy beyond the source+destination doubling); this assertion
+  lives in the crate's own test binary, not in Criterion, so correctness never
+  depends on bench timing. **Required before the cap is ratified (MF-5/T2 gate):**
+  the multi-stream measurements the decision table demands — concurrent large-send
+  *scheduler latency* on the poll thread and *aggregate retained bytes* across N
+  concurrent streams — must also be recorded, because the per-operation cap bounds
+  neither. If the peak-resident gate fails, the copy time is unacceptable on a
+  pinned runner, or the multi-stream aggregate is unacceptable, either lower
+  `MAX_ADAPTER_SEND` to the largest size that meets all gates or open the deferred
+  internal-chunking + per-connection byte-budget design. The chosen value and the
+  measured tables are recorded in `docs/Development.md`. Until the MF-5/T2 table is
+  filled and a value chosen, the 16 MiB cap and the 10 ms budget remain
+  **provisional**, not a committed concrete default.
+
+Concrete Criterion / test-allocator Cargo wiring (added to the package
+`Cargo.toml`; the peak-resident metric needs a counting global allocator, so the
+crate's test binary installs one — under `#[cfg(test)]` — rather than pulling
+`stats_alloc`):
+
+```toml
+[features]
+# Committed bench feature: gates the public `bench_support::copy_into_send_buffer`
+# re-export so the separate Criterion crate can reach the copy path.
+bench-internals = []
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+# Backend-implementer feature: exposes h3's internal `Frame`/`WriteBuf` builders so
+# the CountingExec seam tests can construct a valid non-empty `WriteBuf<Bytes>`
+# (`WriteBuf::<Bytes>::from(Frame::Data(..))`). Dev-only; not enabled for consumers.
+h3 = { version = "0.0.8", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
+
+[[bench]]
+name = "send_copy"
+harness = false                          # Criterion provides its own harness
+required-features = ["bench-internals"]  # bench needs the gated public entry point
+```
+
+```rust
+// benches/send_copy.rs — INFORMATIONAL copy-time measurement ONLY (no hard timing
+// assertion; the BLOCKING peak-resident gate is the in-crate `#[test]` below).
+fn bench_send_copy(c: &mut criterion::Criterion) {
+    use msquic_h3::bench_support::copy_into_send_buffer;   // gated public entry point
+
+    // The source is built ONCE, OUTSIDE the timed region, so Criterion times ONLY
+    // the owned copy via the public `copy_into_send_buffer(&src[..])` entry point.
+    // `&[u8]` is a `Buf`, so this drives the SAME `src.copy_to_bytes(remaining)`
+    // allocation production runs on `&mut WriteBuf<B>` (for a non-`Bytes`-backed
+    // `B` that copy allocates a fresh buffer, which this models exactly). Criterion
+    // reports per-size copy time relative to a same-run baseline; there is NO
+    // absolute 10 ms fail here — that number stays advisory until a pinned runner
+    // exists (MF-4 point 3).
+    for &size in &[32usize, 1 << 10, 64 << 10, 1 << 20, 8 << 20, 16 << 20] {
+        let src: Vec<u8> = vec![0u8; size];                          // prebuilt, NOT timed
+        c.bench_function(&format!("copy_{size}"), |b| {
+            b.iter(|| {
+                let dst = copy_into_send_buffer(&src[..]);           // TIMED: copy only
+                criterion::black_box(&dst);
+            });
+        });
+    }
+}
+
+criterion::criterion_group!(benches, bench_send_copy);
+criterion::criterion_main!(benches);
+```
+
+The deterministic peak-resident bound is the BLOCKING gate and lives in the crate's
+own test binary (private access to `copy_into_send_buffer`, no bench feature needed),
+so correctness never depends on Criterion timing. A counting global allocator is
+installed **only** for the test build (`#[cfg(test)]`), never for production:
+
+```rust
+// msquic-h3/src/buffer.rs — counting allocator + peak-resident gate, test-only.
+#[cfg(test)]
+use std::alloc::{GlobalAlloc, Layout, System};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+#[cfg(test)]
+struct Counting;
+#[cfg(test)]
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(l) };
+        if !p.is_null() {
+            let now = LIVE.fetch_add(l.size(), Ordering::Relaxed) + l.size();
+            PEAK.fetch_max(now, Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        LIVE.fetch_sub(l.size(), Ordering::Relaxed);
+        unsafe { System.dealloc(p, l) };
+    }
+}
+#[cfg(test)]
+#[global_allocator]
+static A: Counting = Counting;
+
+/// Peak resident bytes attributable to ONE measured copy: reset immediately
+/// before, read immediately after. `baseline` is the live bytes just before the
+/// op; seeding PEAK to it excludes every earlier allocation (payload setup outside
+/// the closure, background statics). The op's result is returned and held until
+/// PEAK is read, so the destination buffer is live at the peak. The op must run
+/// with no other thread allocating — the test runs it on one thread, so the only
+/// allocations between reset and read are the op's own.
+#[cfg(test)]
+fn measure_peak_resident<R>(op: impl FnOnce() -> R) -> (R, usize) {
+    let baseline = LIVE.load(Ordering::SeqCst);
+    PEAK.store(baseline, Ordering::SeqCst);       // reset immediately before
+    let out = op();                               // the single measured copy path
+    let peak = PEAK.load(Ordering::SeqCst);       // read immediately after
+    (out, peak.saturating_sub(baseline))          // attributable delta, baseline excluded
+}
+
+// Blocking, deterministic; runs under ordinary `cargo test` with private access to
+// the same `copy_into_send_buffer` production uses.
+#[test]
+fn send_copy_peak_resident_bound() {
+    let payload = 16usize << 20;
+    // Source and destination MUST coexist to capture the design's transient
+    // doubling, so both are allocated inside the measured op.
+    let (held, peak_delta) = measure_peak_resident(|| {
+        let src: Vec<u8> = vec![0u8; payload];                       // source allocation
+        let dst = copy_into_send_buffer(&src[..]);                   // owned copy (private path)
+        (src, dst)                                                   // both live at read
+    });
+    std::hint::black_box(&held);
+    assert!(
+        peak_delta <= 2 * payload + (1 << 20),
+        "16 MiB per-send peak {peak_delta} exceeds 2*payload + 1 MiB ({})",
+        2 * payload + (1 << 20),
+    );
+}
+```
 
 ## Implementation order
 
@@ -1456,10 +4061,22 @@ Required loopback tests:
    seam, and test immediate failure plus callback reclamation.
 7. Integrate the send reducer, `reset`, and idempotent finish; run reducer,
    executor, and synchronous-callback tests after each slice.
-8. Make deterministic outstanding-send setup possible (per the teardown-test
-   mechanism decision), then add loopback conformance tests.
+8. Add the deterministic `CountingExec` send-seam tests (outstanding-send
+   retain/reclaim and immediate-failure reclaim), then add the loopback
+   accepted-send reclamation-ordering conformance test. Close-time inline-drain
+   compatibility is covered by native-source review plus the binding's uniform
+   `close_inner` close contract, not by a drop-triggered teardown test (none
+   exists).
 9. Add runtime native-version verification, the supported matrix, and send-copy
    performance/peak-memory results to `Development.md`.
+10. **Release, compatibility, and scaffold cleanup gate (resolves MF-6 and the
+    MF-7/T5 expiry condition).** Before publishing, complete the compatibility
+    and rollback checklist in the "MF-6 — release, versioning, migration, and
+    rollback" resolution below (crate-version decision, `CHANGELOG.md` entry,
+    migration notes), and execute the appendix cleanup checklist in the
+    scaffold banner (delete/archive the ~1,800-line appendix, promote any
+    depended-on invariant into the narrative). The release stays gated until
+    both are done.
 
 This order fixes callback safety and the error vocabulary first, then moves each
 callback path onto it while keeping changes reviewable and bisectable.

--- a/docs/error-propagation.md
+++ b/docs/error-propagation.md
@@ -136,12 +136,24 @@ legitimately have been dropped. Examples include:
 - an h3 receive half is dropped before another receive callback;
 - an h3 send half is dropped before `SendComplete`;
 - connection shutdown cancels a pending stream start;
-- a finish waiter is dropped before `SendShutdownComplete`.
+- a finish waiter is dropped before `SendShutdownComplete`;
+- the listener accept receiver or shutdown waiter is dropped before
+  [`listener_callback`](../msquic-h3/src/listener.rs) delivers.
 
-An FFI callback must not panic for these lifecycle races. Sending to a closed
-channel should be handled explicitly. There is an additional ownership
-constraint for `SendComplete`: the submitted allocation must be reclaimed even
-if its receiver is gone.
+An FFI callback must not panic for these lifecycle races. This audit covers all
+three callback surfaces — connection, stream, **and listener**. The listener
+path is currently unsafe in the same way: `listener.rs` uses
+`unbounded_send(...).expect("cannot send")` for new connections and end-of-accept,
+`tx.send(()).expect("cannot send")` for the shutdown waiter, and
+`ctx.shutdown.lock().unwrap()` (panics on a poisoned mutex). All of these must
+become fallible, non-panicking sends and poison-recovering locks
+(`PoisonError::into_inner`), because the design already relies on the binding's
+close model for `Listener` as well. Ordinary sender/receiver loss must never
+unwind through FFI, and non-callback waiters (`ConnectionShutdownWaiter::wait`,
+listener frontend waiters) must likewise not turn dropped-sender into a panic.
+Sending to a closed channel should be handled explicitly. There is an additional
+ownership constraint for `SendComplete`: the submitted allocation must be
+reclaimed even if its receiver is gone.
 
 Do not retain the current generic erasure. It would require at least
 `B: Send + 'static`, and [`H3Buff::new`](../msquic-h3/src/buffer.rs) assumes
@@ -186,12 +198,19 @@ both in the box. Moving `Bytes` does not move its referenced byte storage, so
 the pointer remains stable. `SendBuffer` is therefore self-referential:
 `buffers[0]` points into the heap storage owned by `bytes`, not into the struct,
 and stays valid for as long as the box lives. This invariant is load-bearing and
-warrants an explicit safety comment at the construction site. Pass
-`Box::into_raw(send_buffer)` as `client_context`. On `SendComplete`, the callback
-reconstructs `Box<SendBuffer>` and drops it immediately before enqueueing the
-completion event. MsQuic documents that `SendComplete` ends its use of the
-submitted buffers. On an immediate `Stream::send` error, `send_data`
-reconstructs and drops the same box.
+warrants an explicit safety comment at the construction site. Put construction
+behind one function taking an already-validated non-zero `u32` length (the
+validation from finding 5's precedence table has already rejected empty and
+oversized), so `BufferRef::from(&bytes[..])` — whose binding impl casts `usize`
+length to `u32` — never truncates. The `bytes` field exists only to own storage;
+name it `_bytes` (or read it in a small invariant helper) so it survives the
+repository's `-D warnings` policy as an otherwise-unread private field. A test
+asserts the `BufferRef` pointer and length still match after the completed
+`SendBuffer` is moved into its `Box`. Pass `Box::into_raw(send_buffer)` as
+`client_context`. On `SendComplete`, the callback reconstructs `Box<SendBuffer>`
+and drops it immediately before enqueueing the completion event. MsQuic
+documents that `SendComplete` ends its use of the submitted buffers. On an
+immediate `Stream::send` error, `send_data` reconstructs and drops the same box.
 
 This deliberately trades zero-copy sends for a sound implementation of the
 existing `B: Buf` API. It adds no `Send` or `'static` bound to h3's generic
@@ -201,12 +220,21 @@ buffer type. The cost is one full wire-buffer materialization per non-empty
 `bytes::Buf` implementation runs — `BytesMut::with_capacity(len)` then a copy of
 every chunk (the frame header array plus the payload), then `freeze()`. This is
 an allocation and byte copy even when the inner payload `B` is a single
-contiguous `Bytes`; it is not a refcount split. This remains a reasonable
-correctness tradeoff for a sound `B: Buf` implementation, but it should be
-measured rather than assumed cheap. The allocation crossing FFI contains only
-owned `Bytes` plus pointer metadata, and the callback knows its concrete
-destructor. The old generic `H3Buff` can be deleted after its remaining uses are
-removed.
+contiguous `Bytes`; it is not a refcount split, and it doubles peak payload
+memory. Because the design accepts requests up to the native `u32::MAX` limit, a
+near-4 GiB send attempts a second near-4 GiB allocation before MsQuic is called,
+and a Rust allocation failure there may **abort** rather than produce
+`OversizedSend`/`StreamErrorIncoming`.
+
+This is a sound choice (it does not justify retaining the unsound generic
+`H3Buff` erasure), but its cost is a **release gate**, not optional: add a
+benchmark for header-only, small-body, and large contiguous-body sends, document
+peak-memory behavior, and make an explicit decision on the size ceiling — accept
+the native `u32::MAX` limit as-is, impose a lower adapter limit that rejects with
+`OversizedSend` before allocating, or later add internal chunking. The
+allocation crossing FFI contains only owned `Bytes` plus pointer metadata, and
+the callback knows its concrete destructor. The old generic `H3Buff` can be
+deleted after its remaining uses are removed.
 
 ### 6. Pending stream open can panic on connection close (medium)
 
@@ -277,46 +305,73 @@ streams, replace the temporary `H3Stream` in `poll_open_inner` with an
 poll validates the ID before constructing `H3Stream` with concrete ID fields in
 both halves. A local-stream ID that fails h3 validation is an adapter/internal
 error surfaced as nested `ConnectionErrorIncoming::InternalError`, not
-`Unknown(Status)`. For accepted streams, `H3Stream::attach` performs two
-distinct fallible steps whose error types differ, so it cannot funnel both into
-`Result<H3Stream, Status>`:
+`Unknown(Status)`.
 
-1. `Stream::get_stream_id() -> Result<u64, Status>` — a native failure keeps its
-   `Status` and returns it from `connection_callback`.
+For accepted streams, ownership of the native handle is the load-bearing detail.
+`PEER_STREAM_STARTED` delivers a `StreamRef` (a borrow); the current adapter
+takes ownership eagerly with `Stream::from_raw(stream.as_raw())`. **Validate
+before taking ownership**, because a native close through Rust *and* a failed
+callback return would double-close the same handle: MsQuic's `stream_set.c` runs
+`if (QUIC_FAILED(Status)) { QuicStreamClose(Stream); Stream = NULL; }` on the
+failure path (before its `HandleClosed` check), so dropping an owning `Stream`
+and *also* returning failure asks MsQuic to close a handle the app already
+closed — a use-after-free. The two fallible steps are therefore performed
+against the **borrowed** handle:
+
+1. `get_stream_id` against the borrowed `StreamRef`/raw handle
+   (`Result<u64, Status>`) — do not create an owning `Stream` merely to query.
+   If the binding lacks a borrowed query, add one or use the public parameter
+   API on the raw handle.
 2. `u64::try_into::<h3::quic::StreamId>() -> Result<_, h3::quic::InvalidStreamId>`
-   — MsQuic IDs are 62-bit so this branch is impossible by contract, but it must
-   still be handled: publish
-   `ConnectionTerminal::Internal("accepted stream ID is invalid")` and return
-   `Status::new(QUIC_STATUS_INTERNAL_ERROR)` from the callback.
+   — MsQuic IDs are 62-bit so this is impossible by contract, but still handled.
 
-Remove the on-demand `get_id` helper. In both accepted cases below, failure
-drops the owned native stream and publishes a connection terminal (first-writer
-preserved), so the failure is h3-visible rather than only a native status.
+Ownership rule:
 
-Returning a failure status from `connection_callback` does **not** tear down the
-connection. In MsQuic v2.5.1 the `PEER_STREAM_STARTED` handler
-(`stream_set.c`) checks the callback status and, on failure, calls
-`QuicStreamClose(Stream)` to reject and close **that individual native stream**
-as "not accepted" — the connection is untouched. The connection-level result is
-produced by the published terminal instead: a later `poll_accept_*` observes
-`ConnectionErrorIncoming::InternalError`, and h3's connection-error handling
-closes the QUIC connection with `H3_INTERNAL_ERROR`. Accepted-stream attachment
-failure therefore does both, using the same first-writer rules as every other
-connection terminal:
+- **Pre-ownership failure** (either step fails before `Stream::from_raw`):
+  publish the connection terminal, then return the failure `Status` from the
+  callback and take no Rust ownership. MsQuic remains the sole closer and closes
+  the rejected stream itself.
+- **Success**: only now call `Stream::from_raw`, attach the callback, construct
+  `H3Stream` with concrete ID fields in both halves, and enqueue it.
+- **Post-ownership delivery failure** (Rust owns the stream but the incoming
+  channel send fails): drop/close the stream through Rust and return **success**
+  from the callback, so MsQuic's `HandleClosed` branch recognizes the immediate
+  application close and does not close again.
+
+Remove the on-demand `get_id` helper. On the pre-ownership failure path the
+adapter publishes a connection terminal so the failure is h3-visible rather than
+only a native status. Returning a failure status from `connection_callback` does
+**not** tear down the connection — `stream_set.c` only closes the individual
+rejected stream. The connection-level result comes from the published terminal:
+a later `poll_accept_*` observes `ConnectionErrorIncoming::InternalError`, and
+h3's connection-error handling closes the QUIC connection with
+`H3_INTERNAL_ERROR`. The publication uses the same first-writer rules as every
+other connection terminal:
 
 1. Publish the winning h3 connection terminal and wake both acceptors: if
    `ConnectionState` already holds a terminal reason, that winner is preserved;
    otherwise publish `ConnectionTerminal::Internal` — with
    `"accepted stream ID query failed"` for a native `get_stream_id` error, or
    `"accepted stream ID is invalid"` for an h3 `InvalidStreamId`. Do not hold the
-   connection-state lock during the enqueue or the native-stream drop.
+   connection-state lock during the enqueue.
 2. Return failure from `PEER_STREAM_STARTED` (the preserved native `Status`, or
-   `QUIC_STATUS_INTERNAL_ERROR` for an invalid h3 ID) so MsQuic rejects and
-   closes the individual native stream.
+   `QUIC_STATUS_INTERNAL_ERROR` for an invalid h3 ID) so MsQuic closes the
+   rejected stream — the adapter never took Rust ownership, so it never closes.
 3. h3 observes `ConnectionTerminal::Internal` via the accept channel and invokes
    connection close with `H3_INTERNAL_ERROR`.
 
 The rejected stream is never handed to h3.
+
+**Queue policy for an internal terminal.** Unlike a normal connection shutdown,
+an accepted-stream attachment failure is a *fail-fast* adapter-internal error:
+`ConnectionTerminal::Internal` must not be drained behind streams still queued
+in the incoming channels, because the adapter has declared its own connection
+state invalid and should not keep handing new streams to h3. `poll_accept_recv`
+and `poll_accept_bidi` therefore check the sticky connection terminal **before**
+dequeuing another stream once an `Internal` terminal is published. Normal
+peer/transport shutdown keeps the drain-then-terminal ordering (already queued
+streams are delivered first); only the internal-failure class is fail-fast. A
+test asserts each policy.
 
 ## Reference adapter behavior
 
@@ -655,11 +710,17 @@ applies.
 
 All application codes passed to MsQuic use one helper that clamps `u64` to an
 adapter constant `MAX_QUIC_VARINT: u64 = (1 << 62) - 1` without panicking.
-(`msquic::u62` is only a `u64` type alias and has no narrowed `MAX`.) h3's own
-codes are already in range, but this prevents arbitrary trait callers from
-violating the native precondition in `reset` or `stop_sending`.
-Connection close receives `h3::error::Code` and is already valid. Incoming
-MsQuic codes are `u62` and require no normalization.
+(`msquic::u62` is only a `u64` type alias and has no narrowed `MAX`.) Every
+outgoing application code is normalized at the FFI boundary regardless of its
+Rust wrapper type. This includes `OpenStreams::close`: `h3::error::Code`'s
+`From<u64>` performs **no** range check (`Code { code }`) and `value()` returns
+the raw `u64`, so a caller can pass `Code::from(u64::MAX)` and violate the same
+native precondition guarded for `reset` and `stop_sending`. `close` therefore
+applies `clamp_application_code(code.value())` before
+`ConnectionShutdownFlags`/`Connection::shutdown`. Boundary tests cover
+`(1<<62)-1` (accepted unchanged) and `1<<62` (clamped) for connection close,
+`reset`, and `stop_sending`. Incoming MsQuic codes are `u62` and require no
+normalization.
 
 ### Native stream teardown on drop
 
@@ -789,13 +850,22 @@ a system library is not silently assumed supported:
 - A conformance failure is reported as an unsupported native environment, not as
   an adapter test flake. The exact matrix and test command live in the
   development documentation once the tests exist.
+- **Verify the loaded library, not the requested package.** The current CI
+  installs mismatched native builds (Linux apt package `2.5.8`, Windows vcpkg
+  baseline) while the Rust crate is `2.5.1-beta`, and a package-manager command
+  does not prove which shared library the test process actually loads at
+  runtime. Make native version/platform an explicit CI matrix dimension, and
+  before the conformance tests query MsQuic's runtime version and **fail** if it
+  differs from the matrix entry. Keep "compile compatibility" and "conformance
+  support" as separate claims.
 
 **Release gate.** Before release, record the exact supported native
-versions/platforms and the teardown test command in
-[`docs/Development.md`](Development.md) and link that matrix from this teardown
-section. Until that list exists, "supported" has no auditable configuration and
-the release is gated (this is a documentation gate, not an additional
-state-machine change).
+versions/platforms, provenance, and the teardown test command in
+[`docs/Development.md`](Development.md) — at least OS, architecture, Rust binding
+version, native library version, provenance, and command — and link that matrix
+from this teardown section. Until that list exists, "supported" has no auditable
+configuration and the release is gated (this is a documentation gate, not an
+additional state-machine change).
 
 Implement send transitions as a production reducer, not duplicated branches.
 There is exactly one authoritative sticky terminal slot,
@@ -911,30 +981,43 @@ boundary for observing and publishing it:
 - The caller loads the current `StreamState::send_terminal` winner (poison-safe)
   and passes it as the `terminal` field of the input. Terminal precedence is
   **input-specific, not global** — a shared winner must never pre-empt the
-  bookkeeping a `*Submitted` result owes its reservation. The reducer evaluates
-  each input in four ordered groups:
+  bookkeeping a `*Submitted` result owes its reservation. `transition` is one
+  normative `match` in this exact arm order (the tables below derive from it,
+  and reducer tests are table-driven so prose, rows, and code cannot diverge):
 
   1. **Submitted-result bookkeeping first.** `SendSubmitted`,
      `GracefulSubmitted`, and `ResetSubmitted` always validate and clear their
      matching reservation (or commit success) *before* any terminal is
      considered. Only then is a raced shared winner applied to the frontend
-     result. This prevents a stale `finish_submitting`/`reset_submitting` and
-     lets infallible `reset` end in `NoOp` even when a terminal raced in.
+     result. This prevents a stale `send_submitting`/`finish_submitting`/
+     `reset_submitting` and lets infallible `reset` end in `NoOp` even when a
+     terminal raced in. `GracefulSubmitted(Ok)` always commits
+     (`finish_started = true`) and emits `RepollFinish`; the subsequent repoll
+     reloads the shared winner, so channel order (not this arm) decides between a
+     synchronously-queued graceful completion and a terminal wake.
   2. **Absorbing success next.** `finish_complete` makes `PollFinish` return
      `ReturnFinished` before considering later terminals.
   3. **Queued successful finish next.** A
      `PollFinish(Event(FinishComplete { graceful: true }))` while `finish_started`
      sets `finish_complete` and returns `ReturnFinished` **before** method
-     terminal handling. Channel order is the tiebreaker: if the successful finish
-     event was queued ahead of a later `TerminalWake`, finish is absorbing and
-     wins; a terminal queued first is processed first and wins. This exception
-     applies only to graceful finish — never to a terminal wake or a non-graceful
-     finish.
+     terminal handling — it is the *sole* event allowed ahead of method-terminal
+     handling. Channel order is the tiebreaker: if the successful finish event
+     was queued ahead of a later `TerminalWake`, finish is absorbing and wins; a
+     terminal queued first is processed first and wins. This exception applies
+     only to graceful finish — never to a terminal wake or a non-graceful finish.
   4. **Method-specific terminal handling.** A current shared winner produces an
      error for `send_data`/`poll_ready`/`poll_finish`, but `NoOp` for `reset`
-     (after clearing any reset reservation).
+     (after clearing any reset reservation). The `poll_ready`-after-finish misuse
+     `Internal` is **non-sticky** — the `finish_started` state reproduces it on
+     every call, so it is returned directly and not published to the shared slot;
+     every other `SendTerminal::Internal` in the reducer *is* published through
+     the authoritative slot.
   5. **Event rows last.** The channel poll outcome is processed only when no
      earlier group returns.
+
+  In the tables, shorthand like `winner or Failed(status)` means the executor
+  runs first-writer publication with the concrete local candidate shown; the
+  returned winner (possibly a raced callback terminal) is what surfaces.
 - `send_data` is inside the machine and classifies its payload before allocating
   any bytes. `SendRequested { payload, terminal }` applies this precedence, and
   no owned bytes are materialized before the final row: (1) a shared `terminal`
@@ -1084,6 +1167,29 @@ Recommended structural changes:
 Most conversion and channel behavior can be tested without a network by
 constructing callback events and polling the corresponding receiver.
 
+### Test seams
+
+Some required cases are not naturally producible from a live valid peer/stream
+and need explicit, tightly-scoped seams (production ownership must remain
+obvious):
+
+- **Accepted-stream ID validation.** A live MsQuic peer stream always has a
+  valid 62-bit ID, so the `get_stream_id`-failure and `InvalidStreamId` branches
+  cannot occur naturally. Provide a pure `validate_stream_id(u64) -> Result<StreamId, _>`
+  helper (unit-tested directly) and a test-only failpoint around the accepted-ID
+  query that fails exactly one attachment after the native callback begins. The
+  loopback test asserts all three outcomes: the rejected stream is never
+  enqueued, both acceptors observe the winning connection terminal, and the peer
+  observes `H3_INTERNAL_ERROR` after h3 handles it.
+- **Command executor.** The pure reducer proves which `SendCommand` is emitted,
+  but not that the executor calls MsQuic exactly once (or not at all). Route
+  native `open`/`send`/`shutdown(GRACEFUL)`/`shutdown(ABORT_*)` through one
+  narrow executor boundary whose test implementation counts these calls. This
+  keeps the reducer native-free and lets "no native call" (terminal / oversized
+  / misuse) and "exactly once" (graceful, reset) claims be asserted at the
+  reducer-to-executor wiring without a full loopback. A private call table or
+  small test-only probe suffices; the native stream itself need not be generic.
+
 Required unit tests:
 
 - peer application close preserves its non-zero code for both accept methods;
@@ -1182,8 +1288,11 @@ Required unit tests:
   shutdown;
 - immediate graceful-shutdown failure is sticky and is not retried;
 - successful finish stays successful after a later connection shutdown;
-- out-of-range reset and stop-sending codes are clamped to the QUIC 62-bit
-  maximum before FFI;
+- out-of-range application codes are clamped to the QUIC 62-bit maximum before
+  FFI for connection close, `reset`, and `stop_sending`: `(1<<62)-1` passes
+  unchanged and `1<<62` is clamped;
+- listener, connection, and stream callbacks do not panic when a receiver or
+  waiter is already dropped, and recover from a poisoned adapter mutex;
 
 Required loopback tests:
 
@@ -1201,35 +1310,56 @@ Required loopback tests:
   assumption the ownership model relies on, against whichever `libmsquic` is
   linked. The test must be made deterministically outstanding, because with
   MsQuic send buffering the `SendComplete` usually fires inline during
-  `Stream::send`: configure `Settings::set_SendBufferingEnabled(false)`, use a
-  peer/flow-control setup that does not acknowledge the send before the drop,
-  increment an allocation counter before native submission, assert it is exactly
-  one immediately before dropping the final frontend owner, and assert it
-  returns to zero after drop and callback completion. Because Rust's test
-  harness has no "inconclusive" outcome, make the setup deterministic and
-  self-checking: retry the controlled setup a bounded number of times, and if no
-  live outstanding send can be produced, **fail** with a setup-specific message
-  (do not pass or `#[ignore]`, since the compatibility requirement was not
+  `Stream::send`. Disabling send buffering is **not** possible through the
+  current `msquic` 2.5.1-beta safe API: `Settings::set_SendBufferingEnabled` is
+  generated by an enable-only bitflag macro with signature
+  `fn set_SendBufferingEnabled(self) -> Self` that always sets the value to `1`
+  (there is no `bool` argument, and no safe way to set it false). Before this
+  test — and therefore before the direct-drop ownership model can be considered
+  gated — pick and document one feasible mechanism:
+  1. extend the `msquic` binding with `set_SendBufferingEnabled(bool)`;
+  2. add a narrowly scoped, reviewed raw-settings helper that sets `IsSet` and a
+     `false` value; or
+  3. define another deterministic way to hold a send outstanding (e.g. withhold
+     peer flow-control credit) and prove it against every supported native build.
+  The test must **first prove buffering was actually disabled** (or that its
+  chosen mechanism produced an outstanding send), then increment an allocation
+  counter before native submission, assert it is exactly one immediately before
+  dropping the final frontend owner, and assert it returns to zero after drop and
+  callback completion. Because Rust's test harness has no "inconclusive"
+  outcome, make the setup deterministic and self-checking: retry the controlled
+  setup a bounded number of times, and if no live outstanding send can be
+  produced, **fail** with a setup-specific message (do not pass or `#[ignore]`,
+  since the compatibility requirement was not
   exercised). With buffering disabled and flow-control credit withheld, a setup
   failure indicates a real test-environment problem. Run it for every native
   MsQuic configuration declared supported.
 
 ## Implementation order
 
-1. Introduce conversion helpers, scoped terminal enums, and the shared
-  connection terminal slot with unit tests.
-2. Fix connection shutdown propagation and incoming-stream channels, including
-  the stream-callback fallback publication path.
-3. Split receive data, FIN, reset, and connection failure into explicit events.
-4. Introduce `OpeningStream` and cache stream IDs before returning `H3Stream`.
-5. Replace `H3Buff` with the owned `Bytes` send allocation, then split send
-  completion, peer stop, finish, and connection failure into explicit events.
-6. Implement `reset`, make finish flush and idempotent, and remove
-  callback/polling panics.
-7. Add loopback conformance tests, including native reset and finish behavior,
-   before changing downstream users. Keep event conversion and transition logic
-   in pure helpers so the remaining cases stay unit-testable without a native
-   operation abstraction.
+1. **Callback safety first.** Make every callback send fallible and every lock
+   poison-recovering across connection, stream, **and** listener paths, and
+   remove all `expect`/`unwrap` panics from the callback surfaces. Add the
+   receiver-drop and poisoned-lock tests now. This is the first mechanical phase
+   so no later commit leaves an FFI-unwind hazard, and every subsequent edit must
+   preserve the invariant that no send, `take`, lock, or pointer check can panic.
+2. Introduce conversion helpers, scoped terminal enums, outgoing application-code
+   clamping (including `OpenStreams::close`), and table-driven reducer tests.
+3. Add the shared connection terminal slot and incoming-terminal propagation;
+   resolve and test the normal-shutdown-drain versus internal-failure-fail-fast
+   queue policy.
+4. Split receive data, FIN, reset, and connection failure into explicit events.
+5. Introduce `OpeningStream`; validate accepted IDs while the handle is still
+   borrowed and take native ownership only on success (avoiding the double-close
+   boundary). Add the attachment-failpoint tests.
+6. Replace `H3Buff` with the owned `Bytes` `SendBuffer`, add the command-executor
+   seam, and test immediate failure plus callback reclamation.
+7. Integrate the send reducer, `reset`, and idempotent finish; run reducer,
+   executor, and synchronous-callback tests after each slice.
+8. Make deterministic outstanding-send setup possible (per the teardown-test
+   mechanism decision), then add loopback conformance tests.
+9. Add runtime native-version verification, the supported matrix, and send-copy
+   performance/peak-memory results to `Development.md`.
 
-This order fixes the error vocabulary first, then moves each callback path onto
-it while keeping changes reviewable.
+This order fixes callback safety and the error vocabulary first, then moves each
+callback path onto it while keeping changes reviewable and bisectable.

--- a/docs/error-propagation.md
+++ b/docs/error-propagation.md
@@ -168,44 +168,72 @@ allocation is concrete:
 ```rust
 struct SendBuffer {
   buffers: [BufferRef; 1],
-  bytes: Bytes,
+  _bytes: Bytes,
 }
+
+// SAFETY: `_bytes` owns immutable, `Send` heap storage; `buffers` holds only
+// inert pointer/length metadata into that storage. The box is transferred to
+// MsQuic through `client_context` and reconstructed + dropped exactly once
+// after `SendComplete` (or reclaimed by the caller on immediate `Stream::send`
+// failure). No Rust code accesses the bytes while native code owns the box, so
+// dropping it on an MsQuic worker thread is sound.
+unsafe impl Send for SendBuffer {}
+// `SendBuffer` is transferred, never shared, so `Sync` is neither needed nor
+// implemented. A compile-time `assert_impl_all!(SendBuffer: Send)` guards this.
 ```
+
+`SendBuffer` is `!Send` by default because `BufferRef` is
+`#[repr(transparent)]` over `QUIC_BUFFER { Length: u32, Buffer: *mut u8 }` and a
+raw `*mut u8` is `!Send`. The eager `Box::into_raw` -> `client_context` ->
+`Box::from_raw` transfer launders the box through `*const c_void`, so the
+compiler cannot check the cross-thread drop; the `unsafe impl Send` above makes
+that transfer explicit and reviewable (the old `H3Buff` path relied on the same
+mechanism via `unsafe impl Send for BufPtr`).
 
 A single send request is capped at `u32::MAX` bytes by MsQuic itself:
 `MsQuicStreamSend` sums every `QUIC_BUFFER.Length` into a `u64 TotalLength` and
 returns `QUIC_STATUS_INVALID_PARAMETER` when that sum exceeds `UINT32_MAX`,
-before the request is queued. Partitioning a larger payload across multiple
-`BufferRef` entries therefore does not help — the whole request is rejected — so
-the design validates the complete length up front and keeps a single buffer:
+before the request is queued. Relying on that native limit alone is a poor
+ceiling for an *owned-copy* design: a near-`u32::MAX` `send_data` would allocate
+a second near-4 GiB buffer before MsQuic is called, and a Rust allocation
+failure there can abort the process rather than return an error. The adapter
+therefore imposes its own finite ceiling `MAX_ADAPTER_SEND` (initial decision:
+`16 * 1024 * 1024`, i.e. 16 MiB — comfortably above normal HTTP/3 frame sizes,
+well below any dangerous allocation), named separately from the native
+`u32::MAX` protocol maximum and tunable later. A `send_data` above the ceiling
+is rejected with `OversizedSend` **before** any allocation. Partitioning a
+larger payload across multiple `BufferRef` entries is intentionally not done —
+internal chunking would require the reducer to track multiple native sends per
+h3 `send_data` and is deferred as a separate future design. So the design
+validates the complete length up front and keeps a single buffer:
 
 ```text
-remaining == 0              -> successful no-op (no allocation, no native send,
-                               send_inprogress stays false)
-remaining > u32::MAX        -> Err(StreamErrorIncoming::Unknown(OversizedSend))
-                               before any allocation or native submission;
-                               finish/terminal state unchanged
-0 < remaining <= u32::MAX   -> materialize into owned Bytes, construct one
-                               BufferRef, submit one native send
+remaining == 0                     -> successful no-op (no allocation, no native
+                                      send, send_inprogress stays false)
+remaining > MAX_ADAPTER_SEND       -> Err(StreamErrorIncoming::Unknown(OversizedSend))
+                                      before any allocation or native submission;
+                                      finish/terminal state unchanged
+0 < remaining <= MAX_ADAPTER_SEND  -> materialize into owned Bytes, construct one
+                                      BufferRef, submit one native send
 ```
 
 `OversizedSend` is a small adapter-owned `Debug + Display + Error` type. An
 oversized send is a stream-operation limitation, not a connection failure or a
 peer termination, so `StreamErrorIncoming::Unknown` is the closest h3 class.
 
-Construct `bytes` first, then construct the `BufferRef` from its slice and put
+Construct `_bytes` first, then construct the `BufferRef` from its slice and put
 both in the box. Moving `Bytes` does not move its referenced byte storage, so
 the pointer remains stable. `SendBuffer` is therefore self-referential:
-`buffers[0]` points into the heap storage owned by `bytes`, not into the struct,
+`buffers[0]` points into the heap storage owned by `_bytes`, not into the struct,
 and stays valid for as long as the box lives. This invariant is load-bearing and
 warrants an explicit safety comment at the construction site. Put construction
 behind one function taking an already-validated non-zero `u32` length (the
 validation from finding 5's precedence table has already rejected empty and
-oversized), so `BufferRef::from(&bytes[..])` — whose binding impl casts `usize`
-length to `u32` — never truncates. The `bytes` field exists only to own storage;
-name it `_bytes` (or read it in a small invariant helper) so it survives the
-repository's `-D warnings` policy as an otherwise-unread private field. A test
-asserts the `BufferRef` pointer and length still match after the completed
+above-ceiling), so `BufferRef::from(&_bytes[..])` — whose binding impl casts
+`usize` length to `u32` — never truncates. The `_bytes` field exists only to own
+storage; its leading underscore keeps the repository's `-D warnings` policy happy
+for an otherwise-unread private field (or read it in a small invariant helper). A
+test asserts the `BufferRef` pointer and length still match after the completed
 `SendBuffer` is moved into its `Box`. Pass `Box::into_raw(send_buffer)` as
 `client_context`. On `SendComplete`, the callback reconstructs `Box<SendBuffer>`
 and drops it immediately before enqueueing the completion event. MsQuic
@@ -221,17 +249,17 @@ buffer type. The cost is one full wire-buffer materialization per non-empty
 every chunk (the frame header array plus the payload), then `freeze()`. This is
 an allocation and byte copy even when the inner payload `B` is a single
 contiguous `Bytes`; it is not a refcount split, and it doubles peak payload
-memory. Because the design accepts requests up to the native `u32::MAX` limit, a
-near-4 GiB send attempts a second near-4 GiB allocation before MsQuic is called,
-and a Rust allocation failure there may **abort** rather than produce
-`OversizedSend`/`StreamErrorIncoming`.
+memory. The `MAX_ADAPTER_SEND` ceiling (above) bounds that doubling and removes
+the near-4 GiB double-allocation / allocation-abort hazard: a request above the
+ceiling is rejected with `OversizedSend` before any allocation.
 
 This is a sound choice (it does not justify retaining the unsound generic
-`H3Buff` erasure), but its cost is a **release gate**, not optional: add a
-benchmark for header-only, small-body, and large contiguous-body sends, document
-peak-memory behavior, and make an explicit decision on the size ceiling — accept
-the native `u32::MAX` limit as-is, impose a lower adapter limit that rejects with
-`OversizedSend` before allocating, or later add internal chunking. The
+`H3Buff` erasure). The remaining **release-gate** work is measurement, not the
+ceiling decision: add a benchmark for header-only, small-body, and large
+contiguous-body sends up to the ceiling, document peak-memory behavior, and
+revisit `MAX_ADAPTER_SEND` if the benchmarks justify a different value or motivate
+internal chunking (a separate future design that would make the reducer track
+multiple native sends per `send_data`). The
 allocation crossing FFI contains only owned `Bytes` plus pointer metadata, and
 the callback knows its concrete destructor. The old generic `H3Buff` can be
 deleted after its remaining uses are removed.
@@ -856,7 +884,15 @@ a system library is not silently assumed supported:
   does not prove which shared library the test process actually loads at
   runtime. Make native version/platform an explicit CI matrix dimension, and
   before the conformance tests query MsQuic's runtime version and **fail** if it
-  differs from the matrix entry. Keep "compile compatibility" and "conformance
+  differs from the matrix entry. The query is `PARAM_GLOBAL_VERSION`
+  (`0x01000004`) against a null global handle, whose value is `[u32; 4]`
+  (`QUIC_PARAM_GLOBAL_LIBRARY_VERSION` is `uint32_t[4]`) — `get_param_auto::<u32>`
+  allocates only 4 bytes and returns `QUIC_STATUS_BUFFER_TOO_SMALL`, so the query
+  type must be `[u32; 4]`. Compare normalized numeric components (and optionally
+  `PARAM_GLOBAL_LIBRARY_GIT_HASH` when two builds share a semantic version), not
+  a loosely formatted string. Keep this in the conformance preflight, not in
+  `Registration::new` (which must still accept ABI-compatible libraries outside
+  the tested-support matrix). Keep "compile compatibility" and "conformance
   support" as separate claims.
 
 **Release gate.** Before release, record the exact supported native
@@ -907,12 +943,14 @@ enum SendPoll {
     Closed,
 }
 
-/// `send_data` payload classification, computed after conversion into
-/// `WriteBuf<B>` but before any owned bytes are materialized.
+/// `send_data` payload classification, computed from `remaining()` after
+/// conversion into `WriteBuf<B>` but before any owned bytes are materialized.
+/// The `NonEmpty`/`Oversized` split is against `MAX_ADAPTER_SEND`, not the raw
+/// native `u32::MAX`.
 enum SendPayload {
     Empty,
-    NonEmpty { len: u32 },
-    Oversized { len: usize },
+    NonEmpty { len: u32 },        // 0 < len <= MAX_ADAPTER_SEND
+    Oversized { len: usize },     // len > MAX_ADAPTER_SEND
 }
 
 enum SendInput {
@@ -1111,6 +1149,7 @@ Request and event inputs:
 | `PollFinish(Event(Complete{cancelled:false}))` | send pending, not finishing | `send_inprogress=false`, `finish_submitting=true` | `SubmitGraceful` |
 | `PollFinish(Event(Complete{cancelled:true}))` | send pending, not finishing | `send_inprogress=false` | `PublishTerminal{winner or Failed(ABORTED), PollFinish}` |
 | `PollFinish(Event(TerminalWake))` | any (not complete) | none | `PublishTerminal{winner or Internal, PollFinish}` |
+| `PollFinish(Pending)` | `send_inprogress`, not finishing | none | `Pending` (waiting for the in-flight data send; no graceful submit yet) |
 | `PollFinish(Pending)` | idle, not finishing | `finish_submitting=true` | `SubmitGraceful` |
 | `PollFinish(Event(FinishComplete{graceful:true}))` | `finish_started` | `finish_complete=true` | `ReturnFinished` |
 | `PollFinish(Event(FinishComplete{graceful:false}))` | `finish_started` | none | `PublishTerminal{winner or Failed(ABORTED), PollFinish}` |
@@ -1136,6 +1175,38 @@ unexpected or impossible event is adapter `Internal`, never a panic. Unit tests
 call the reducer and prove that repeated finish polls
 emit `SubmitGraceful` exactly once and reset emits exactly one
 `SubmitReset(code)` without a mock native stream abstraction.
+
+#### Command execution loop
+
+The reducer is pure; a per-method executor loop runs its commands against MsQuic
+(through the counting executor seam) and feeds results straight back into
+`transition`. The loop must make bounded progress within one poll — in
+particular `RepollFinish` performs one fresh channel poll in the **same**
+`poll_finish` call, never deferring to a later external invocation (that would
+recreate the lost-waker bug). Normative shape for `poll_finish`:
+
+```text
+loop {
+    let poll = poll_send_channel(cx);            // Pending | Event(e) | Closed
+    match transition(&mut state, PollFinish { poll, terminal: load_winner() }) {
+        Pending            => return Poll::Pending,        // waker already registered
+        ReturnFinished     => return Poll::Ready(Ok(())),
+        ReturnError(t)     => return Poll::Ready(Err(convert(t))),
+        SubmitGraceful     => feed(GracefulSubmitted { result: exec.graceful(), .. }),
+        PublishTerminal{..} => feed(TerminalPublished { winner: publish(..), .. }),
+        RepollFinish       => continue,           // re-poll the channel this call
+        _                  => unreachable_internal(),
+    }
+}
+```
+
+Only `Pending`, a return command, or an impossible-state `Internal` exits the
+loop; native-submission and terminal-publication results are fed back
+immediately, and `RepollFinish` iterates. `poll_ready`, `send_data`, and `reset`
+use the same immediate-feedback discipline for their own command sets. Test the
+real executor with a stubbed channel that queues `FinishComplete` during the
+native-call stub (proving same-call consumption) and one that stays pending
+(proving the waker is registered before `Pending`).
 
 
 Recommended structural changes:
@@ -1181,6 +1252,18 @@ obvious):
   loopback test asserts all three outcomes: the rejected stream is never
   enqueued, both acceptors observe the winning connection terminal, and the peer
   observes `H3_INTERNAL_ERROR` after h3 handles it.
+- **Connection-scoped controls (not thread-local / process-global).** MsQuic
+  callbacks run on worker threads and a connection may move between workers, so a
+  thread-local failpoint set by the test thread would never fire in the callback,
+  and a process-global one-shot flag or counter would race parallel tests. Put
+  test controls in state already cloned into the callback, behind `#[cfg(test)]`
+  or a private test-support feature: the accepted-ID failpoint is an
+  atomic action/counter in `ConnectionState` (fail the next or Nth query for
+  that connection, consuming itself atomically and identifying exactly which
+  stream is rejected), and the reclamation counter is an `Arc<AtomicUsize>` tied
+  to the conformance test's connection/stream family and retained by each test
+  `SendBuffer`. Tests must run correctly under the normal parallel harness;
+  serializing the whole suite is a weaker, explicitly-stated fallback.
 - **Command executor.** The pure reducer proves which `SendCommand` is emitted,
   but not that the executor calls MsQuic exactly once (or not at all). Route
   native `open`/`send`/`shutdown(GRACEFUL)`/`shutdown(ABORT_*)` through one
@@ -1284,6 +1367,14 @@ Required unit tests:
   `TerminalWake` through `poll_finish` becomes `Internal`;
 - `poll_ready` after `finish_started` returns nested `InternalError` and issues
   no native call;
+- `poll_finish` while a data send is in flight waits (`Pending`) with **no**
+  native shutdown call, and a following `Complete{cancelled:false}` then emits
+  exactly one `SubmitGraceful` in the same poll (both paths from the same
+  starting state);
+- terminal-first ordering (a `TerminalWake` observed before the corresponding
+  `Complete`) never triggers a second native call or a buffer leak, even though
+  `Complete` may remain queued and `send_inprogress` stays set until drop — the
+  sticky terminal is returned and the stream is an intentional dead state;
 - stream IDs are cached before exposure and remain available after native
   shutdown;
 - immediate graceful-shutdown failure is sticky and is not retried;
@@ -1308,32 +1399,41 @@ Required loopback tests:
   the send-allocation count back to zero (exactly-once `SendBuffer` reclamation)
   with no callback panic. This directly guards the close-time inline-drain
   assumption the ownership model relies on, against whichever `libmsquic` is
-  linked. The test must be made deterministically outstanding, because with
-  MsQuic send buffering the `SendComplete` usually fires inline during
-  `Stream::send`. Disabling send buffering is **not** possible through the
-  current `msquic` 2.5.1-beta safe API: `Settings::set_SendBufferingEnabled` is
-  generated by an enable-only bitflag macro with signature
-  `fn set_SendBufferingEnabled(self) -> Self` that always sets the value to `1`
-  (there is no `bool` argument, and no safe way to set it false). Before this
-  test — and therefore before the direct-drop ownership model can be considered
-  gated — pick and document one feasible mechanism:
-  1. extend the `msquic` binding with `set_SendBufferingEnabled(bool)`;
-  2. add a narrowly scoped, reviewed raw-settings helper that sets `IsSet` and a
-     `false` value; or
-  3. define another deterministic way to hold a send outstanding (e.g. withhold
-     peer flow-control credit) and prove it against every supported native build.
-  The test must **first prove buffering was actually disabled** (or that its
-  chosen mechanism produced an outstanding send), then increment an allocation
-  counter before native submission, assert it is exactly one immediately before
-  dropping the final frontend owner, and assert it returns to zero after drop and
-  callback completion. Because Rust's test harness has no "inconclusive"
-  outcome, make the setup deterministic and self-checking: retry the controlled
-  setup a bounded number of times, and if no live outstanding send can be
-  produced, **fail** with a setup-specific message (do not pass or `#[ignore]`,
-  since the compatibility requirement was not
-  exercised). With buffering disabled and flow-control credit withheld, a setup
-  failure indicates a real test-environment problem. Run it for every native
-  MsQuic configuration declared supported.
+  linked. The test must be made deterministically outstanding, because with send
+  buffering enabled `SendComplete` may occur too quickly for the test to retain
+  an observably outstanding allocation after `Stream::send` returns. (MsQuic does
+  **not** invoke recursive application callbacks for ordinary API down-calls by
+  default — that only happens with an explicit `QUIC_STREAM_SHUTDOWN_FLAG_INLINE`
+  shutdown, which this design does not use — but a completion can still be
+  processed on the connection worker before the caller's next observation, or
+  race a call from another thread.) Disabling send buffering is not possible
+  through the current `msquic` 2.5.1-beta safe API: `set_SendBufferingEnabled` is
+  an enable-only bitflag macro (`fn set_SendBufferingEnabled(self) -> Self` that
+  always sets the value to `1`). **Selected mechanism:** extend the `msquic`
+  binding with a `set_SendBufferingEnabled(bool)` setter that sets `IsSet` and
+  the given value — it exposes an existing native setting without adapter-local
+  `QUIC_SETTINGS` layout manipulation, and is the design's committed dependency
+  (not an implementation-time fork). If that upstream change is unavailable, the
+  fallback is a narrowly scoped, reviewed, test-only raw-settings helper that
+  documents the exact `QUIC_SETTINGS` field, `IsSet` bit, and platform ABI
+  assumptions.
+  The test must prove four distinct facts, in order: (1) buffering was actually
+  disabled (or another deterministic blocking condition was established);
+  (2) exactly one adapter allocation remained outstanding after `Stream::send`
+  returned; (3) final-owner drop caused exactly one callback reclamation; and
+  (4) the count returned to zero before native close returned / the test's
+  explicit completion point. Because Rust's test harness has no "inconclusive"
+  outcome, make the setup deterministic and self-checking: bounded retries may
+  tolerate scheduling variation only **after** the setup is proven — they must
+  not be the mechanism that occasionally creates the condition — and if no live
+  outstanding send can be produced, **fail** with a setup-specific message (do
+  not pass or `#[ignore]`). Run it for every native MsQuic configuration declared
+  supported;
+- native `SendComplete` ownership contract, both directions: an **accepted** send
+  returns its context in exactly one completion; a **rejected** send (controlled
+  immediate `Stream::send` failure) produces **no** completion. A callback
+  counter asserts the exactly-once allocation invariant across supported native
+  versions.
 
 ## Implementation order
 

--- a/docs/error-propagation.md
+++ b/docs/error-propagation.md
@@ -284,7 +284,7 @@ measurements (per MF-5/T2), then either ratify the value, lower the cap, or adop
 internal chunking (a separate future design that would make the reducer track
 multiple native sends per `send_data`). Until those measurements are in, 16 MiB
 is a provisional working value, not a decided ceiling; see MF-5/T2 for the
-decision table and the appendix constant note. The allocation crossing FFI
+decision table and the as-built `MAX_ADAPTER_SEND` constant. The allocation crossing FFI
 contains only owned `Bytes` plus pointer metadata, and the callback knows its
 concrete destructor. The old generic `H3Buff` can be deleted after its remaining
 uses are removed.
@@ -303,7 +303,7 @@ cancelled without any published connection reason, it should map to the nested
 recorded reason" classification used at lines 296-297 and by the required
 mapping), never `Unknown` and never a panic. (Resolves review C-1: the earlier
 "should be `Unknown`" wording is superseded by `InternalError` so the prose,
-the mapping table, and the appendix agree.)
+the mapping table, and the as-built code agree.)
 
 `poll_open_inner` checks the shared connection terminal before creating a
 native stream and again before polling an existing `OpeningStream`. A published
@@ -397,8 +397,8 @@ against the **borrowed** handle:
    query is `Api::get_param_auto::<u64>(handle, QUIC_PARAM_STREAM_ID)` internally,
    whose failure surfaces as `Err(Status)`. Do not use the raw parameter API and
    do not fork on adding a borrowed query; the deref query is the single chosen
-   implementation. See the [Accepted-stream ID query](#accepted-stream-id-query)
-   appendix for the exact signature and safety contract.
+   implementation. See the accepted-stream ID query in `msquic-h3/src/lib.rs`
+   for the exact signature and safety contract.
 2. `u64::try_into::<h3::quic::StreamId>() -> Result<_, h3::quic::InvalidStreamId>`
    — MsQuic IDs are 62-bit so this is impossible by contract, but still handled.
 
@@ -814,7 +814,7 @@ v2.5.1 native `QuicStreamClose` source and the binding's uniform
 inline-drain-on-close contract** (both below) — *not* from an adapter unit test,
 because the public API cannot deterministically hold a real native send
 outstanding across a drop-triggered `StreamClose` (see
-[Native-test mechanisms](#native-test-mechanisms)). What the adapter *does*
+[As-built implementation](#as-built-implementation)). What the adapter *does*
 unit-test is its own exactly-once `Box<SendBuffer>` reclamation on the production
 `SendComplete` callback path (the `CountingExec` seam test); the native
 inline-drain-on-close behavior that makes the drain safe is a *documented
@@ -889,7 +889,7 @@ expectation** on whatever library is linked — argued from the v2.5.1
 `QuicStreamClose` source above and the binding's uniform `close_inner` contract,
 **not** asserted by an adapter unit test: the public API cannot deterministically
 hold a native send outstanding across `StreamClose` (per
-[Native-test mechanisms](#native-test-mechanisms)), so no such native teardown
+[As-built implementation](#as-built-implementation)), so no such native teardown
 test exists. The release-gate loopback conformance suite still exercises the
 accepted-send `SendComplete`/reclaim-once ordering, and the `CountingExec` seam
 test proves the adapter's own exactly-once reclamation bookkeeping — but neither
@@ -932,7 +932,7 @@ Two smaller points from those reviews are retained but deferred, not blocking:
    from an adapter drop-triggered `StreamClose` teardown test — no such test
    exists, because the public API cannot deterministically hold a native send
    outstanding across the close (see
-   [Native-test mechanisms](#native-test-mechanisms)). The available send
+   [As-built implementation](#as-built-implementation)). The available send
    conformance tests — the `CountingExec` seam tests
    (`accepted_send_reclaims_via_callback_exactly_once`,
    `immediate_send_failure_reclaims_without_completion`) and the loopback
@@ -1516,7 +1516,7 @@ Required loopback tests:
 The observably-outstanding retain/reclaim transition and the exactly-once
 `SendComplete` ownership contract are therefore proven by **seam tests, not
 loopback tests** — the deterministic `CountingExec` send seam described in the
-[Native-test mechanisms](#native-test-mechanisms) appendix:
+[As-built implementation](#as-built-implementation) section:
 
 - outstanding-send retain/reclaim: the seam retains the submitted
   `Box<SendBuffer>` in a test-held `client_context` slot, so the reclamation
@@ -1525,7 +1525,7 @@ loopback tests** — the deterministic `CountingExec` send seam described in the
   no `[patch.crates.io]` entry, and no raw `set_param` helper**; the earlier
   "extend the binding with a `set_SendBufferingEnabled(bool)` setter" and
   "test-only raw-settings fallback" requirements are withdrawn in favor of the
-  appendix's public-API decision. The seam test proves four distinct facts, in
+  as-built public-API decision. The seam test proves four distinct facts, in
   order: (1) the deterministic blocking condition was established (the seam
   retained the buffer without a `SendComplete`); (2) exactly one adapter
   allocation remained outstanding after the submit call returned; (3) feeding the
@@ -1547,14 +1547,15 @@ forcing that drop path — so close-time / inline-drain compatibility is **not**
 asserted by any test here. It rests on native-source review (`QuicStreamClose`
 inline `SendComplete` drain) plus the binding's uniform `close_inner` close
 contract (per ~793–805/~862–881 and the
-[Native-test mechanisms](#native-test-mechanisms) appendix, ~3092–3099).
+[As-built implementation](#as-built-implementation) section).
 
 ## Society-of-thought review resolutions (round 13)
 
 This section is the stable, authoritative record of how the round-13
 society-of-thought review (7 Must-Fix, 10 Should-Fix, 5 Trade-offs, 9 Consider)
-is resolved. It supersedes the appendix below wherever they differ (see the
-appendix banner). Trade-offs are decided with the fixed priority hierarchy
+is resolved. It is the authoritative design of record; the pre-implementation
+scaffold that formerly followed it has been removed (see the
+[As-built implementation](#as-built-implementation) section). Trade-offs are decided with the fixed priority hierarchy
 **Correctness > Security > Reliability > Performance > Maintainability >
 Developer Experience**. Code-level claims below were re-verified against the real
 repo (`Cargo.toml`, `msquic-h3/src/*`, `.github/workflows/build.yaml`) and the
@@ -1565,7 +1566,8 @@ h3-quinn-0.0.10}`).
 
 **Problem.** The narrative makes chronological enqueue order the tiebreaker
 between graceful `FinishComplete` and a later `TerminalWake` ("Send-side
-transitions" and the send transition table), but the appendix routes
+transitions" and the send transition table), but an earlier pre-implementation
+draft routed
 `FinishComplete` through a separate `shutdown` one-shot (`StreamSendCtx.shutdown`
 / `SendStreamReceiveCtx.shutdown`) while `TerminalWake` and data `Complete` ride
 the `send` mpsc, and `poll_send_channel` always drains the mpsc first. A
@@ -1634,7 +1636,9 @@ without a network).
 
 **Problem.** The unsafe close-time reclamation premise depends on the *actual
 loaded* binary's inline-drain / exactly-once behavior, but the preflight only
-compares `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` to `[2,5,1]`; provenance is a
+compares `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` to a single hard-coded version for
+every provenance row (wrong once the rows resolve to different patch versions —
+see the per-row gate in the decision below); provenance is a
 `find`↔`src` edit inside `[dev-dependencies]` (an uncommitted manifest change,
 not a committed CI dimension); and the `teardown` substring test filter may match
 none of the named seam tests.
@@ -1677,8 +1681,10 @@ none of the named seam tests.
    the `static` feature is set, which these jobs do not set). The preflight
    attests the **loaded** binary two ways:
    - **Live-handle identity (primary).** Query, through the live MsQuic handle the
-     test process is using, `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (must equal
-     `[2,5,1]`) **and** `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH` (param id `8`,
+     test process is using, `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (must equal the
+     row's pinned version — **`[2,5,8]` for `native-find`**, **`[2,5,1]` for
+     `native-src`**; the as-built gate is per row, see the Phase 9 attestation
+     policy) **and** `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH` (param id `8`,
      `char[64]` null-terminated). Both values are produced by code inside the
      actually-loaded image, so they attest the running library regardless of file
      path (verified: `msquic-2.5.1-beta/src/core/library.c`
@@ -1837,7 +1843,7 @@ multi-stream measurements before a value is committed:
 Measurements to add before committing: multi-stream latency (concurrent large
 sends) and aggregate retained bytes, not only the single 16 MiB copy. Until the
 table is filled and a value chosen, `MAX_ADAPTER_SEND` is documented as
-provisional (see the finding-5 text and the appendix constant note).
+provisional (see the finding-5 text and the as-built `MAX_ADAPTER_SEND` constant).
 
 ### MF-6 — release, versioning, migration, and rollback
 
@@ -1872,14 +1878,18 @@ blocking).**
 
 ### MF-7 / T5 — the appendix is a temporary scaffold, not a second source of truth
 
-**Decision (Maintainability, once code exists).** The ~1,800-line appendix
-(lines 1536–end) is demoted from "normative / takes precedence" to a **temporary
-pre-implementation scaffold** with an explicit expiry banner and cleanup
-checklist (added at the head of the appendix) and a release-gate item
-(implementation-order item 10). The living design of record is the narrative
-above plus this resolutions section — invariants, interfaces, mappings, and
-rationale. No depended-on invariant is deleted: the cleanup checklist requires
-promoting any such invariant into the narrative before the appendix is removed.
+**Decision (Maintainability, once code exists).** The ~1,800-line appendix was
+demoted from "normative / takes precedence" to a **temporary pre-implementation
+scaffold** and, now that the implementation has landed (Phases 1–9 in
+`msquic-h3/src/`), **has been removed per its expiry condition** (Phase 10 /
+implementation-order item 10). The living design of record is this narrative plus
+the resolutions section — invariants, interfaces, mappings, and rationale — and
+the as-built reference in `.paw/work/error-propagation/Docs.md`. No depended-on
+invariant was deleted: the load-bearing rules (the send transition table below,
+the single-ordered send-event queue of MF-1, the exactly-once reclamation
+contract of SF-3, and the per-row native-version gate of MF-3) all live in the
+narrative and are realized in the checked production code and tests. See the
+"As-built implementation" section where the scaffold formerly stood.
 
 ### SF-1 — name `StreamExecutor` as the send-half owner
 
@@ -2083,1962 +2093,75 @@ bumped, so they are updated opportunistically, not en masse.
   source review of the exact inline-drain path.
 - **C-9 — consolidated into T3** (proof obligations for removing `SendBuffer`).
 
-## Implementation-ready definitions (round 6)
-
-> **⚠ TEMPORARY IMPLEMENTATION SCAFFOLD — remove or replace when implementation
-> lands (resolves MF-7 / T5).** Everything from this banner to the end of the
-> document (the ~1,800-line Rust appendix that follows) is a *generated,
-> pre-implementation scaffold*, not living design. It is **no longer normative
-> and no longer takes precedence** over the narrative above: where the appendix
-> and the stable design (the sections above plus "Society-of-thought review
-> resolutions (round 13)") disagree, **the narrative and the resolutions section
-> win**, and the appendix is presumed stale. The stable, long-lived design of
-> record is: the review findings, the required mapping, "Proposed adapter
-> state", the send/receive/terminal transition rules, and the round-13
-> resolutions — i.e. invariants, interfaces, and rationale, not full method
-> bodies.
->
-> **Expiry condition / cleanup checklist (owner: implementer of the send
-> redesign):**
-> 1. When the production code lands in `msquic-h3/src/`, delete this appendix
->    (or move it to a throwaway branch / `docs/archive/`), leaving only links to
->    the checked production modules and tests.
-> 2. Replace any invariant that the design genuinely depends on (e.g. the send
->    transition table, the single-ordered-send-event-queue rule, the exactly-once
->    reclamation contract) with a short prose statement in the narrative above,
->    so no design dependency is silently lost.
-> 3. Do not fix bugs by editing this appendix once code exists; fix the code and
->    update the narrative invariants. CI already checks the real code
->    (`cargo check --all-targets --all-features` + `clippy -D warnings`, see
->    `.github/workflows/build.yaml`), so this appendix must not become a second
->    maintained source of truth.
-> 4. Implementation-order item 10 (below) enforces this cleanup as a release
->    gate.
-
-This appendix gives concrete Rust definitions, exact signatures, one committed
-choice at every former decision point, and precise per-site callback outcomes,
-to reduce implementation-time ambiguity. It is a scaffold only (see banner
-above). All constants keep their earlier values: `MAX_ADAPTER_SEND: u64 = 16 *
-1024 * 1024` (16 MiB, **provisional** per MF-5/T2), `MAX_QUIC_VARINT: u64 = (1 <<
-62) - 1`, and the native per-send `u32::MAX` protocol maximum. Where any listing
-below still shows a `FinishComplete` one-shot separate from the send mpsc, an
-`Unknown` no-reason cancellation, or an unqualified 16 MiB default, it is
-superseded by the round-13 resolutions.
-
-### Revised adapter structs and constructors
-
-All new fields carry the shared terminal state and cached IDs described above.
-`ConnectionState`/`StreamState` are the exact types from
-[Proposed adapter state](#proposed-adapter-state); the `Arc` ownership below is
-the load-bearing addition.
-
-```rust
-// ── Connection handle: unchanged fields, no terminal here (it lives in the
-//    Arc<ConnectionState> that ConnHandle also carries so callback + frontend
-//    share one slot). Field order (inner before _guard before state) is kept.
-#[derive(Debug)]
-pub(crate) struct ConnHandle {
-    inner: msquic::Connection,
-    state: Arc<ConnectionState>,   // NEW: shared, cloned into callback + streams
-    _guard: RundownGuard,
-}
-
-impl ConnHandle {
-    pub(crate) fn new(
-        inner: msquic::Connection,
-        state: Arc<ConnectionState>,
-        guard: RundownGuard,
-    ) -> Self {
-        Self { inner, state, _guard: guard }
-    }
-    pub(crate) fn state(&self) -> &Arc<ConnectionState> { &self.state }
-    pub(crate) fn inner(&self) -> &msquic::Connection { &self.inner }
-}
-
-#[derive(Debug)]
-pub struct Connection {
-    conn: Arc<ConnHandle>,
-    ctx: ConnCtxReceiver,
-    opener: StreamOpener,
-}
-
-// ── Callback → frontend. `bidi`/`uni` now carry IncomingStream<H3Stream>
-//    (stream OR terminal), not Option<H3Stream>. The callback clones the shared
-//    ConnectionState to derive/publish terminals and to seed accepted streams.
-#[derive(Debug)]
-struct ConnCtxSender {
-    state: Arc<ConnectionState>,            // NEW: publish/read shared terminal
-    connected: Option<oneshot::Sender<Result<(), Status>>>,  // was Sender<()>
-    shutdown: Option<oneshot::Sender<()>>,
-    bidi: Option<mpsc::UnboundedSender<IncomingStream<H3Stream>>>,
-    uni: Option<mpsc::UnboundedSender<IncomingStream<H3Stream>>>,
-}
-
-#[derive(Debug)]
-struct ConnCtxReceiver {
-    connected: Option<oneshot::Receiver<Result<(), Status>>>, // was Receiver<()>
-    shutdown: Option<oneshot::Receiver<()>>,
-    // Sticky accept-side terminal: first Terminal seen is stored and replayed by
-    // every later poll_accept_* on that side without re-polling the channel.
-    bidi: mpsc::UnboundedReceiver<IncomingStream<H3Stream>>,
-    uni: mpsc::UnboundedReceiver<IncomingStream<H3Stream>>,
-    bidi_terminal: Option<ConnectionTerminal>,  // NEW sticky accept state
-    uni_terminal: Option<ConnectionTerminal>,   // NEW sticky accept state
-}
-
-// Constructor now seeds both halves with the shared state clone.
-fn conn_ctx_channel(state: Arc<ConnectionState>) -> (ConnCtxSender, ConnCtxReceiver) {
-    let (conn_tx, conn_rx) = oneshot::channel::<Result<(), Status>>();
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let (bidi_tx, bidi_rx) = mpsc::unbounded();
-    let (uni_tx, uni_rx) = mpsc::unbounded();
-    (
-        ConnCtxSender {
-            state,
-            connected: Some(conn_tx),
-            shutdown: Some(shutdown_tx),
-            bidi: Some(bidi_tx),
-            uni: Some(uni_tx),
-        },
-        ConnCtxReceiver {
-            connected: Some(conn_rx),
-            shutdown: Some(shutdown_rx),
-            bidi: bidi_rx,
-            uni: uni_rx,
-            bidi_terminal: None,
-            uni_terminal: None,
-        },
-    )
-}
-```
-
-```rust
-// ── Stream side. StreamSendCtx (callback-owned) publishes terminals and events;
-//    both receive contexts cache the resolved StreamId and sticky terminals.
-struct StreamSendCtx {
-    state: Arc<StreamState>,                         // NEW: shared send terminal
-    start: Option<oneshot::Sender<Result<u64, Status>>>,   // was Result<(), Status>; now carries id
-    // Explicit send events (buffer reclaimed by callback before enqueue).
-    send: Option<mpsc::UnboundedSender<SendEvent>>,  // was (bool, BufPtr)
-    // Explicit receive events replace channel-closure signalling.
-    receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,  // was Bytes
-    receive_terminal_sent: bool,                     // NEW: first Fin/Reset/Conn wins
-    shutdown: Option<oneshot::Sender<SendEvent>>,    // finish completion channel
-}
-
-// Frontend receive half.
-#[derive(Debug)]
-struct RecvStreamReceiveCtx {
-    id: h3::quic::StreamId,                           // NEW cached id
-    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
-    terminal: Option<ReceiveTerminal>,               // NEW sticky recv terminal
-    // SF-6: local, sticky end-of-stream flag set by OUR OWN stop_sending. Distinct
-    // from `terminal` (which holds a peer/connection-caused reason); `terminal` is
-    // left untouched when this is set. When true, poll_data returns
-    // Ready(Ok(None)) and NO receive terminal is injected.
-    receive_closed: bool,                            // NEW SF-6 sticky local flag
-}
-
-// Frontend send half. `state` is the shared Arc; the reducer's own bookkeeping
-// is SendState (see below); the sticky winner is StreamState::send_terminal.
-#[derive(Debug)]
-struct SendStreamReceiveCtx {
-    id: h3::quic::StreamId,                           // NEW cached id
-    state: Arc<StreamState>,                          // NEW shared send terminal
-    send: mpsc::UnboundedReceiver<SendEvent>,
-    reducer: SendState,                               // was `send_inprogress: bool`
-    // Finish completion channel; the reducer treats it as a SendEvent source.
-    shutdown: oneshot::Receiver<SendEvent>,
-}
-
-#[derive(Debug)]
-pub struct H3SendStream {
-    // No `stream` field: every native send-side verb goes through `exec`, and the
-    // production `StreamExecutor` (held by `exec`) owns the `Arc<msquic::Stream>`
-    // that keeps the send half's native handle alive. This ownership is
-    // independent of the recv half: `H3RecvStream` holds its own `Arc` clone, so
-    // dropping the recv half first does NOT invalidate the send side (see the
-    // recv-drop-then-send test required by the resolutions section). This is also
-    // what lets `with_exec` build a send half with no live connection.
-    sctx: SendStreamReceiveCtx,   // carries cached id + Arc<StreamState>
-    exec: Box<dyn SendExec>,      // replaceable send-side seam (below); prod =
-                                  // StreamExecutor, tests = CountingExec
-}
-
-#[derive(Debug)]
-pub struct H3RecvStream {
-    stream: Arc<msquic::Stream>,
-    rctx: RecvStreamReceiveCtx,   // carries cached id
-}
-
-#[derive(Debug)]
-pub struct H3Stream {
-    send: H3SendStream,
-    recv: H3RecvStream,
-}
-
-// Constructor returns the callback-owned sender plus the two frontend halves.
-// It takes the shared per-stream state so the callback and both halves agree.
-fn stream_ctx_channel(
-    state: Arc<StreamState>,
-    id: h3::quic::StreamId,
-) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
-    let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
-    let (send_tx, send_rx) = mpsc::unbounded::<SendEvent>();
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<SendEvent>();
-    let (receive_tx, receive_rx) = mpsc::unbounded::<ReceiveEvent>();
-    (
-        StreamSendCtx {
-            state: state.clone(),
-            start: Some(start_tx),
-            send: Some(send_tx),
-            receive: Some(receive_tx),
-            receive_terminal_sent: false,
-            shutdown: Some(shutdown_tx),
-        },
-        SendStreamReceiveCtx {
-            id, state, send: send_rx,
-            reducer: SendState::new(),   // all-false; see reducer section
-            shutdown: shutdown_rx,
-        },
-        RecvStreamReceiveCtx { id, receive: receive_rx, terminal: None, receive_closed: false },
-    )
-}
-```
-
-The retained receive half implements the SF-6 post-`stop_sending` contract with the
-new `receive_closed` flag: our own `stop_sending` submits `ABORT_RECEIVE` (no receive
-terminal injected) and sets the sticky flag, so every subsequent `poll_data` is a
-defined `Poll::Ready(Ok(None))` end-of-stream rather than `Pending` — and the
-`terminal` slot is left untouched. `h3::quic::RecvStream::poll_data` returns
-`Poll<Result<Option<Self::Buf>, StreamErrorIncoming>>` and `stop_sending(&mut self,
-error_code: u64)` (verified in `h3-0.0.8/src/quic.rs`):
-
-```rust
-// SF-6: post-`stop_sending` polling contract on the retained recv half.
-impl h3::quic::RecvStream for H3RecvStream {
-    type Buf = bytes::Bytes;
-
-    fn poll_data(
-        &mut self,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
-        use std::task::Poll;
-        // SF-6: our OWN stop_sending already ended the receive half locally. This is a
-        // clean end-of-stream, NOT a terminal: `terminal` stays whatever it was
-        // (normally None) and no receive terminal is injected.
-        if self.rctx.receive_closed {
-            return Poll::Ready(Ok(None));
-        }
-        // Normal path: drain one ReceiveEvent. Data -> Ok(Some(bytes)); a sticky
-        // terminal (Fin/Reset/Connection/Internal) is stored in `self.rctx.terminal`
-        // and mapped by `convert_recv` (Fin -> Ok(None), else Err(..)); no event yet
-        // and channel open -> Pending. (Full drain logic elided; see convert_recv.)
-        drain_one_receive_event(&mut self.rctx, cx)
-    }
-
-    fn stop_sending(&mut self, error_code: u64) {
-        // Submit ABORT_RECEIVE with the clamped code (per the stop_sending(code) rule
-        // above, inject NO receive terminal), then set the sticky local flag so every
-        // subsequent poll_data is a defined Ready(Ok(None)) rather than Pending.
-        self.stream
-            .shutdown(msquic::StreamShutdownFlags::ABORT_RECEIVE, clamp_application_code(error_code));
-        self.rctx.receive_closed = true;              // sticky; `terminal` untouched
-    }
-
-    fn recv_id(&self) -> h3::quic::StreamId {
-        self.rctx.id
-    }
-}
-
-#[test]
-fn poll_data_after_local_stop_sending_is_ok_none() {
-    use std::task::Poll;
-    // Open connection, no peer FIN/reset, empty terminal slot.
-    let mut recv = test_recv_stream_open_no_terminal();
-    recv.stop_sending(0);
-    let mut cx = noop_context();
-    // Defined clean end-of-stream: not Pending, not Err.
-    assert!(matches!(recv.poll_data(&mut cx), Poll::Ready(Ok(None))));
-    // No terminal was injected: the sticky recv terminal slot remains empty.
-    assert!(recv.rctx.terminal.is_none());
-    assert!(recv.rctx.receive_closed);
-}
-```
-
-Accepted streams already have a validated `StreamId` (queried from the borrowed
-`StreamRef`, see below), so they call `stream_ctx_channel` above, which builds
-both id-bearing frontend halves immediately. Locally opened streams have **no
-id** until `StartComplete`, so they *cannot* call `stream_ctx_channel`. They use
-a distinct **pre-ID constructor** that builds only the callback-owned
-`StreamSendCtx` (the senders) plus a bundle of the four matching receiver ends.
-The id-bearing frontend halves are built later, by `OpeningStream::finalize`,
-once `StartComplete` yields the id:
-
-```rust
-// Frontend receiver ends held by an OpeningStream until the id is known. These
-// are the *receiver* halves whose *sender* halves live in the callback-owned
-// StreamSendCtx. Holding them keeps every channel open (so callback sends never
-// fail) and lets finalize move them into the H3Stream halves unchanged.
-#[derive(Debug)]
-struct PreIdReceivers {
-    start: oneshot::Receiver<Result<u64, Status>>,
-    send: mpsc::UnboundedReceiver<SendEvent>,
-    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
-    shutdown: oneshot::Receiver<SendEvent>,
-}
-
-/// Pre-ID variant of stream_ctx_channel: no StreamId is required or produced.
-/// Used only by locally opened streams. It builds the callback-owned
-/// StreamSendCtx (senders) and returns the matching receiver ends bundled, so
-/// an OpeningStream can hold them until StartComplete yields the id.
-fn stream_ctx_channel_pre_id(state: Arc<StreamState>) -> (StreamSendCtx, PreIdReceivers) {
-    let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
-    let (send_tx, send_rx) = mpsc::unbounded::<SendEvent>();
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<SendEvent>();
-    let (receive_tx, receive_rx) = mpsc::unbounded::<ReceiveEvent>();
-    (
-        StreamSendCtx {
-            state,
-            start: Some(start_tx),
-            send: Some(send_tx),
-            receive: Some(receive_tx),
-            receive_terminal_sent: false,
-            shutdown: Some(shutdown_tx),
-        },
-        PreIdReceivers {
-            start: start_rx,
-            send: send_rx,
-            receive: receive_rx,
-            shutdown: shutdown_rx,
-        },
-    )
-}
-```
-
-```rust
-// ── StreamOpener: same shape; its temp holders are OpeningStream, and it owns
-//    the connection-scoped open seam (OpenExec, executor section) so tests can
-//    substitute the native open/start.
-#[derive(Debug)]
-pub struct StreamOpener {
-    conn: Arc<ConnHandle>,
-    bidi_temp: Option<OpeningStream>,   // was Option<H3Stream>
-    uni_temp: Option<OpeningStream>,    // was Option<H3Stream>
-    open_exec: Box<dyn OpenExec>,       // prod = StreamOpenExecutor (see below)
-}
-// Clone (used by Connection::opener) resets both temps and installs a fresh
-// production StreamOpenExecutor, since an in-flight OpeningStream is not shared.
-
-/// A locally opened stream whose native handle is started but whose h3 StreamId
-/// is not yet known. Private to StreamOpener; the only stream form allowed to
-/// exist without a cached id. On a successful StartComplete it is consumed into
-/// an H3Stream with concrete id fields in both halves.
-#[derive(Debug)]
-struct OpeningStream {
-    stream: Arc<msquic::Stream>,
-    state: Arc<StreamState>,
-    // Frontend *receiver* ends (senders live in the callback's StreamSendCtx),
-    // held until finalize so callback sends keep working and the ends can be
-    // moved into the H3Stream halves unchanged.
-    recv: PreIdReceivers,
-}
-
-impl OpeningStream {
-    /// Consume into an H3Stream once StartComplete has yielded a validated id.
-    /// `start` has already been polled to completion by poll_open_inner and is
-    /// dropped here; the remaining three receivers move into the two halves.
-    fn finalize(self, id: h3::quic::StreamId) -> H3Stream {
-        let OpeningStream { stream, state, recv } = self;
-        let PreIdReceivers { start: _done, send, receive, shutdown } = recv;
-        H3Stream {
-            send: H3SendStream {
-                exec: Box::new(StreamExecutor { stream: stream.clone() }),
-                sctx: SendStreamReceiveCtx {
-                    id,
-                    state,
-                    send,
-                    reducer: SendState::new(),   // all-false; see reducer section
-                    shutdown,
-                },
-            },
-            recv: H3RecvStream {
-                stream,
-                rctx: RecvStreamReceiveCtx { id, receive, terminal: None, receive_closed: false },
-            },
-        }
-    }
-}
-```
-
-Exact constructor/finalizer **bodies** (accepted-connection state creation, the
-`OpeningStream` finalizer, and the pre-ID open path threaded through `attach`):
-
-```rust
-impl Connection {
-    // Accepted connection: the *caller path is the listener callback*, but the
-    // shared ConnectionState is created here (not by the caller), then cloned
-    // into the callback and into ConnHandle — exactly like connect(). This is
-    // the single place accepted-connection state is created and threaded.
-    pub(crate) fn attach(inner: msquic::Connection, guard: RundownGuard) -> Self {
-        // 1. Shared connection terminal slot, created before the callback runs.
-        let state = Arc::new(ConnectionState {
-            terminal: std::sync::Mutex::new(None),
-        });
-        // 2. Ctx channel is seeded with a clone (conn_ctx_channel takes state).
-        let (mut ctx, rx) = conn_ctx_channel(state.clone());
-        // 3. Install the callback BEFORE returning from the listener callback;
-        //    the closure owns `ctx`, which owns the second state clone and is the
-        //    clone PeerStreamStarted uses to seed accepted streams.
-        let handler =
-            move |_: msquic::ConnectionRef, ev: msquic::ConnectionEvent| connection_callback(&mut ctx, ev);
-        inner.set_callback_handler(handler);
-        // 4. ConnHandle owns the third clone alongside the native handle + guard.
-        let conn = Arc::new(ConnHandle::new(inner, state, guard));
-        Connection { conn: conn.clone(), ctx: rx, opener: StreamOpener::new(conn) }
-    }
-    // connect() is unchanged in shape but likewise builds ConnectionState before
-    // msquic::Connection::open, passes state.clone() to conn_ctx_channel, and to
-    // ConnHandle::new; its `connected` await now yields Result<(), Status>.
-}
-
-impl H3Stream {
-    // Accepted stream: id already validated from the borrowed StreamRef (below),
-    // and the shared connection terminal is threaded into the new StreamState.
-    pub(crate) fn attach(
-        stream: msquic::Stream,
-        conn_state: Arc<ConnectionState>,
-        id: h3::quic::StreamId,
-    ) -> Self {
-        let state = Arc::new(StreamState {
-            connection: conn_state,
-            send_terminal: std::sync::Mutex::new(None),
-        });
-        // id is known, so build both id-bearing halves directly.
-        let (mut ctx, sctx, rctx) = stream_ctx_channel(state, id);
-        let handler =
-            move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
-        stream.set_callback_handler(handler);
-        let s = Arc::new(stream);
-        H3Stream {
-            send: H3SendStream {
-                exec: Box::new(StreamExecutor { stream: s.clone() }),
-                sctx,
-            },
-            recv: H3RecvStream { stream: s, rctx },
-        }
-    }
-
-    // Locally opened: takes &ConnHandle (not &msquic::Connection) so it can copy
-    // the shared ConnectionState into the new StreamState, and returns the
-    // pre-id OpeningStream rather than a temporary H3Stream. The native open+start
-    // are the production body of OpenExec::submit_open_start.
-    fn open_and_start(conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
-        let state = Arc::new(StreamState {
-            connection: conn.state().clone(),   // copy the shared connection terminal
-            send_terminal: std::sync::Mutex::new(None),
-        });
-        let (mut ctx, recv) = stream_ctx_channel_pre_id(state.clone());
-        let handler =
-            move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
-        let flag = if uni { StreamOpenFlags::UNIDIRECTIONAL } else { StreamOpenFlags::NONE };
-        let stream = msquic::Stream::open(conn.inner(), flag, handler)?;
-        stream.start(StreamStartFlags::NONE)?;   // id arrives later via StartComplete
-        Ok(OpeningStream { stream: Arc::new(stream), state, recv })
-    }
-}
-
-impl StreamOpener {
-    fn new(conn: Arc<ConnHandle>) -> Self {
-        Self { conn, bidi_temp: None, uni_temp: None, open_exec: Box::new(StreamOpenExecutor) }
-    }
-
-    // Check shared connection terminal first; create the OpeningStream via the
-    // open seam; await StartComplete; on Ok(id) validate and finalize.
-    fn poll_open_inner(
-        conn: &Arc<ConnHandle>,
-        open_exec: &dyn OpenExec,
-        uni: bool,
-        holder: &mut Option<OpeningStream>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Result<H3Stream, StreamErrorIncoming>> {
-        use std::task::Poll;
-        // 1. Fail fast if the connection already published a terminal.
-        if let Some(reason) = conn.state().load_terminal() {
-            *holder = None;   // drop any in-flight OpeningStream
-            return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
-                connection_error: convert_conn(reason),
-            }));
-        }
-        // 2. Create + start the native stream if none is in flight.
-        if holder.is_none() {
-            match open_exec.submit_open_start(conn, uni) {
-                Ok(opening) => *holder = Some(opening),
-                Err(status) => {
-                    // A shutdown may have raced the open; prefer the conn terminal.
-                    return Poll::Ready(Err(match conn.state().load_terminal() {
-                        Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
-                            connection_error: convert_conn(reason),
-                        },
-                        None => StreamErrorIncoming::Unknown(Box::new(status)),
-                    }));
-                }
-            }
-        }
-        // 3. Await StartComplete on the OpeningStream's `start` receiver.
-        let opening = holder.as_mut().expect("holder populated in step 2");
-        let raw = match Pin::new(&mut opening.recv.start).poll(cx) {
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(Ok(raw)) => raw,   // Result<u64, Status> from StartComplete
-            Poll::Ready(Err(oneshot::Canceled)) => {
-                // Sender dropped by ShutdownComplete without a StartComplete.
-                *holder = None;
-                let connection_error = match conn.state().load_terminal() {
-                    Some(reason) => convert_conn(reason),
-                    None => ConnectionErrorIncoming::InternalError(
-                        "stream start cancelled without a terminal reason".into()),
-                };
-                return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming { connection_error }));
-            }
-        };
-        // 4. StartComplete carried a status; classify it.
-        let opening = holder.take().expect("holder populated in step 2");
-        match raw {
-            Err(status) => Poll::Ready(Err(match conn.state().load_terminal() {
-                Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
-                    connection_error: convert_conn(reason),
-                },
-                None => StreamErrorIncoming::Unknown(Box::new(status)),
-            })),
-            Ok(raw_id) => match validate_stream_id(raw_id) {   // (below)
-                Ok(id) => Poll::Ready(Ok(opening.finalize(id))),
-                Err(_) => Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
-                    connection_error: ConnectionErrorIncoming::InternalError(
-                        "local stream ID is invalid".into()),
-                })),
-            },
-        }
-    }
-}
-```
-
-The lone `expect("holder populated in step 2")` calls are internal invariants on
-a value this function set on the immediately preceding lines, not FFI-reachable
-callback code; they can equally be written as `let Some(..) = .. else { return
-Poll::Pending }`. No `expect` touches a channel result, a native handle, or a
-lock, so no callback path can unwind through FFI. `poll_open_bidi`/`poll_open_send`
-call `Self::poll_open_inner(&self.conn, &*self.open_exec, uni, &mut self.bidi_temp
-/ self.uni_temp, cx)`.
-
-### Adapter-owned error types
-
-Compilable definitions with derives, `Display`, and `From` conversions. `Status`,
-`u64` codes, and `&'static str` messages are the only stored data. All four are
-`Send + Sync` because `QUIC_STATUS` (an integer alias) and the primitives are.
-
-```rust
-use std::fmt;
-use crate::msquic::Status;
-
-/// send_data payload above MAX_ADAPTER_SEND. One-shot; never stored in the
-/// shared send-terminal slot (see SendOperationError below).
-#[derive(Debug)]
-pub struct OversizedSend {
-    /// Requested payload length in bytes (the `remaining()` that was rejected).
-    pub len: usize,
-}
-impl fmt::Display for OversizedSend {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "send_data payload of {} bytes exceeds MAX_ADAPTER_SEND ({} bytes)",
-            self.len, MAX_ADAPTER_SEND
-        )
-    }
-}
-impl std::error::Error for OversizedSend {}
-
-/// Non-application transport shutdown. Both the QUIC status and the wire
-/// transport error code are retained for diagnostics.
-#[derive(Debug)]
-pub struct MsQuicTransportError {
-    pub status: Status,
-    pub error_code: u64,
-}
-impl fmt::Display for MsQuicTransportError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "QUIC transport shutdown: status {} (transport error_code {})",
-            self.status, self.error_code
-        )
-    }
-}
-impl std::error::Error for MsQuicTransportError {}
-
-/// Local (application-initiated) connection close. Carries no peer code — see
-/// the mapping table row: "do not invent a peer code".
-#[derive(Debug)]
-pub struct LocalConnectionClose;
-impl fmt::Display for LocalConnectionClose {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("connection closed locally by the application")
-    }
-}
-impl std::error::Error for LocalConnectionClose {}
-
-/// Local reset via SendStream::reset(code). Distinct from a peer
-/// StreamTerminated: h3 should not poll a reset send stream.
-#[derive(Debug)]
-pub struct LocalStreamReset {
-    pub code: u64,
-}
-impl fmt::Display for LocalStreamReset {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "send stream reset locally with code {}", self.code)
-    }
-}
-impl std::error::Error for LocalStreamReset {}
-```
-
-`From` conversions used at the polling boundary (these are the *only* places that
-mint h3 errors, keeping the two similarly named `OversizedSend` uses consistent):
-
-```rust
-// ConnectionTerminal -> ConnectionErrorIncoming
-fn convert_conn(t: ConnectionTerminal) -> ConnectionErrorIncoming {
-    use ConnectionTerminal as C;
-    match t {
-        C::PeerApplication(code) => ConnectionErrorIncoming::ApplicationClose { error_code: code },
-        C::Timeout => ConnectionErrorIncoming::Timeout,
-        C::Transport { status, error_code } =>
-            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(
-                MsQuicTransportError { status, error_code })),
-        C::LocalClose =>
-            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(LocalConnectionClose)),
-        C::Internal(msg) => ConnectionErrorIncoming::InternalError(msg.to_string()),
-    }
-}
-
-// SendTerminal -> StreamErrorIncoming
-fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
-    use SendTerminal as S;
-    match t {
-        S::Stopped(code) => StreamErrorIncoming::StreamTerminated { error_code: code },
-        S::Connection(reason) =>
-            StreamErrorIncoming::ConnectionErrorIncoming { connection_error: convert_conn(reason) },
-        S::LocalReset(code) =>
-            StreamErrorIncoming::Unknown(Box::new(LocalStreamReset { code })),
-        S::Failed(status) => StreamErrorIncoming::Unknown(Box::new(status)),
-        S::Internal(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
-            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
-        },
-    }
-}
-
-// ReceiveTerminal -> Result<Option<Bytes>, StreamErrorIncoming>
-fn convert_recv(t: ReceiveTerminal) -> Result<Option<bytes::Bytes>, StreamErrorIncoming> {
-    use ReceiveTerminal as R;
-    match t {
-        R::Fin => Ok(None),
-        R::Reset(code) => Err(StreamErrorIncoming::StreamTerminated { error_code: code }),
-        R::Connection(reason) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
-            connection_error: convert_conn(reason) }),
-        R::Internal(msg) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
-            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()) }),
-    }
-}
-```
-
-`SendOperationError` → h3 error mapping is the disambiguation the reviewer asked
-for. `SendOperationError` is the **one-shot** `send_data` result and is *never*
-stored in `StreamState::send_terminal`; the sticky `SendTerminal` path
-(`convert_send`) is separate:
-
-```rust
-// send_data's ReturnImmediateError(SendOperationError) is converted here, and
-// nowhere else, so `SendOperationError::OversizedSend { len }` and the final
-// boxed `OversizedSend` cannot diverge:
-fn convert_send_op(e: SendOperationError) -> StreamErrorIncoming {
-    match e {
-        SendOperationError::OversizedSend { len } =>
-            StreamErrorIncoming::Unknown(Box::new(OversizedSend { len })),
-        SendOperationError::Misuse(_msg) =>
-            StreamErrorIncoming::ConnectionErrorIncoming {
-                connection_error: ConnectionErrorIncoming::InternalError(
-                    "send_data called while a send is in progress or after finish".into()),
-            },
-    }
-}
-```
-
-Thus `SendOperationError::OversizedSend { len }` maps 1:1 to the boxed
-`OversizedSend { len }` (`StreamErrorIncoming::Unknown`), and
-`SendOperationError::Misuse` maps to nested `InternalError` — the same class the
-reference adapters use for send-while-busy. No other site constructs these
-errors.
-
-### Accepted-stream ID query
-
-Committed, no `msquic` dependency change:
-
-```rust
-/// Pure, unit-testable id validation. MsQuic ids are 62-bit so this never fails
-/// for a live peer, but the InvalidStreamId branch is still handled.
-fn validate_stream_id(raw: u64) -> Result<h3::quic::StreamId, h3::quic::InvalidStreamId> {
-    h3::quic::StreamId::try_from(raw)   // impl TryFrom<u64>, h3-0.0.8 proto/stream.rs:147
-}
-```
-
-Accepted-stream attachment in `connection_callback`, `PeerStreamStarted { stream:
-StreamRef, flags }`:
-
-```rust
-// stream: &StreamRef (borrowed; Drop nulls the handle so it never closes it).
-// StreamRef: Deref<Target = Stream>, so this calls Stream::get_stream_id via
-// auto-deref against the BORROWED handle. No owning Stream is created here.
-// Safety: get_stream_id issues Api::get_param_auto::<u64>(handle,
-// QUIC_PARAM_STREAM_ID) on the still-native-owned handle; we hold only a
-// borrow, take no ownership, and never StreamClose it on this failure path.
-let raw_id: u64 = match stream.get_stream_id() {   // Result<u64, Status>
-    Ok(id) => id,
-    Err(status) => {
-        // pre-ownership failure: publish Internal terminal, wake acceptors,
-        // return `status` so MsQuic closes the rejected stream itself.
-        publish_conn_internal(&ctx.state, "accepted stream ID query failed");
-        wake_acceptors(ctx);
-        return Err(status);
-    }
-};
-let id = match validate_stream_id(raw_id) {
-    Ok(id) => id,
-    Err(_) => {
-        publish_conn_internal(&ctx.state, "accepted stream ID is invalid");
-        wake_acceptors(ctx);
-        return Err(Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR));
-    }
-};
-// Success: only now take ownership and attach.
-let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
-let h3 = H3Stream::attach(owned, ctx.state.clone(), id);
-// post-ownership delivery failure -> drop/close via Rust, return Ok (below).
-```
-
-`get_stream_id` lives on `msquic::Stream` (`lib.rs:1230`) and is reached through
-`StreamRef: Deref<Target = Stream>` (`lib.rs:1236`). No borrowed-query helper is
-added to the binding, no raw `Api::get_param` call is written in the adapter, and
-no dependency patch/version bump is required.
-
-### Reducer: exhaustive `match` form
-
-`SendState::new()` is all-false:
-
-```rust
-impl SendState {
-    fn new() -> Self {
-        SendState {
-            send_submitting: false,
-            send_inprogress: false,
-            finish_submitting: false,
-            finish_started: false,
-            finish_complete: false,
-            reset_submitting: false,
-        }
-    }
-}
-```
-
-Named predicates (exact boolean expressions the transition arms use):
-
-```rust
-impl SendState {
-    /// A native submission is reserved but its *Submitted result has not arrived.
-    fn submission_reserved(&self) -> bool {
-        self.send_submitting || self.finish_submitting || self.reset_submitting
-    }
-    /// "idle": accepting a new send_data — nothing in flight, not finishing,
-    /// no reservation outstanding.
-    fn idle(&self) -> bool {
-        !self.send_inprogress && !self.finish_started && !self.finish_complete
-            && !self.submission_reserved()
-    }
-    /// "send pending": a data send is committed and awaiting its SendComplete.
-    fn send_pending(&self) -> bool { self.send_inprogress }
-    /// "finishing": graceful finish reserved or committed, not yet complete.
-    fn finishing(&self) -> bool {
-        (self.finish_submitting || self.finish_started) && !self.finish_complete
-    }
-}
-```
-
-Guard-set membership by frontend method (which reservation flags each checks):
-
-| Guard | Flags it inspects | Meaning |
-| --- | --- | --- |
-| `send_data` misuse | `send_inprogress \|\| send_submitting \|\| finish_submitting \|\| finish_started \|\| finish_complete` | any in-flight/finishing state rejects a new `send_data` |
-| `poll_ready` reservation block | `submission_reserved()` (all three) | a method arriving mid-submission is `Internal` |
-| `poll_ready`-after-finish misuse | `finish_started` (regardless of `finish_complete`) | non-sticky nested `InternalError` |
-| `poll_finish` reservation block | `submission_reserved()` (all three) | same as above |
-| `reset` no-op | `finish_complete \|\| terminal_present` | infallible `NoOp` |
-| `reset` impossible | `submission_reserved()` | `PublishTerminal{Internal, Reset}` |
-
-`TerminalPublished` arms (previously implicit) are now enumerated: after the
-first-writer helper returns the `winner`, the reducer emits exactly one command
-per `continuation`, and mutates no state (the winner is already in the shared
-slot):
-
-| `TerminalPublished { winner, continuation }` | Command |
-| --- | --- |
-| `continuation = SendData` | `ReturnError(winner)` → `Err(convert_send(winner))` from `send_data` |
-| `continuation = PollReady` | `ReturnError(winner)` → `Poll::Ready(Err(convert_send(winner)))` |
-| `continuation = PollFinish` | `ReturnError(winner)` → `Poll::Ready(Err(convert_send(winner)))` |
-| `continuation = Reset` | `NoOp` (infallible method; winner stored for a later poll) |
-
-The "impossible combination" is no longer a prose wildcard: because every
-`SendInput` variant and every inner `SendPoll`/`SendPayload`/`SendEvent` case is
-matched, the reducer is one exhaustive `match` with no outer `_` arm. Each
-formerly-implicit "impossible" pairing is encoded as an explicit
-`PublishTerminal { candidate: SendTerminal::Internal(..), continuation }` arm
-that mutates no committed flag and never panics. The complete body, directly
-translatable:
-
-```rust
-fn transition(state: &mut SendState, input: SendInput) -> SendCommand {
-    use SendCommand::*;
-    use SendInput::*;
-    use TerminalContinuation as K;
-    let aborted = || SendTerminal::Failed(Status::new(StatusCode::QUIC_STATUS_ABORTED));
-
-    match input {
-        // ── Precedence 1: *Submitted bookkeeping. Always clears its reservation
-        //    before any winner is applied; a missing reservation is internal.
-        SendSubmitted { result, terminal } => {
-            if !state.send_submitting {
-                return PublishTerminal {
-                    candidate: SendTerminal::Internal("SendSubmitted without reservation"),
-                    continuation: K::SendData,
-                };
-            }
-            state.send_submitting = false;
-            match result {
-                Ok(()) => {
-                    state.send_inprogress = true;
-                    match terminal {
-                        Some(w) => ReturnError(w),   // a winner raced in
-                        None => ReturnSent,          // send_data's Ok(())
-                    }
-                }
-                // Buffer already reclaimed by the caller on the Err path.
-                Err(status) => PublishTerminal {
-                    candidate: terminal.unwrap_or(SendTerminal::Failed(status)),
-                    continuation: K::SendData,
-                },
-            }
-        }
-        GracefulSubmitted { result, terminal } => {
-            if !state.finish_submitting {
-                return PublishTerminal {
-                    candidate: SendTerminal::Internal("GracefulSubmitted without reservation"),
-                    continuation: K::PollFinish,
-                };
-            }
-            state.finish_submitting = false;
-            match result {
-                Ok(()) => { state.finish_started = true; RepollFinish }  // never Pending directly
-                Err(status) => PublishTerminal {
-                    candidate: terminal.unwrap_or(SendTerminal::Failed(status)),
-                    continuation: K::PollFinish,
-                },
-            }
-        }
-        ResetSubmitted { code, result, terminal } => {
-            if !state.reset_submitting {
-                return PublishTerminal {
-                    candidate: SendTerminal::Internal("ResetSubmitted without reservation"),
-                    continuation: K::Reset,
-                };
-            }
-            state.reset_submitting = false;
-            let candidate = match result {
-                Ok(()) => terminal.unwrap_or(SendTerminal::LocalReset(code)),
-                Err(status) => terminal.unwrap_or(SendTerminal::Failed(status)),
-            };
-            PublishTerminal { candidate, continuation: K::Reset }
-        }
-
-        // ── Consume the resolved winner (no state mutation).
-        TerminalPublished { winner, continuation } => match continuation {
-            K::SendData | K::PollReady | K::PollFinish => ReturnError(winner),
-            K::Reset => NoOp,   // infallible method; winner stored for a later poll
-        },
-
-        // ── send_data request. Terminal wins; else misuse if busy/finishing.
-        SendRequested { payload, terminal } => {
-            if let Some(w) = terminal { return ReturnError(w); }
-            if state.send_inprogress || state.send_submitting
-                || state.finish_submitting || state.finish_started || state.finish_complete {
-                return ReturnImmediateError(SendOperationError::Misuse("send_data while busy/finishing"));
-            }
-            match payload {                                              // idle, no winner
-                SendPayload::Empty => ReturnSent,                        // no-op, no reservation
-                SendPayload::Oversized { len } =>
-                    ReturnImmediateError(SendOperationError::OversizedSend { len }),  // state unchanged
-                SendPayload::NonEmpty { .. } => { state.send_submitting = true; SubmitSend }
-            }
-        }
-
-        // ── reset request (infallible; at most one native SubmitReset).
-        Reset { code, terminal } => {
-            if state.finish_complete || terminal.is_some() {
-                return NoOp;   // already terminal; nothing to submit
-            }
-            if state.submission_reserved() {
-                return PublishTerminal {   // impossible under serialized callers
-                    candidate: SendTerminal::Internal("reset during submission reservation"),
-                    continuation: K::Reset,
-                };
-            }
-            state.reset_submitting = true;   // otherwise, incl. incomplete finish
-            SubmitReset(code)
-        }
-
-        // ── poll_ready request. A present shared terminal is surfaced first.
-        PollReady { poll, terminal } => {
-            if state.submission_reserved() {
-                return PublishTerminal {
-                    candidate: SendTerminal::Internal("poll_ready during submission reservation"),
-                    continuation: K::PollReady,
-                };
-            }
-            // Method-terminal step: a winner already in the shared slot is returned
-            // before ordinary event handling, so a `Pending` poll can never linger
-            // past a terminal.
-            if let Some(w) = terminal {
-                state.send_inprogress = false;
-                return ReturnError(w);
-            }
-            if state.finish_started {   // h3 misuse; no native call, non-sticky
-                return ReturnError(SendTerminal::Internal("poll_ready after finish"));
-            }
-            match poll {
-                // Terminal handled above, so a closed channel here has no winner.
-                SendPoll::Closed => PublishTerminal {
-                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
-                    continuation: K::PollReady,
-                },
-                SendPoll::Event(SendEvent::Complete { cancelled: false }) => {
-                    if !state.send_inprogress {
-                        return PublishTerminal {   // impossible idle-state completion
-                            candidate: SendTerminal::Internal("SendComplete without an outstanding send"),
-                            continuation: K::PollReady,
-                        };
-                    }
-                    state.send_inprogress = false; ReturnReady
-                }
-                SendPoll::Event(SendEvent::Complete { cancelled: true }) => {
-                    if !state.send_inprogress {
-                        return PublishTerminal {   // impossible idle-state completion
-                            candidate: SendTerminal::Internal("cancelled SendComplete without an outstanding send"),
-                            continuation: K::PollReady,
-                        };
-                    }
-                    state.send_inprogress = false;
-                    // No shared winner (handled above): synthesize the abort terminal.
-                    PublishTerminal { candidate: aborted(), continuation: K::PollReady }
-                }
-                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
-                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
-                    continuation: K::PollReady,
-                },
-                SendPoll::Event(SendEvent::FinishComplete { .. }) => PublishTerminal {
-                    candidate: SendTerminal::Internal("finish event observed on poll_ready"),
-                    continuation: K::PollReady,
-                },
-                SendPoll::Pending => if state.send_inprogress { Pending } else { ReturnReady },
-            }
-        }
-
-        // ── poll_finish request. Absorbing finish and a completed graceful finish
-        //    both precede the method-terminal step and ordinary event handling.
-        PollFinish { poll, terminal } => {
-            if state.finish_complete { return ReturnFinished; }   // absorbing
-            if state.submission_reserved() {
-                return PublishTerminal {
-                    candidate: SendTerminal::Internal("poll_finish during submission reservation"),
-                    continuation: K::PollFinish,
-                };
-            }
-            // Documented successful-finish exception: a graceful finish that
-            // actually completed wins even over a present terminal.
-            if let SendPoll::Event(SendEvent::FinishComplete { graceful }) = poll {
-                if !state.finish_started {
-                    return PublishTerminal {
-                        candidate: SendTerminal::Internal("finish complete without a started finish"),
-                        continuation: K::PollFinish,
-                    };
-                }
-                if graceful {
-                    state.finish_complete = true;
-                    return ReturnFinished;
-                }
-                // graceful == false while finishing: abort (winner wins if present).
-                return PublishTerminal {
-                    candidate: terminal.unwrap_or_else(aborted),
-                    continuation: K::PollFinish,
-                };
-            }
-            // Method-terminal step: after the finish exceptions, a present winner is
-            // surfaced before any Pending/SubmitGraceful, so PollFinish(Pending) can
-            // never submit graceful shutdown once a terminal has won.
-            if let Some(w) = terminal {
-                state.send_inprogress = false;
-                return ReturnError(w);
-            }
-            match poll {
-                SendPoll::Closed => PublishTerminal {
-                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
-                    continuation: K::PollFinish,
-                },
-                SendPoll::Event(SendEvent::Complete { cancelled: false }) if !state.finish_started => {
-                    if !state.send_inprogress {
-                        return PublishTerminal {   // impossible idle-state completion
-                            candidate: SendTerminal::Internal("SendComplete without an outstanding send"),
-                            continuation: K::PollFinish,
-                        };
-                    }
-                    state.send_inprogress = false; state.finish_submitting = true; SubmitGraceful
-                }
-                SendPoll::Event(SendEvent::Complete { cancelled: true }) if !state.finish_started => {
-                    if !state.send_inprogress {
-                        return PublishTerminal {   // impossible idle-state completion
-                            candidate: SendTerminal::Internal("cancelled SendComplete without an outstanding send"),
-                            continuation: K::PollFinish,
-                        };
-                    }
-                    state.send_inprogress = false;
-                    PublishTerminal { candidate: aborted(), continuation: K::PollFinish }
-                }
-                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
-                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
-                    continuation: K::PollFinish,
-                },
-                SendPoll::Pending if state.finish_started => Pending,
-                SendPoll::Pending if state.send_inprogress => Pending,     // wait for in-flight data send
-                SendPoll::Pending => { state.finish_submitting = true; SubmitGraceful }  // idle, not finishing
-                // Any remaining event/state pair (e.g. a data completion while
-                // finishing) is adapter-internal, never a panic.
-                SendPoll::Event(_) => PublishTerminal {
-                    candidate: SendTerminal::Internal("impossible poll_finish event/state"),
-                    continuation: K::PollFinish,
-                },
-            }
-        }
-    }
-}
-```
-
-The guard order inside each arm follows the precedence stated earlier
-(submitted-result bookkeeping is discharged by the outer variant match itself;
-absorbing `finish_complete` precedes reservation/method handling in `PollFinish`;
-`submission_reserved()` precedes method-specific handling in `PollReady`). Reducer
-tests are table-driven from the rows above and need no executor or native handle.
-
-### Command-executor boundary and per-method loops
-
-The reducer touches MsQuic only through two seams, split by lifetime because one
-*acts on* an existing stream and the other *creates* one:
-
-```rust
-/// Send-side seam: acts on an already-open stream. Stored behind a trait object
-/// in H3SendStream so a test double replaces it without a live connection. The
-/// reducer never names it.
-trait SendExec: std::fmt::Debug + Send {
-    /// Materialize the already-validated non-zero payload's SendBuffer,
-    /// Box::into_raw it as client_context, and call Stream::send. On an immediate
-    /// Err the box is reconstructed and dropped here, before returning.
-    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status>;
-    fn submit_graceful(&mut self) -> Result<(), Status>;   // Stream::shutdown(GRACEFUL)
-    fn submit_reset(&mut self, code: u64) -> Result<(), Status>;  // shutdown(ABORT_SEND)
-}
-
-#[derive(Debug)]
-struct StreamExecutor { stream: Arc<msquic::Stream> }   // production send seam
-impl SendExec for StreamExecutor {
-    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
-        // Box the self-referential SendBuffer and hand its raw pointer to native as
-        // client_context. `buf.buffers` (a [BufferRef; 1]) points into `buf._bytes`
-        // and stays valid because the box is never moved again until SendComplete.
-        let cc: *mut SendBuffer = Box::into_raw(Box::new(buf));
-        // SAFETY: buffers memory is valid until the SendComplete callback
-        // reconstructs+drops the box (Stream::send's contract). FIN is not set on a
-        // data send; graceful finish is a separate shutdown call.
-        let res = unsafe {
-            self.stream.send(&(*cc).buffers, msquic::SendFlags::NONE, cc as *const std::ffi::c_void)
-        };
-        if let Err(status) = res {
-            // Immediate failure: MsQuic took no ownership, so reclaim the box here
-            // (mirroring the SendComplete drop) before returning.
-            drop(unsafe { Box::from_raw(cc) });
-            return Err(status);
-        }
-        Ok(())
-    }
-    fn submit_graceful(&mut self) -> Result<(), Status> {
-        // GRACEFUL FIN; error_code is ignored for a graceful shutdown.
-        self.stream.shutdown(msquic::StreamShutdownFlags::GRACEFUL, 0)
-    }
-    fn submit_reset(&mut self, code: u64) -> Result<(), Status> {
-        // ABORT_SEND with the already-clamped application code (<= MAX_QUIC_VARINT).
-        self.stream.shutdown(msquic::StreamShutdownFlags::ABORT_SEND, code)
-    }
-}
-
-/// Open seam: *creates and starts* the native stream, returning the OpeningStream
-/// (which carries the start receiver). Separate from SendExec because it cannot
-/// act on an Arc<Stream> that does not exist yet. Stored in StreamOpener.
-trait OpenExec: std::fmt::Debug {
-    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status>;
-}
-
-#[derive(Debug)]
-struct StreamOpenExecutor;   // production open seam
-impl OpenExec for StreamOpenExecutor {
-    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
-        H3Stream::open_and_start(conn, uni)   // real Stream::open + Stream::start
-    }
-}
-```
-
-This resolves the earlier contradiction: `submit_open_start` now creates the
-stream and returns it (not `Result<(), Status>`), and `H3SendStream` stores
-`Box<dyn SendExec>` (not a concrete `StreamExecutor`), so a `CountingExec` is
-injectable in wiring tests.
-
-**Construction interface.** Production builds `H3SendStream` via
-`OpeningStream::finalize` / `H3Stream::attach` (which install
-`Box::new(StreamExecutor { stream })`). Tests use an internal constructor that
-takes only the injected seam and the send-side context — **no `Arc<msquic::Stream>`**,
-because the send half has no `stream` field and the production stream lives inside
-`StreamExecutor`:
-
-```rust
-impl H3SendStream {
-    /// Test/internal constructor: inject any SendExec (incl. CountingExec) plus the
-    /// send-side context whose channel senders the test retains. No live connection
-    /// or native stream is required — the reducer and loops touch only `exec` and
-    /// `sctx`.
-    fn with_exec(exec: Box<dyn SendExec>, sctx: SendStreamReceiveCtx) -> Self {
-        H3SendStream { exec, sctx }
-    }
-}
-```
-
-For a pure wiring test the caller builds `sctx` with `stream_ctx_channel(state, id)`
-(keeping the `StreamSendCtx` senders so it can feed `SendEvent`s and the finish
-one-shot by hand) and passes `Box::new(CountingExec::new(handle.clone(), script))`.
-
-`CountingExec` must stay inspectable **after** it is moved behind
-`Box<dyn SendExec>`, and it must actually **retain** the submitted buffer while the
-send is outstanding (so the test can later replay the production reclamation). Both
-are achieved with a cloneable, shared handle the test keeps, plus a real
-`Box::into_raw` `client_context` slot the test feeds back through the real
-`stream_callback`:
-
-```rust
-use std::collections::VecDeque;
-use std::ffi::c_void;
-use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
-use std::sync::{Arc, Mutex, PoisonError};
-
-/// Shared, inspectable counters + client_context slots. The test keeps a clone of
-/// this handle, so every counter is readable AFTER the CountingExec is moved into
-/// H3SendStream behind Box<dyn SendExec>.
-#[derive(Clone, Debug, Default)]
-struct CountingHandle {
-    sends: Arc<AtomicUsize>,
-    gracefuls: Arc<AtomicUsize>,
-    resets: Arc<AtomicUsize>,
-    allocs: Arc<AtomicUsize>,                  // total Box<SendBuffer> created (Box::into_raw)
-    reclaims: Arc<AtomicUsize>,                // in-exec reclamations (immediate-failure arm only)
-    client_ctx: Arc<Mutex<VecDeque<usize>>>,   // raw ptrs "native" holds; the test replays each
-                                               // through stream_callback (the production reclaim path)
-}
-
-#[derive(Debug)]
-struct CountingExec {
-    h: CountingHandle,
-    script: VecDeque<Result<(), Status>>,      // scripted submit_send results
-}
-impl CountingExec {
-    fn new(h: CountingHandle, script: VecDeque<Result<(), Status>>) -> Self { Self { h, script } }
-}
-impl SendExec for CountingExec {
-    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
-        self.h.sends.fetch_add(1, Relaxed);
-        // Mirror StreamExecutor EXACTLY: box the buffer and produce its raw
-        // client_context pointer BEFORE inspecting the scripted result, so both arms
-        // model the real allocation.
-        let cc = Box::into_raw(Box::new(buf));
-        self.h.allocs.fetch_add(1, Relaxed);
-        match self.script.pop_front().unwrap_or(Ok(())) {
-            Ok(()) => {
-                // Native accepted ownership: retain the pointer so the test can replay
-                // the native SendComplete through stream_callback. The box is NOT
-                // dropped here; it is outstanding until that callback reclaims it.
-                self.h.client_ctx.lock().unwrap_or_else(PoisonError::into_inner).push_back(cc as usize);
-                Ok(())
-            }
-            Err(status) => {
-                // Immediate failure: MsQuic takes no ownership and delivers no
-                // SendComplete, so the caller reclaims here and now — exactly as
-                // StreamExecutor's immediate-Err arm does (`Box::from_raw` + drop).
-                drop(unsafe { Box::from_raw(cc) });
-                self.h.reclaims.fetch_add(1, Relaxed);
-                Err(status)
-            }
-        }
-    }
-    fn submit_graceful(&mut self) -> Result<(), Status> { self.h.gracefuls.fetch_add(1, Relaxed); Ok(()) }
-    fn submit_reset(&mut self, _c: u64) -> Result<(), Status> { self.h.resets.fetch_add(1, Relaxed); Ok(()) }
-}
-// Reclamation of an accepted send's `Box<SendBuffer>` is NOT a test-only helper: the
-// test replays the retained `client_context` through the production `stream_callback`
-// as a synthesized `StreamEvent::SendComplete`, which is the exact reconstruct+drop
-// path the binding invokes. There is deliberately no separate `reclaim_client_context`
-// shim, so the seam test verifies the real callback code and its exactly-once event.
-```
-
-`test_send_ctx` builds a send-side context with **no live connection**: a fresh
-`StreamState`, an arbitrary cached id, and the id-bearing halves from
-`stream_ctx_channel`. It returns the frontend `SendStreamReceiveCtx` together with
-the callback-owned `StreamSendCtx`; the test keeps the latter so it can both drive
-`stream_callback` and observe the `SendEvent`s it emits. Constructing a non-empty
-`WriteBuf<Bytes>` uses h3's real `From<Frame<B>>` impl (`h3` `stream.rs:181`) — the
-only public way to build a data-carrying `WriteBuf`, since `WriteBuf`'s fields are
-private and its `From` sources (`Frame`, `StreamType`, `UniStreamHeader`) are h3
-internals. h3 exposes them to backend implementers behind the
-`i-implement-a-third-party-backend-and-opt-into-breaking-changes` feature, enabled
-in `[dev-dependencies]` (see the release-gate wiring) so these tests can write
-`WriteBuf::<Bytes>::from(Frame::Data(..))` exactly as h3's own frontend does:
-
-```rust
-use bytes::Bytes;
-use std::ffi::c_void;
-use h3::proto::frame::Frame;            // gated by the backend dev-feature (see wiring)
-use h3::quic::SendStream;
-
-/// No live connection or native stream: fresh shared state + id-bearing halves.
-/// Returns (frontend send ctx, callback-owned senders). The recv half is unused.
-fn test_send_ctx() -> (SendStreamReceiveCtx, StreamSendCtx) {
-    let state = Arc::new(StreamState {
-        connection: Arc::new(ConnectionState { terminal: std::sync::Mutex::new(None) }),
-        send_terminal: std::sync::Mutex::new(None),
-    });
-    let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
-    let (ctx, sctx, _rctx) = stream_ctx_channel(state, id);
-    (sctx, ctx)
-}
-
-#[test]
-fn accepted_send_reclaims_via_callback_exactly_once() {
-    let h = CountingHandle::default();
-    let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new())); // all-Ok script
-    let (sctx, mut ctx) = test_send_ctx();                              // ctx keeps the senders
-    let mut s = H3SendStream::with_exec(exec, sctx);
-
-    // Valid WriteBuf<Bytes>: an h3 DATA frame carrying the payload, built via the
-    // real From<Frame<B>> impl. send_data classifies it NonEmpty and submits.
-    SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"hello world"))).unwrap();
-    assert_eq!(h.sends.load(Relaxed), 1);
-    assert_eq!(h.allocs.load(Relaxed), 1);              // one Box<SendBuffer> created
-    assert_eq!(h.reclaims.load(Relaxed), 0);            // not the immediate-failure arm
-    assert_eq!(h.client_ctx.lock().unwrap().len(), 1);  // outstanding: "native" holds the box
-
-    // Replay the native SendComplete through the PRODUCTION callback path: the exact
-    // stream_callback the binding invokes, fed the retained client_context pointer.
-    let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
-    stream_callback(&mut ctx, StreamEvent::SendComplete {
-        cancelled: false,
-        client_context: cc as *const c_void,
-    }).unwrap();
-
-    // The callback reconstructed+dropped the Box<SendBuffer> once and enqueued
-    // exactly one Complete; a second poll is empty -> exactly-once callback count.
-    assert!(matches!(s.sctx.send.try_next(), Ok(Some(SendEvent::Complete { cancelled: false }))));
-    assert!(s.sctx.send.try_next().is_err());           // no second event
-    assert_eq!(h.reclaims.load(Relaxed), 0);            // reclaim happened in the callback
-}
-
-#[test]
-fn immediate_send_failure_reclaims_without_completion() {
-    let h = CountingHandle::default();
-    let mut script = VecDeque::new();
-    script.push_back(Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER)));
-    let exec = Box::new(CountingExec::new(h.clone(), script));
-    let (sctx, _ctx) = test_send_ctx();
-    let mut s = H3SendStream::with_exec(exec, sctx);
-
-    // submit_send returns Err; send_data surfaces the error.
-    assert!(SendStream::<Bytes>::send_data(
-        &mut s, Frame::Data(Bytes::from_static(b"hello world"))).is_err());
-
-    // One allocation, one immediate in-exec reclamation, nothing left outstanding,
-    // and ZERO SendComplete callbacks (native took no ownership, emitted no event).
-    assert_eq!(h.sends.load(Relaxed), 1);
-    assert_eq!(h.allocs.load(Relaxed), 1);
-    assert_eq!(h.reclaims.load(Relaxed), 1);
-    assert!(h.client_ctx.lock().unwrap().is_empty());   // no outstanding box
-    assert!(s.sctx.send.try_next().is_err());           // no Complete event ever enqueued
-}
-```
-
-The reducer and its inputs reference neither trait nor either impl, so reducer
-unit tests need no executor at all; executor-wiring tests read the `CountingHandle`
-counters directly. Open-count coverage uses a `CountingOpenExec` that delegates to
-`StreamOpenExecutor` while incrementing a counter, exercised by the loopback
-conformance test (an `OpeningStream` requires a real `HQUIC`, so it cannot be
-fabricated in a pure unit test).
-
-Ownership of bytes during immediate feedback. `SendInput::SendRequested` carries
-only the payload *classification* (`SendPayload`), never `B`. The original
-generic `WriteBuf<B>` is **not** moved into the reducer; the frontend keeps it on
-its own stack. When the reducer returns `SubmitSend`, the frontend — still on the
-caller thread, still owning `WriteBuf<B>` — runs `wb.copy_to_bytes(n)` (which
-takes `&mut wb`) into `Bytes`, builds `SendBuffer`, and hands it to
-`exec.submit_send(buf)`. The `Box<SendBuffer>` (which owns the `Bytes`) is
-`Box::into_raw`'d as `client_context` inside `submit_send`. On an immediate
-`Err(status)`, `submit_send` reconstructs and drops that box before returning, so
-exactly one owner exists at all times and the reducer's `SendSubmitted(Err)`
-bookkeeping runs with the buffer already reclaimed. On `Ok`, ownership is with
-MsQuic until `SendComplete`. Thus `Bytes`/`Box<SendBuffer>` lives on the frontend
-stack until `submit_send`, then in native `client_context`; it is never inside
-`SendState` or `SendInput`.
-
-Every loop below is driven by a single mutable `input` value; `feed(x)` means
-`input = x`, so each `transition` result is fed straight back within the same
-call. `wb` is `mut` because `Buf::copy_to_bytes(&mut self, ..)` consumes it.
-
-Normative `send_data` loop:
-
-```rust
-fn send_data<T: Into<WriteBuf<B>>>(&mut self, data: T) -> Result<(), StreamErrorIncoming> {
-    use SendCommand::*;
-    let mut wb: WriteBuf<B> = data.into();               // owned on the frontend stack
-    let payload = classify(wb.remaining());              // Empty | NonEmpty{len} | Oversized{len}
-    let mut input = SendInput::SendRequested {
-        payload, terminal: load_winner(&self.sctx.state),
-    };
-    loop {
-        match transition(&mut self.sctx.reducer, input) {
-            ReturnSent              => return Ok(()),                       // Ok(()) / empty no-op
-            ReturnImmediateError(e) => return Err(convert_send_op(e)),      // oversized / misuse
-            ReturnError(t)          => return Err(convert_send(t)),         // sticky winner
-            SubmitSend => {
-                // The ONE production copy path, shared verbatim with the benchmark:
-                // `&mut wb` is a `Buf`, so this runs the identical `copy_to_bytes`.
-                let buf = buffer::copy_into_send_buffer(&mut wb);         // consumes wb's bytes
-                let res = self.exec.submit_send(buf);                     // reclaims box on Err
-                input = SendInput::SendSubmitted { result: res, terminal: load_winner(&self.sctx.state) };
-            }
-            PublishTerminal { candidate, continuation } => {
-                let winner = publish(&self.sctx.state, candidate);         // first-writer helper
-                input = SendInput::TerminalPublished { winner, continuation };
-            }
-            // The reducer never returns these for a send_data-rooted input.
-            NoOp | ReturnReady | ReturnFinished | Pending
-            | SubmitGraceful | SubmitReset(_) | RepollFinish =>
-                return Err(convert_send(SendTerminal::Internal("unexpected send_data command"))),
-        }
-    }
-}
-```
-
-`poll_ready` loop:
-
-```rust
-fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
-    use SendCommand::*;
-    // First input polls the channel; subsequent inputs are fed results.
-    let mut input = SendInput::PollReady {
-        poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
-    };
-    loop {
-        match transition(&mut self.sctx.reducer, input) {
-            Pending        => return Poll::Pending,                        // waker already registered
-            ReturnReady    => return Poll::Ready(Ok(())),
-            ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
-            PublishTerminal { candidate, continuation } => {
-                let winner = publish(&self.sctx.state, candidate);
-                input = SendInput::TerminalPublished { winner, continuation };
-            }
-            NoOp | ReturnSent | ReturnFinished | ReturnImmediateError(_)
-            | SubmitSend | SubmitGraceful | SubmitReset(_) | RepollFinish =>
-                return Poll::Ready(Err(convert_send(SendTerminal::Internal("unexpected poll_ready command")))),
-        }
-    }
-}
-```
-
-`reset` loop (infallible; stores the terminal, never returns to h3):
-
-```rust
-fn reset(&mut self, code: u64) {
-    use SendCommand::*;
-    let mut input = SendInput::Reset {
-        code: clamp_application_code(code), terminal: load_winner(&self.sctx.state),
-    };
-    loop {
-        match transition(&mut self.sctx.reducer, input) {
-            NoOp => return,                                                // already terminal
-            SubmitReset(c) => {
-                let res = self.exec.submit_reset(c);
-                input = SendInput::ResetSubmitted { code: c, result: res, terminal: load_winner(&self.sctx.state) };
-            }
-            PublishTerminal { candidate, continuation } => {
-                let winner = publish(&self.sctx.state, candidate);        // stored for a later poll
-                input = SendInput::TerminalPublished { winner, continuation };
-            }
-            // reset consumes any terminal; there is nothing to surface to h3 now.
-            ReturnError(_) | ReturnReady | ReturnFinished | ReturnSent
-            | ReturnImmediateError(_) | Pending | SubmitSend | SubmitGraceful | RepollFinish => return,
-        }
-    }
-}
-```
-
-The undefined `publish_result` from the earlier sketch is gone: the first-writer
-`publish(..)` return value is bound to `_winner` and fed straight back as
-`TerminalPublished { winner: _winner, .. }`.
-
-`poll_finish` loop (complete, with `RepollFinish` re-polling in the same call):
-
-```rust
-fn poll_finish(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), StreamErrorIncoming>> {
-    use SendCommand::*;
-    let mut input = SendInput::PollFinish {
-        poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
-    };
-    loop {
-        match transition(&mut self.sctx.reducer, input) {
-            Pending        => return Poll::Pending,
-            ReturnFinished => return Poll::Ready(Ok(())),
-            ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
-            SubmitGraceful => {
-                let res = self.exec.submit_graceful();
-                input = SendInput::GracefulSubmitted { result: res, terminal: load_winner(&self.sctx.state) };
-            }
-            RepollFinish => {
-                // Re-poll the channel in THIS call so a synchronously-queued
-                // FinishComplete is drained (or the waker re-armed) — never defer.
-                input = SendInput::PollFinish {
-                    poll: self.poll_send_channel(cx), terminal: load_winner(&self.sctx.state),
-                };
-            }
-            PublishTerminal { candidate, continuation } => {
-                let winner = publish(&self.sctx.state, candidate);
-                input = SendInput::TerminalPublished { winner, continuation };
-            }
-            NoOp | ReturnReady | ReturnSent | ReturnImmediateError(_)
-            | SubmitSend | SubmitReset(_) =>
-                return Poll::Ready(Err(convert_send(SendTerminal::Internal("unexpected poll_finish command")))),
-        }
-    }
-}
-```
-
-**Load-bearing helper bodies.** The loops above call six helpers; their exact
-bodies (so callback/channel ordering is not left to the implementer):
-
-```rust
-/// send_data length classification, against MAX_ADAPTER_SEND (not native u32::MAX).
-fn classify(remaining: usize) -> SendPayload {
-    if remaining == 0 {
-        SendPayload::Empty
-    } else if remaining as u64 > MAX_ADAPTER_SEND {
-        SendPayload::Oversized { len: remaining }
-    } else {
-        // 0 < remaining <= 16 MiB, so the u32 cast never truncates.
-        SendPayload::NonEmpty { len: remaining as u32 }
-    }
-}
-
-/// Read the current sticky send winner (poison-safe clone; None if unset).
-fn load_winner(state: &StreamState) -> Option<SendTerminal> {
-    state.send_terminal.lock().unwrap_or_else(PoisonError::into_inner).clone()
-}
-
-/// First-writer publish: install `candidate` only if the slot is empty, and return
-/// whichever value now owns the slot. Poison-safe; never overwrites an earlier
-/// winner (the callback and the frontend race into the same slot).
-fn publish(state: &StreamState, candidate: SendTerminal) -> SendTerminal {
-    let mut slot = state.send_terminal.lock().unwrap_or_else(PoisonError::into_inner);
-    slot.get_or_insert(candidate).clone()
-}
-
-/// Construct the self-referential SendBuffer from already-validated non-empty owned
-/// bytes. `BufferRef::from(&bytes[..])` casts the (<= 16 MiB) length to u32 without
-/// truncation; moving `Bytes` into the struct does not move its heap storage, so
-/// the BufferRef pointer stays valid for the box's lifetime.
-impl SendBuffer {
-    fn new(bytes: Bytes) -> SendBuffer {
-        let bref = BufferRef::from(&bytes[..]);   // points into `bytes`'s heap storage
-        SendBuffer { buffers: [bref], _bytes: bytes }
-    }
-}
-
-/// Clamp an outgoing application error code to the QUIC 62-bit varint maximum.
-/// Matches the clamp used for connection close and stop_sending: (1<<62)-1 passes
-/// unchanged, 1<<62 clamps down.
-fn clamp_application_code(code: u64) -> u64 {
-    code.min(MAX_QUIC_VARINT)   // MAX_QUIC_VARINT = (1 << 62) - 1
-}
-
-impl H3SendStream {
-    /// Poll the two send-side event sources into a single SendPoll, with a defined
-    /// priority: the send-event mpsc (data `Complete`, `TerminalWake`) is polled
-    /// FIRST, because a data completion must be observed before the graceful-finish
-    /// completion that follows it; the finish one-shot is polled only when the mpsc
-    /// yields nothing. Both wakers are registered on a `Pending` result, so no
-    /// wakeup is lost, and the priority is deterministic (no `select!` fairness).
-    fn poll_send_channel(&mut self, cx: &mut Context<'_>) -> SendPoll {
-        use futures::StreamExt;                 // poll_next_unpin (Receiver: Unpin)
-        use std::future::Future;                // oneshot::Receiver: Future + Unpin
-        match self.sctx.send.poll_next_unpin(cx) {
-            // (1) A send event is always taken ahead of the finish one-shot.
-            Poll::Ready(Some(ev)) => SendPoll::Event(ev),
-            // mpsc closed: no further send events. A finish may still be
-            // deliverable, so consult the one-shot before declaring the channel
-            // closed (a closed channel with no terminal is an adapter-internal error).
-            Poll::Ready(None) => match Pin::new(&mut self.sctx.shutdown).poll(cx) {
-                Poll::Ready(Ok(ev)) => SendPoll::Event(ev),
-                Poll::Ready(Err(_canceled)) => SendPoll::Closed,
-                Poll::Pending => SendPoll::Pending,
-            },
-            // (2) No send event yet; poll the finish one-shot.
-            Poll::Pending => match Pin::new(&mut self.sctx.shutdown).poll(cx) {
-                Poll::Ready(Ok(ev)) => SendPoll::Event(ev),     // FinishComplete
-                // No finish yet; the mpsc waker is armed, so keep waiting.
-                Poll::Ready(Err(_canceled)) | Poll::Pending => SendPoll::Pending,
-            },
-        }
-    }
-}
-```
-
-**Routing `open` through the seam.** Stream *open/start* is outside the send
-reducer (it has no `SendState`); it goes through `OpenExec::submit_open_start`,
-whose production body is `Stream::open` + `Stream::start` and whose result — the
-`OpeningStream` carrying the start receiver — is finalized by `poll_open_inner`.
-This keeps all four native verbs (`open` / `send` / `shutdown(GRACEFUL)` /
-`shutdown(ABORT_SEND)`) behind the two seams whose test doubles count them,
-replacing the earlier "private call table or small test-only probe suffices"
-language.
-
-### Callback-safety: exact per-site outcomes
-
-Every site below becomes fallible/non-panicking. "Outcome" is what the callback
-does; none may unwind through FFI.
-
-| Site (`lib.rs`/`listener.rs`/`registration.rs`) | Current | Exact outcome |
-| --- | --- | --- |
-| `connection_callback` `Connected` sender (`lib.rs:113`) | `take().unwrap().send().unwrap()` | `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Ok(())); }` — a **duplicate** `Connected` (slot already `None`) is ignored; a **missing** receiver (send `Err`) is dropped silently |
-| `connection_callback` `ShutdownInitiatedByTransport { status, .. }` / `ShutdownInitiatedByPeer { error_code }` (new arms, currently `_ => {}` at `lib.rs:137`) | none (pending `connected` only resolved by `Connected` or dropped at `ShutdownComplete`) | resolve the pending connect one-shot as a failure **before** `ShutdownComplete`: `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Err(status)); }` for transport (carries a real `Status`), and `Err(Status::new(StatusCode::QUIC_STATUS_ABORTED))` for peer (only an `error_code`). Also publish the connection terminal via the first-writer helper. Absent/duplicate → no-op |
-| `connection_callback` `PeerStreamStarted` delivery (`lib.rs:120,124`) | `.expect("cannot send")` | on `unbounded_send` `Err` after taking native ownership: drop/close the owned `H3Stream` through Rust and **return `Ok`** from the callback (post-ownership delivery failure path), so MsQuic's `HandleClosed` branch does not double-close |
-| `connection_callback` `ShutdownComplete` shutdown one-shot (`lib.rs:133`) | already `let _ =`; but pending `connected` is dropped via `ctx.connected.take()` at `lib.rs:130` | keep the waiter send as a no-op-safe `let _ =`. For `connected`: if it is *still* pending here (neither `Connected` nor a `ShutdownInitiated*` arm resolved it — e.g. a bare local close), resolve it as failure instead of a bare drop: `if let Some(tx) = ctx.connected.take() { let _ = tx.send(Err(Status::new(StatusCode::QUIC_STATUS_ABORTED))); }`, so `connect()`'s await returns `Err` deterministically rather than mapping a `Canceled` drop |
-| `stream_callback` `StartComplete` sender (`lib.rs:476-481`) | `take().unwrap()...expect` | `if let Some(tx) = ctx.start.take() { let _ = tx.send(result); }` — duplicate `StartComplete` ignored, dropped `OpeningStream` receiver ignored |
-| `stream_callback` `Receive` delivery (`lib.rs:505`) | `.expect("cannot send")` (split-receive drop panic) | this is one of the split-receive-drop panics the design removes. On a non-empty buffer, deliver `ReceiveEvent::Data(bytes)`: `if let Some(tx) = ctx.receive.as_ref() { if tx.unbounded_send(ReceiveEvent::Data(b)).is_err() { ctx.receive.take(); } }` — a **failed** delivery (frontend `H3RecvStream` dropped) drops the receiver sender so no further receive events are attempted, and **returns `Ok`**. FIN handling is gated on `flags.contains(ReceiveFlags::FIN)` (`msquic types.rs:544`): only when FIN is set does the callback publish the sticky `ReceiveEvent::Fin` (after any same-notification `Data`) and then `ctx.receive.take()`, so the reader observes the terminal rather than a bare channel close. An **empty, non-FIN** notification (zero-length buffer, `!flags.contains(FIN)`) is **non-terminal**: it publishes no event and does not take the sender, consistent with the approved rule ("Empty non-FIN receive notifications produce no event", ~line 675) |
-| `stream_callback` `SendComplete` (`lib.rs:487-492`) | `.expect("cannot send")` / `debug_assert!(false,"mem leak")` | reconstruct+drop `Box<SendBuffer>` **first** (buffer reclaimed even if receiver gone), then `if let Some(tx) = ctx.send.as_ref() { let _ = tx.unbounded_send(SendEvent::Complete{..}); }` |
-| `stream_callback` `SendShutdownComplete` (`lib.rs:518-519`) | `.expect` | `if let Some(tx) = ctx.shutdown.take() { let _ = tx.send(SendEvent::FinishComplete{graceful}); }` |
-| `listener_callback` `NewConnection` config validation (`listener.rs:65-69`) | `from_raw` → `set_configuration` → on `Err`, `drop(ConnHandle::new(inner, guard))` (closes) **and** `return Err(e)` — a **close-then-reject** that trips native `listener.c:676-680` `CXPLAT_FRE_ASSERTMSG(!HandleClosed, "App MUST not close and reject connection!")` | do `set_configuration` through the **borrowed** `ConnectionRef` *before* `from_raw`: `if let Err(e) = connection.set_configuration(config) { return Err(e); }` (the `ConnectionRef` derefs to `Connection`, `lib.rs:944`, and its `Drop` only nulls the handle — it never closes). Because ownership was **not** taken, the callback returns `Err` without any close, and native `listener.c` performs the single close via `QuicConnTransportError`. Only **after** `set_configuration` succeeds is ownership taken: `let inner = unsafe { Connection::from_raw(connection.as_raw()) };` then `Connection::attach(inner, guard)` |
-| `listener_callback` `NewConnection` delivery (`listener.rs:73`) | `.expect("cannot send")` | on `unbounded_send` `Err` **after** ownership was taken (`Connection::attach` owns the handle): drop the owned `Connection` (its `ConnHandle`/`ConnectionClose` runs — a single close) and **return `Ok`**, so the callback does not *also* return `Err` (which combined with the close would trip the same `listener.c:676-680` assert) |
-| `listener_callback` `StopComplete` end marker (`listener.rs:79`) | `.expect` | `let _ = tx.unbounded_send(None);` |
-| `listener_callback` shutdown lock+send (`listener.rs:81-85`) | `.lock().unwrap()` + `.expect` | poison-safe lock (`into_inner`), then `if let Some(tx) = lk.take() { let _ = tx.send(()); }` |
-| `Listener::shutdown` frontend (`listener.rs:144,148`) | `.lock().unwrap()` + `rx.await.expect` | poison-safe lock; on cancellation `rx.await` `Err` → treat as already-shutdown and **return** (no panic). Calling `shutdown` twice is a no-op because the receiver was taken |
-| `ConnectionShutdownWaiter::wait` (`lib.rs:217-221`) | `.expect("failed to wait...")` | `let _ = self.rx.await;` — a dropped sender (connection torn down without a clean `ShutdownComplete`) resolves the wait rather than panicking |
-| listener frontend `poll_accept` (`listener.rs:133`) | `unwrap_or(None)` | keep (already non-panicking) |
-| test-harness `sht_tx.send(()).unwrap()` (`listener.rs:310`) | `.unwrap()` | test-only; change to `let _ = sht_tx.send(());` for consistency, not FFI-reachable |
-
-Corrected `NewConnection` body (single close/accept outcome, guard preserved):
-
-```rust
-ListenerEvent::NewConnection { info: _, connection } => {
-    // `connection` is the borrowed ConnectionRef; the native handle already
-    // holds a registration rundown ref, so reserve our count now.
-    let guard = RundownGuard::new(state.clone());
-    // Validate/configure through the BORROWED ref, before taking ownership.
-    if let Err(e) = connection.set_configuration(config) {
-        // No from_raw, no close: native listener.c closes on our Err (single close).
-        drop(guard);            // release our reserved rundown count
-        return Err(e);
-    }
-    // set_configuration succeeded: NOW take ownership.
-    let inner = unsafe { msquic::Connection::from_raw(connection.as_raw()) };
-    let conn = crate::Connection::attach(inner, guard);
-    if let Some(tx) = ctx.conn.as_ref() {
-        if let Err(send_err) = tx.unbounded_send(Some(conn)) {
-            // Delivery failed after ownership: drop (single close) and return Ok,
-            // never Err — returning Err here while owned would trip the assert.
-            drop(send_err.into_inner());   // drops the owned Connection
-        }
-    }
-    Ok(())
-}
-```
-
-**`RundownState::waiters` poisonable locks (`registration.rs:62,142,159`).** The
-reviewer is correct that these remain FFI-reachable even after phase one, because
-`RundownGuard::drop` runs *inside* a native `*Close` call, and a native close can
-run while a listener/connection callback is dropping an undeliverable handle
-(the post-ownership-delivery-failure paths above call `drop(ConnHandle)` /
-`drop(Connection)` from within the callback, which triggers `ConnectionClose` →
-`RundownGuard::drop`). A poisoned `waiters` mutex would then unwind
-`self.state.waiters.lock().unwrap()` at `registration.rs:62` through FFI. All
-three sites must therefore recover poison:
-
-```rust
-// registration.rs:62  (RundownGuard::drop)
-let woken: Vec<Waker> = {
-    let mut w = self.state.waiters.lock().unwrap_or_else(PoisonError::into_inner);
-    w.map.drain().map(|(_, waker)| waker).collect()
-};
-// registration.rs:142 (WaitIdle::deregister) and :159 (WaitIdle::poll) identically:
-let mut w = this.state.waiters.lock().unwrap_or_else(PoisonError::into_inner);
-```
-
-`Waiters` holds only a `u64` and a `HashMap<u64, Waker>`; recovering the inner
-value after a poisoned poll is always safe (no torn invariant). This is added in
-implementation phase one alongside the other callback-safety edits, and a test
-poisons `waiters` (panic while holding it) then drops a `RundownGuard` to prove
-no unwind. `WaitIdle::poll`/`deregister` run on the frontend, not in a callback,
-but are converted too so a poisoned mutex never turns `wait_idle` into a panic.
-
-### Native-test mechanisms
-
-Both mechanisms below use only the **already-published `msquic 2.5.1-beta`
-public API** (the counting `SendExec` seam). They
-require **no binding change, no `[patch.crates.io]` entry, and no git-pinned
-revision** — resolving the earlier dev/test-only-vs-global-replacement
-contradiction by removing the dependency change entirely. The workspace
-`Cargo.toml` is unchanged; the only test-side additions are `#[cfg(test)]` code
-and the dev-dependencies listed in the release-gate section.
-
-**(a) Keeping a send observably outstanding.** A **real** loopback send cannot be
-held observably outstanding through the public API. Send buffering is on by default
-and cannot be disabled through the safe `Settings` builder
-(`set_SendBufferingEnabled` is enable-only, `settings.rs:133`), and MsQuic copies a
-*buffered* send into an internal buffer and immediately indicates `SEND_COMPLETE` —
-**before the submit call returns** and irrespective of peer flow-control
-backpressure (`msquic-2.5.1-beta/src/core/stream_send.c:478-534`:
-`QuicStreamSendBufferRequest` allocates an internal buffer, `CxPlatCopyMemory`s the
-payload, sets `QUIC_SEND_FLAG_BUFFERED`, and calls
-`QuicStreamIndicateEvent(SEND_COMPLETE)` synchronously). A small stream receive
-window therefore does **not** keep a buffered send outstanding. The design commits
-to a single, fully deterministic mechanism that depends on neither buffering nor
-timing:
-
-*The deterministic `CountingExec` seam (required, no native).* Drive the send-side
-seam with the `CountingExec` defined in the executor section. On an `Ok` script
-entry its `submit_send` `Box::into_raw`s the `SendBuffer` (incrementing
-`CountingHandle::allocs`) into a **retained** `client_context` slot (the shared
-`CountingHandle::client_ctx` queue) and does **not** drop the box — modelling native
-taking ownership. Because no native stream exists, no `SendComplete` ever fires on
-its own, so the slot holds **exactly one** outstanding pointer the instant the submit
-call returns and keeps it. The test then takes that retained pointer and feeds it
-back **through the production `stream_callback`, as a synthesized
-`StreamEvent::SendComplete { cancelled: false, client_context }`** — the exact
-reclamation path the binding invokes (`NonNull` check → reconstruct+drop
-`Box<SendBuffer>` → enqueue one `SendEvent::Complete`). The callback reclaims the box
-once and emits exactly one `Complete`; a second channel poll is empty, proving
-exactly-once. The outstanding→reclaimed transition is caused solely by the test's own
-step ordering; there is no loopback, no ACK, and no race. Test body:
-`accepted_send_reclaims_via_callback_exactly_once` in the executor section.
-
-*Why no loopback variant.* Because the public API cannot suppress the immediate
-buffered `SendComplete`, there is no public-API loopback configuration that keeps a
-real send outstanding at the moment the count is read. The previous "flow-control
-backpressure with a small recv window" variant is **withdrawn**: it left buffering
-enabled and would complete synchronously. The loopback conformance suite still
-covers end-to-end reclamation *ordering* (an accepted send yields exactly one
-`SendComplete`, box reclaimed once), but the *observably-outstanding* guarantee is
-proven only by the seam test.
-
-*Expected counts.* The seam test proves, in order: (1) after the submit call
-returns, `allocs` reads **1** and `client_ctx` holds exactly **one** outstanding
-pointer (one `SendBuffer` outstanding; in-exec `reclaims` still **0**); (2) feeding
-the retained `client_context` through `stream_callback` drives exactly **one**
-callback reclamation and **one** `SendEvent::Complete`; (3) a second channel poll is
-empty afterward (exactly once). If step (1) cannot read one outstanding pointer, the
-test **fails** with a setup-specific message — it is never skipped or `#[ignore]`d.
-
-**(b) Controlled immediate `Stream::send` failure.** The earlier "single
-`BufferRef` reporting `Length = u32::MAX` over a small backing allocation" idea is
-**removed**: it violates the `BufferRef` validity contract (the pointer must be
-valid for the reported length) and is UB. The async `ABORT_SEND`-then-send race is
-**removed** too, because `Stream::shutdown(ABORT_SEND)` is queued asynchronously,
-so an immediately following `Stream::send` can still succeed. The design commits to
-one safe mechanism per half:
-
-*Reducer/ownership half (required, deterministic — no native).* Script the
-`CountingExec` to return `Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER))`
-from `submit_send`. Mirroring `StreamExecutor`, `submit_send` still boxes the buffer
-(`allocs` → **1**) and then, on the scripted `Err`, reclaims it in place via
-`Box::from_raw` + drop (`reclaims` → **1**) before returning, so no pointer is ever
-retained (`client_ctx` stays empty) and **zero** `SendComplete` callbacks fire
-(native took no ownership, so no `SendEvent::Complete` is ever enqueued). `send_data`
-surfaces the error and the reducer records `SendSubmitted(Err)` with the buffer
-already reclaimed. Test body: `immediate_send_failure_reclaims_without_completion`
-in the executor section (`allocs == 1`, `reclaims == 1`, `client_ctx` empty, and the
-send-event channel yields nothing).
-
-*Loopback half (deterministic via synchronized shutdown, not a race).* Fully shut
-the connection down and **await `ShutdownComplete`** on the connection's shutdown
-one-shot, *then* call `Stream::send` on the now-dead stream. `MsQuicStreamSend`
-rejects synchronously with `QUIC_STATUS_INVALID_STATE`/`QUIC_STATUS_ABORTED`
-(connection gone), takes no ownership, and produces no `SendComplete`. Because the
-send happens strictly after the observed `ShutdownComplete`, there is no timing
-window. With the production `StreamExecutor`, `submit_send` `Box::into_raw`s the
-box, `Stream::send` returns `Err`, and `submit_send` reconstructs+drops it before
-returning: net reclamation **0** at return, **zero** `SendComplete`.
-
-Exact counts summary: accepted send → `allocs` **1**, exactly **one** `SendComplete`
-reclaiming the box once via `stream_callback`; rejected send (either half) → `allocs`
-**1**, **zero** `SendComplete`, box reclaimed in place by the immediate-failure path
-(`reclaims` **1**) within the call.
-
-### Release-gate resolution
-
-**Supported native matrix and its provenance/command coupling.** *Superseded by
-the MF-3 narrative resolution above ("MF-3 — a stronger native-version attestation
-gate"); that resolution is authoritative.* Provenance is selected by the committed
-CI matrix dimension `provenance: [native-find, native-src]`, where `native-find`
-(`= ["msquic/find"]`) and `native-src` (`= ["msquic/src"]`) are **msquic-h3**
-features and **every** build/test step runs
-`--no-default-features --features ${{ matrix.provenance }}`, so exactly one
-provenance is chosen by committed config rather than by an uncommitted
-`[dev-dependencies]`/`Cargo.toml` edit. Both provenance rows pin the **same** exact
-native version, **2.5.1** (major.minor.patch), so the `native_version_preflight`
-expected value is a single constant `[2, 5, 1]` for both. The runtime preflight
-below queries `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (`= 16777220`, `0x01000004`,
-`ffi/linux_bindings.rs:169`) into `[u32; 4]` (`[major, minor, patch, build]`) and
-**fails** the conformance job if the loaded library's first three components differ
-from the pin (the build-id component is ignored):
-
-```rust
-// tests/native_version_preflight.rs — fails the conformance job on version drift.
-const EXPECTED_MSQUIC_VERSION: [u32; 3] = [2, 5, 1];   // major, minor, patch (matrix pin)
-
-#[test]
-fn native_version_preflight() {
-    // Open a registration so the library is loaded and Api::ffi_ref() is ready.
-    let _reg = msquic::Registration::new(&msquic::RegistrationConfig::new())
-        .expect("open msquic registration");
-    // Global param; null handle. Buffer is [major, minor, patch, build].
-    let v: [u32; 4] = unsafe {
-        msquic::Api::get_param_auto::<[u32; 4]>(
-            std::ptr::null_mut(),
-            msquic::ffi::QUIC_PARAM_GLOBAL_LIBRARY_VERSION,   // 16777220
-        )
-    }
-    .expect("query GLOBAL_LIBRARY_VERSION");
-    assert_eq!(
-        [v[0], v[1], v[2]],
-        EXPECTED_MSQUIC_VERSION,
-        "linked libmsquic {:?} != pinned matrix version {:?} (build id v[3]={} ignored)",
-        v, EXPECTED_MSQUIC_VERSION, v[3],
-    );
-}
-```
-
-Test commands — the exact per-row conformance targets are the MF-3 commands above,
-each carrying the committed provenance feature so exactly one clean-checkout row is
-selected (the msquic native library is pulled in transitively by that feature, so no
-separate `--features find` is needed):
-
-```sh
-# conformance jobs (per matrix row); provenance = committed native-find/native-src
-cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} accepted_send_reclaims_via_callback_exactly_once -- --exact
-cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} immediate_send_failure_reclaims_without_completion -- --exact
-cargo test -p msquic-h3 --no-default-features --features ${{ matrix.provenance }} native_version_preflight -- --exact
-```
-
-Record OS, arch, native version, provenance (which committed `native-find`/
-`native-src` feature), and the exact command in `docs/Development.md` and link it from
-the teardown section; until that table exists the release stays gated (documentation
-gate).
-
-**`MAX_ADAPTER_SEND` benchmark harness and acceptance criterion.** The retain/
-adjust decision is a measurement. `MAX_ADAPTER_SEND = 16 MiB` is **PROVISIONAL**
-per the MF-5/T2 resolution above and is **not** ratified from the single-copy
-benchmark alone; the harness below is defined concretely, but ratification also
-requires the multi-stream measurements the MF-5/T2 decision table demands:
-
-- Harness split across TWO targets that share the ONE copy helper: (a) a Criterion
-  benchmark (`benches/send_copy.rs`) over the pure copy path
-  `bench_support::copy_into_send_buffer(&src[..])` (the gated public entry point;
-  `&[u8]` is a `Buf`, so it runs the same `copy_to_bytes` allocation production runs
-  on `&mut WriteBuf<B>`), plus a loopback throughput bench that sends N frames of
-  each size to a local echo; and (b) the deterministic peak-resident **`#[test]`**
-  below, an in-crate test with private access to `buffer::copy_into_send_buffer` (no
-  bench feature needed).
-- Payload sizes: header-only (~32 B), small body (1 KiB), medium (64 KiB), large
-  contiguous body at 1 MiB, 8 MiB, and 16 MiB (`MAX_ADAPTER_SEND`).
-- Reported metrics, per size: wall-clock per copy (source buffer prebuilt once
-  **outside** the timed window, so only `copy_into_send_buffer(&src[..])` is timed),
-  throughput (MiB/s) — **informational/relative**, no hard timing assertion in the
-  bench — and **peak resident bytes** attributable to one in-flight send, asserted
-  by the in-crate `#[test]` via `measure_peak_resident` below (a global-allocator
-  counter reset immediately before the single copy and read immediately after, so
-  the harness and all earlier allocations are excluded), since the owned-copy design
-  transiently doubles peak payload memory.
-- Acceptance criteria (all **necessary**, and NOT sufficient on their own to
-  ratify 16 MiB). (1) *Copy-time (informational)*: reported by the Criterion bench
-  relative to a same-run baseline. With the source prebuilt **once outside** the
-  timed window, the **median** of 64 timed copies is tracked against the ~10 ms
-  reference target, but that number is **advisory only** and the bench carries **no
-  hard fail** until a pinned/isolated runner exists (see MF-4 point 3). (2)
-  *Peak-resident gate (BLOCKING, in-crate `#[test]`)*: measured with source and
-  destination deliberately coexisting so the transient doubling is visible, the
-  `peak_delta` must satisfy the computable bound `peak_delta <= 2 * payload + 1 MiB`
-  (no unexpected extra copy beyond the source+destination doubling); this assertion
-  lives in the crate's own test binary, not in Criterion, so correctness never
-  depends on bench timing. **Required before the cap is ratified (MF-5/T2 gate):**
-  the multi-stream measurements the decision table demands — concurrent large-send
-  *scheduler latency* on the poll thread and *aggregate retained bytes* across N
-  concurrent streams — must also be recorded, because the per-operation cap bounds
-  neither. If the peak-resident gate fails, the copy time is unacceptable on a
-  pinned runner, or the multi-stream aggregate is unacceptable, either lower
-  `MAX_ADAPTER_SEND` to the largest size that meets all gates or open the deferred
-  internal-chunking + per-connection byte-budget design. The chosen value and the
-  measured tables are recorded in `docs/Development.md`. Until the MF-5/T2 table is
-  filled and a value chosen, the 16 MiB cap and the 10 ms budget remain
-  **provisional**, not a committed concrete default.
-
-Concrete Criterion / test-allocator Cargo wiring (added to the package
-`Cargo.toml`; the peak-resident metric needs a counting global allocator, so the
-crate's test binary installs one — under `#[cfg(test)]` — rather than pulling
-`stats_alloc`):
-
-```toml
-[features]
-# Committed bench feature: gates the public `bench_support::copy_into_send_buffer`
-# re-export so the separate Criterion crate can reach the copy path.
-bench-internals = []
-
-[dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
-# Backend-implementer feature: exposes h3's internal `Frame`/`WriteBuf` builders so
-# the CountingExec seam tests can construct a valid non-empty `WriteBuf<Bytes>`
-# (`WriteBuf::<Bytes>::from(Frame::Data(..))`). Dev-only; not enabled for consumers.
-h3 = { version = "0.0.8", features = ["i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
-
-[[bench]]
-name = "send_copy"
-harness = false                          # Criterion provides its own harness
-required-features = ["bench-internals"]  # bench needs the gated public entry point
-```
-
-```rust
-// benches/send_copy.rs — INFORMATIONAL copy-time measurement ONLY (no hard timing
-// assertion; the BLOCKING peak-resident gate is the in-crate `#[test]` below).
-fn bench_send_copy(c: &mut criterion::Criterion) {
-    use msquic_h3::bench_support::copy_into_send_buffer;   // gated public entry point
-
-    // The source is built ONCE, OUTSIDE the timed region, so Criterion times ONLY
-    // the owned copy via the public `copy_into_send_buffer(&src[..])` entry point.
-    // `&[u8]` is a `Buf`, so this drives the SAME `src.copy_to_bytes(remaining)`
-    // allocation production runs on `&mut WriteBuf<B>` (for a non-`Bytes`-backed
-    // `B` that copy allocates a fresh buffer, which this models exactly). Criterion
-    // reports per-size copy time relative to a same-run baseline; there is NO
-    // absolute 10 ms fail here — that number stays advisory until a pinned runner
-    // exists (MF-4 point 3).
-    for &size in &[32usize, 1 << 10, 64 << 10, 1 << 20, 8 << 20, 16 << 20] {
-        let src: Vec<u8> = vec![0u8; size];                          // prebuilt, NOT timed
-        c.bench_function(&format!("copy_{size}"), |b| {
-            b.iter(|| {
-                let dst = copy_into_send_buffer(&src[..]);           // TIMED: copy only
-                criterion::black_box(&dst);
-            });
-        });
-    }
-}
-
-criterion::criterion_group!(benches, bench_send_copy);
-criterion::criterion_main!(benches);
-```
-
-The deterministic peak-resident bound is the BLOCKING gate and lives in the crate's
-own test binary (private access to `copy_into_send_buffer`, no bench feature needed),
-so correctness never depends on Criterion timing. A counting global allocator is
-installed **only** for the test build (`#[cfg(test)]`), never for production:
-
-```rust
-// msquic-h3/src/buffer.rs — counting allocator + peak-resident gate, test-only.
-#[cfg(test)]
-use std::alloc::{GlobalAlloc, Layout, System};
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-
-#[cfg(test)]
-struct Counting;
-#[cfg(test)]
-static LIVE: AtomicUsize = AtomicUsize::new(0);
-#[cfg(test)]
-static PEAK: AtomicUsize = AtomicUsize::new(0);
-#[cfg(test)]
-unsafe impl GlobalAlloc for Counting {
-    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
-        let p = unsafe { System.alloc(l) };
-        if !p.is_null() {
-            let now = LIVE.fetch_add(l.size(), Ordering::Relaxed) + l.size();
-            PEAK.fetch_max(now, Ordering::Relaxed);
-        }
-        p
-    }
-    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
-        LIVE.fetch_sub(l.size(), Ordering::Relaxed);
-        unsafe { System.dealloc(p, l) };
-    }
-}
-#[cfg(test)]
-#[global_allocator]
-static A: Counting = Counting;
-
-/// Peak resident bytes attributable to ONE measured copy: reset immediately
-/// before, read immediately after. `baseline` is the live bytes just before the
-/// op; seeding PEAK to it excludes every earlier allocation (payload setup outside
-/// the closure, background statics). The op's result is returned and held until
-/// PEAK is read, so the destination buffer is live at the peak. The op must run
-/// with no other thread allocating — the test runs it on one thread, so the only
-/// allocations between reset and read are the op's own.
-#[cfg(test)]
-fn measure_peak_resident<R>(op: impl FnOnce() -> R) -> (R, usize) {
-    let baseline = LIVE.load(Ordering::SeqCst);
-    PEAK.store(baseline, Ordering::SeqCst);       // reset immediately before
-    let out = op();                               // the single measured copy path
-    let peak = PEAK.load(Ordering::SeqCst);       // read immediately after
-    (out, peak.saturating_sub(baseline))          // attributable delta, baseline excluded
-}
-
-// Blocking, deterministic; runs under ordinary `cargo test` with private access to
-// the same `copy_into_send_buffer` production uses.
-#[test]
-fn send_copy_peak_resident_bound() {
-    let payload = 16usize << 20;
-    // Source and destination MUST coexist to capture the design's transient
-    // doubling, so both are allocated inside the measured op.
-    let (held, peak_delta) = measure_peak_resident(|| {
-        let src: Vec<u8> = vec![0u8; payload];                       // source allocation
-        let dst = copy_into_send_buffer(&src[..]);                   // owned copy (private path)
-        (src, dst)                                                   // both live at read
-    });
-    std::hint::black_box(&held);
-    assert!(
-        peak_delta <= 2 * payload + (1 << 20),
-        "16 MiB per-send peak {peak_delta} exceeds 2*payload + 1 MiB ({})",
-        2 * payload + (1 << 20),
-    );
-}
-```
+## As-built implementation
+
+> The ~1,800-line "Implementation-ready definitions (round 6)" appendix that
+> formerly stood here was a **temporary pre-implementation scaffold** (MF-7 / T5).
+> Now that the redesign has landed, it has been **removed per its expiry
+> condition** (Phase 10 / implementation-order item 10). The concrete, checked
+> definitions live in the production code under `msquic-h3/src/` and its inline
+> tests; the durable as-built technical reference is
+> [`.paw/work/error-propagation/Docs.md`](../.paw/work/error-propagation/Docs.md).
+> This section promotes the load-bearing invariants the design depends on so
+> nothing is lost with the scaffold.
+
+**Where the code lives (as built).**
+
+- `msquic-h3/src/error.rs` — the scoped terminal vocabulary
+  (`ConnectionTerminal`, `ReceiveTerminal`, `SendTerminal`), the `convert_*`
+  minting boundary, outgoing application-code clamping (`clamp_application_code`,
+  `MAX_QUIC_VARINT`), the send-size ceiling (`MAX_ADAPTER_SEND`, `OversizedSend`),
+  and the pure send reducer (`transition`, `SendInput`/`SendCommand`).
+- `msquic-h3/src/buffer.rs` — the owned `SendBuffer`, `classify_send_len`, the
+  single production copy path (`copy_into_send_buffer`), and the exactly-once
+  reclamation `Drop`.
+- `msquic-h3/src/lib.rs` — the FFI callbacks, the connection terminal slot with
+  refinement/freeze-on-observation, the explicit receive events, safe stream
+  open/identity, and the `SendExec`/`OpenExec` executor seam plus the conformance
+  suite.
+- `msquic-h3/src/attest.rs` — the per-row native-version attestation gate.
+
+**Promoted invariants (design-load-bearing; realized in the code above).**
+
+1. **Single ordered send-event source (MF-1).** All order-sensitive send events
+   (data completion, terminal wake, finish completion) ride one mpsc, so
+   chronological finish-vs-terminal order is preserved by construction. There is
+   no separate finish one-shot to race.
+2. **Pure send reducer over a native-free state machine.** `transition` mutates
+   only `SendState` and emits exactly one `SendCommand` per input; the frontend
+   executor runs the command against MsQuic through the `SendExec` seam and feeds
+   the result back. The send transition table above (see "Send transition table")
+   is the authoritative specification of these transitions.
+3. **`ProvisionalAbort` refinement (MF-2).** A cancelled `SendComplete` with no
+   yet-known cause is recorded as the distinct provisional `SendTerminal::ProvisionalAbort`
+   marker, never surfaced while unobserved, refinable to a richer peer/connection
+   cause, and finalized to `Failed(QUIC_STATUS_ABORTED)` at the defined closure
+   point. A real native `Failed` (including `QUIC_STATUS_ABORTED`) is authoritative
+   and never refined.
+4. **First-writer-wins terminal scopes with bounded refinement (SF-7 / T4,
+   SF-9).** Each scope (connection/receive/send) records its terminal reason
+   once. A *provisional* cause (a `ConnectionTerminal::LocalClose`, or the send
+   `ProvisionalAbort` marker) may be refined to a more-specific peer/transport
+   cause **only while still unobserved**; observation freezes the value.
+5. **Exactly-once `SendBuffer` reclamation (SF-3).** The owned buffer is destroyed
+   exactly once — either by the callback-replayed `SendComplete` reclaiming the
+   leaked box, or by the caller on an immediate `Stream::send` failure — proven by
+   the `Drop` counter in the seam tests, never twice and never leaked.
+6. **Explicit receive events, no empty-non-FIN EOF.** Data, FIN, peer reset,
+   local `stop_sending`, and connection failure are distinct events; an empty,
+   non-FIN receive notification produces no event (it is not EOF). A clean FIN
+   maps to `Ok(None)`; a peer reset maps to `StreamTerminated`.
+7. **Per-row native-version attestation gate (MF-3).** The version gate is
+   **row-specific**: `native-find` (system-package libmsquic) expects `[2,5,8]`;
+   `native-src` (crate-built from the vendored `msquic-2.5.1-beta` source) expects
+   `[2,5,1]`; `MSQUIC_EXPECTED_VERSION` overrides per matrix cell. On Linux the
+   loaded-artifact digest (from `/proc/self/maps`) is a **blocking** part of the
+   gate. This supersedes any earlier single hard-coded `[2,5,1]` pin.
+8. **Close-time inline-drain is source-review-only (SC-007).** The unsafe
+   close-time reclamation premise is established by native-source review plus the
+   binding's uniform `close_inner` contract, **not** by an executable
+   drop-triggered teardown test (the public API cannot hold a real send stream at
+   drop). It is documented as a labelled, untested guarantee.
 
 ## Implementation order
 
@@ -4072,11 +2195,12 @@ fn send_copy_peak_resident_bound() {
 10. **Release, compatibility, and scaffold cleanup gate (resolves MF-6 and the
     MF-7/T5 expiry condition).** Before publishing, complete the compatibility
     and rollback checklist in the "MF-6 — release, versioning, migration, and
-    rollback" resolution below (crate-version decision, `CHANGELOG.md` entry,
-    migration notes), and execute the appendix cleanup checklist in the
-    scaffold banner (delete/archive the ~1,800-line appendix, promote any
-    depended-on invariant into the narrative). The release stays gated until
-    both are done.
+    rollback" resolution above (crate-version decision, `CHANGELOG.md` entry,
+    migration notes), and execute the appendix cleanup (delete/archive the
+    ~1,800-line appendix, promote any depended-on invariant into the narrative).
+    Both are done in Phase 10: the crate is bumped to `0.0.7` with a
+    `CHANGELOG.md`, and the appendix has been replaced by the "As-built
+    implementation" section above.
 
 This order fixes callback safety and the error vocabulary first, then moves each
 callback path onto it while keeping changes reviewable and bisectable.

--- a/msquic-h3/benches/send_copy.rs
+++ b/msquic-h3/benches/send_copy.rs
@@ -1,0 +1,207 @@
+//! INFORMATIONAL send-copy measurements (MF-4 / FR-012 ceiling inputs).
+//!
+//! This Criterion target is a separate crate, so it reaches the copy path only
+//! through the gated public entry point `msquic_h3::bench_support::copy_into_send_buffer`
+//! (compiled in **only** under the committed `bench-internals` feature — see the
+//! `[[bench]]` `required-features` in `Cargo.toml`). `&[u8]` is a `Buf`, so this
+//! drives the SAME `src.copy_to_bytes(remaining)` allocation production runs on
+//! `&mut WriteBuf<B>`.
+//!
+//! Three measurements, ALL informational (no hard fail here — the BLOCKING,
+//! deterministic memory gate is the in-crate `send_copy_peak_resident_bound`
+//! `#[test]`):
+//!
+//! 1. **Per-send copy cost** (Criterion): the isolated wall-time of ONE owned
+//!    copy at representative payload sizes.
+//! 2. **Aggregate send-buffer memory under concurrent streams**: hold N owned
+//!    `SendBuffer`s simultaneously (N × up-to-ceiling payloads, mirroring N
+//!    concurrent outstanding streams) and record the aggregate *retained* heap
+//!    bytes / peak. This demonstrates the design's unbounded-aggregate concern:
+//!    retained memory grows linearly in the number of in-flight sends with no
+//!    adapter-level ceiling on the sum. Feeds the FR-012 provisional-ceiling
+//!    decision (recorded, not ratified here).
+//! 3. **Scheduler/executor latency of the synchronous copy**: the wall-time the
+//!    synchronous copy blocks the calling task at representative payload sizes
+//!    (the copy runs inline on the caller's thread, so this time is the latency
+//!    it injects into the send executor before the native submit).
+//!
+//! Timing here is **informational / relative to a same-run baseline** — there is
+//! NO hard 10 ms assertion (that number stays advisory until a pinned, isolated
+//! runner exists).
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use criterion::{Criterion, black_box};
+use msquic_h3::bench_support::copy_into_send_buffer;
+
+// ── Bench-local counting allocator ──────────────────────────────────────────
+// Installed ONLY for this benchmark binary (never the library), it counts live
+// and peak heap bytes on threads that opted in via `measure_retained`, so the
+// aggregate-memory measurement is not polluted by Criterion's own allocations.
+thread_local! {
+    // `const` init is allocation-free, so reading it from inside the global
+    // allocator cannot re-enter the allocator.
+    static MEASURING: Cell<bool> = const { Cell::new(false) };
+}
+
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+struct Counting;
+
+#[inline]
+fn measuring() -> bool {
+    MEASURING.try_with(|m| m.get()).unwrap_or(false)
+}
+
+// SAFETY: forwards every request to the system allocator unchanged; the only
+// added work is bookkeeping on process-global atomics, and it never returns a
+// different pointer than `System` produced.
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(l) };
+        if !p.is_null() && measuring() {
+            let now = LIVE.fetch_add(l.size(), Ordering::Relaxed) + l.size();
+            PEAK.fetch_max(now, Ordering::Relaxed);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+        if measuring() {
+            LIVE.fetch_sub(l.size(), Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(p, l) };
+    }
+}
+
+#[global_allocator]
+static A: Counting = Counting;
+
+/// Run `op` with this-thread heap counting enabled and return
+/// `(op_result, live_delta, peak_delta)` where the deltas are bytes attributable
+/// to the op (baseline excluded). The result is returned so the caller can keep
+/// the allocations alive across the read.
+fn measure_retained<R>(op: impl FnOnce() -> R) -> (R, usize, usize) {
+    MEASURING.with(|m| m.set(true));
+    let baseline = LIVE.load(Ordering::SeqCst);
+    PEAK.store(baseline, Ordering::SeqCst);
+    let out = op();
+    let live = LIVE.load(Ordering::SeqCst);
+    let peak = PEAK.load(Ordering::SeqCst);
+    MEASURING.with(|m| m.set(false));
+    (
+        out,
+        live.saturating_sub(baseline),
+        peak.saturating_sub(baseline),
+    )
+}
+
+// ── Measurement 1: per-send copy cost (Criterion) ───────────────────────────
+fn bench_send_copy(c: &mut Criterion) {
+    // Payload sizes: header-only (~32 B), small body (1 KiB), medium (64 KiB), and
+    // large contiguous bodies up to `MAX_ADAPTER_SEND` (16 MiB).
+    for &size in &[32usize, 1 << 10, 64 << 10, 1 << 20, 8 << 20, 16 << 20] {
+        // Source built ONCE, OUTSIDE the timed region, so Criterion times ONLY the
+        // owned copy.
+        let src: Vec<u8> = vec![0u8; size];
+        c.bench_function(&format!("copy_{size}"), |b| {
+            b.iter(|| {
+                let dst = copy_into_send_buffer(black_box(&src[..])); // TIMED: copy only
+                black_box(&dst);
+            });
+        });
+    }
+}
+
+// ── Measurement 2: aggregate send-buffer memory under concurrent streams ────
+/// Hold N owned `SendBuffer`s at once (each a `per_stream`-byte payload, up to
+/// the 16 MiB ceiling) to model N concurrent outstanding streams, and report the
+/// aggregate *retained* heap bytes while all N are live. Because nothing caps the
+/// SUM of outstanding owned copies, retained memory grows linearly in N — the
+/// unbounded-aggregate concern the design flags and FR-012 must bound.
+fn measure_aggregate_memory() {
+    println!("\n=== aggregate send-buffer memory under concurrent streams (informational) ===");
+    println!("(each outstanding stream retains one owned SendBuffer of `per_stream` bytes;");
+    println!(" the adapter imposes NO ceiling on the SUM, so retained memory is unbounded in N)");
+
+    // A representative per-stream payload (256 KiB) plus a near-ceiling payload
+    // (16 MiB) so the linear, unbounded growth is visible at both scales.
+    for &per_stream in &[256usize << 10, 16usize << 20] {
+        println!(
+            "\n  per-stream payload = {per_stream} bytes ({} KiB):",
+            per_stream >> 10
+        );
+        for &n in &[1usize, 8, 64, 256] {
+            // Build the source OUTSIDE the measured region so the measurement
+            // captures only the RETAINED owned copies, not the transient source.
+            let src: Vec<u8> = vec![0u8; per_stream];
+            let (held, live, peak) = measure_retained(|| {
+                let mut bufs = Vec::with_capacity(n);
+                for _ in 0..n {
+                    // One owned SendBuffer per simulated outstanding stream; all N
+                    // are retained in `bufs` simultaneously, exactly as N in-flight
+                    // sends each hold their box until SendComplete.
+                    bufs.push(copy_into_send_buffer(black_box(&src[..])));
+                }
+                bufs
+            });
+            let expected = (n as u64) * (per_stream as u64);
+            println!(
+                "    N={n:>4} outstanding -> retained {live:>12} B, peak {peak:>12} B \
+                 (~N*payload = {expected} B)",
+            );
+            // Keep the N buffers alive until AFTER the read above, then drop.
+            drop(held);
+        }
+    }
+}
+
+// ── Measurement 3: scheduler/executor latency of the synchronous copy ───────
+/// Time the synchronous copy inline (as it runs on the caller's send-executor
+/// task) at representative payload sizes and report per-call wall-time. This is
+/// the latency the synchronous copy injects before the native submit; it stays
+/// INFORMATIONAL (no hard fail on an unpinned runner).
+fn measure_copy_latency() {
+    println!("\n=== synchronous-copy scheduler/executor latency (informational) ===");
+    println!("(wall-time the inline copy blocks the calling send task, per payload size)");
+    for &size in &[1usize << 10, 64 << 10, 1 << 20, 8 << 20, 16 << 20] {
+        let src: Vec<u8> = vec![0u8; size];
+        // Warm up so first-touch page faults / allocator arena growth don't skew
+        // the reported figure.
+        for _ in 0..8 {
+            black_box(copy_into_send_buffer(black_box(&src[..])));
+        }
+        let iters: u32 = if size >= (8 << 20) { 50 } else { 500 };
+        // Capture elapsed immediately after each copy, BEFORE the buffer is
+        // dropped, so the reported figure isolates the synchronous copy and does
+        // not include SendBuffer destruction/deallocation.
+        let mut total = std::time::Duration::ZERO;
+        for _ in 0..iters {
+            let t = Instant::now();
+            let dst = copy_into_send_buffer(black_box(&src[..]));
+            total += t.elapsed();
+            black_box(&dst);
+            // `dst` drops here, outside the measured interval.
+        }
+        let per_call = total / iters;
+        println!(
+            "  size {size:>9} B ({:>5} KiB): {per_call:>12?}/copy over {iters} iters",
+            size >> 10
+        );
+    }
+}
+
+fn main() {
+    // Print the informational aggregate-memory + latency measurements first so
+    // they appear in the CI log and can be cited in Phase-10 Development.md, then
+    // hand off to Criterion for the per-send copy-cost timing.
+    measure_aggregate_memory();
+    measure_copy_latency();
+
+    let mut criterion = Criterion::default().configure_from_args();
+    bench_send_copy(&mut criterion);
+    criterion.final_summary();
+}

--- a/msquic-h3/src/attest.rs
+++ b/msquic-h3/src/attest.rs
@@ -1,0 +1,267 @@
+//! Runtime native-library attestation gate (MF-3).
+//!
+//! Before the release conformance suite runs, [`tests::native_version_preflight`]
+//! attests the library the test process **actually loaded**, two ways:
+//!
+//! 1. **Live-handle identity (primary).** Query, through the live MsQuic handle
+//!    this process opened, `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` (`[u32; 4]` =
+//!    `[major, minor, patch, build]`) **and** `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH`
+//!    (`char[64]`, NUL-terminated). Both values are produced by code inside the
+//!    loaded image, so they attest the running library regardless of file path.
+//! 2. **Loaded-artifact digest (secondary, Linux).** Parse `/proc/self/maps` for
+//!    the `libmsquic.so*` the loader actually mapped and record its SHA-256. On
+//!    Linux this is a **blocking** part of the gate: if the loaded path/digest
+//!    cannot be resolved the attestation FAILS (a missing digest cannot attest
+//!    the loaded binary). Platforms without the digest mechanism (e.g. Windows)
+//!    are an explicit, separately-scoped skip, never a silent Linux pass.
+//!
+//! The version gate is **row-specific** (Phase 9 decision, overriding MF-3's
+//! single `[2,5,1]`): `native-find` links the system package (Linux CI installs
+//! **2.5.8**) → expect `[2,5,8]`; `native-src` builds the vendored
+//! `msquic-2.5.1-beta` source → expect `[2,5,1]`. `MSQUIC_EXPECTED_VERSION`
+//! (`"major.minor.patch"`) overrides the per-feature default so any supported
+//! matrix cell can pin its own value.
+//!
+//! This module is compiled only under `#[cfg(test)]`.
+
+use msquic::{Api, Registration, RegistrationConfig};
+
+/// Open a throwaway registration purely to force the native library to load and
+/// initialize the global API table, so the global `get_param` queries below have
+/// a live handle to answer them.
+fn ensure_loaded() -> Registration {
+    Registration::new(&RegistrationConfig::new())
+        .expect("open msquic registration to load the native library")
+}
+
+/// Query `QUIC_PARAM_GLOBAL_LIBRARY_VERSION` = `[major, minor, patch, build]`
+/// through the live handle the test process is using.
+pub(crate) fn library_version() -> [u32; 4] {
+    let _reg = ensure_loaded();
+    // SAFETY: a global param (null handle) whose FFI type is `uint32_t[4]`, which
+    // `[u32; 4]` matches exactly; the library is loaded via `_reg` above.
+    unsafe {
+        Api::get_param_auto::<[u32; 4]>(
+            std::ptr::null_mut(),
+            msquic::ffi::QUIC_PARAM_GLOBAL_LIBRARY_VERSION,
+        )
+    }
+    .expect("query QUIC_PARAM_GLOBAL_LIBRARY_VERSION")
+}
+
+/// Query `QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH` (`char[64]`, NUL-terminated) and
+/// return it as a UTF-8 string with any trailing NUL padding removed.
+pub(crate) fn library_git_hash() -> String {
+    let _reg = ensure_loaded();
+    // SAFETY: a global param (null handle) whose FFI type is `char[64]`, matched
+    // exactly by `[u8; 64]`; the library is loaded via `_reg` above.
+    let raw = unsafe {
+        Api::get_param_auto::<[u8; 64]>(
+            std::ptr::null_mut(),
+            msquic::ffi::QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH,
+        )
+    }
+    .expect("query QUIC_PARAM_GLOBAL_LIBRARY_GIT_HASH");
+    let end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+    String::from_utf8_lossy(&raw[..end]).into_owned()
+}
+
+/// Resolve the `libmsquic.so*` the loader actually mapped into this process by
+/// parsing `/proc/self/maps`, and return `(path, sha256_hex)`.
+///
+/// Ties the digest to the image the loader resolved — an installed-package digest
+/// alone would not prove the process loaded *that* file.
+#[cfg(target_os = "linux")]
+pub(crate) fn loaded_libmsquic_digest() -> Option<(String, String)> {
+    let maps = std::fs::read_to_string("/proc/self/maps").ok()?;
+    let path = maps.lines().find_map(|line| {
+        let p = line.split_whitespace().last()?;
+        // Match the mapped shared object (e.g. `libmsquic.so.2`, possibly a
+        // symlink target under `/usr/lib/...` or `$OUT_DIR/lib/...`).
+        if p.rsplit('/')
+            .next()
+            .unwrap_or(p)
+            .starts_with("libmsquic.so")
+        {
+            Some(p.to_string())
+        } else {
+            None
+        }
+    })?;
+    let bytes = std::fs::read(&path).ok()?;
+    Some((path, sha256_hex(&bytes)))
+}
+
+/// Minimal, dependency-free SHA-256 (FIPS 180-4) over a byte slice, returning the
+/// lowercase hex digest. Test-only; used solely to record the loaded-artifact
+/// digest, so it favors clarity over throughput.
+#[cfg(target_os = "linux")]
+fn sha256_hex(input: &[u8]) -> String {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    let mut h: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+
+    // Pre-processing: append 0x80, pad with zeros, then the 64-bit bit length.
+    let bit_len = (input.len() as u64).wrapping_mul(8);
+    let mut msg = input.to_vec();
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+
+    for chunk in msg.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in w.iter_mut().take(16).enumerate() {
+            *word = u32::from_be_bytes([
+                chunk[i * 4],
+                chunk[i * 4 + 1],
+                chunk[i * 4 + 2],
+                chunk[i * 4 + 3],
+            ]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut hh] = h;
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let t1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+
+        for (dst, v) in h.iter_mut().zip([a, b, c, d, e, f, g, hh]) {
+            *dst = dst.wrapping_add(v);
+        }
+    }
+
+    let mut out = String::with_capacity(64);
+    for word in h {
+        out.push_str(&format!("{word:08x}"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Row-specific expected `[major, minor, patch]`. `MSQUIC_EXPECTED_VERSION`
+    /// (`"a.b.c"`) overrides; otherwise the committed provenance feature decides.
+    fn expected_version() -> [u32; 3] {
+        if let Ok(s) = std::env::var("MSQUIC_EXPECTED_VERSION") {
+            let parts: Vec<u32> = s
+                .split('.')
+                .map(|p| {
+                    p.trim()
+                        .parse()
+                        .expect("MSQUIC_EXPECTED_VERSION component not a u32")
+                })
+                .collect();
+            assert!(
+                parts.len() >= 3,
+                "MSQUIC_EXPECTED_VERSION must be 'major.minor.patch', got {s:?}"
+            );
+            return [parts[0], parts[1], parts[2]];
+        }
+        // `native-find` and `native-src` are mutually exclusive; `cfg!` avoids the
+        // unreachable-code lint a `#[cfg]`-return ladder would trip under
+        // `-D warnings`.
+        if cfg!(feature = "native-find") {
+            [2, 5, 8]
+        } else if cfg!(feature = "native-src") {
+            [2, 5, 1]
+        } else {
+            // No provenance selected: the link step would already have failed, so
+            // this branch is only reached by `cargo check`. Keep the source pin.
+            [2, 5, 1]
+        }
+    }
+
+    /// BLOCKING native-support gate: the loaded library's major/minor/patch MUST
+    /// equal the row-specific expected version. Always records
+    /// version + git-hash + loaded-artifact digest for the job's attestation.
+    #[test]
+    fn native_version_preflight() {
+        let v = library_version();
+        let git = library_git_hash();
+        let expected = expected_version();
+
+        println!("msquic attestation: version={v:?} (major.minor.patch.build) git_hash={git:?}");
+        // Loaded-artifact digest is a BLOCKING part of the gate on Linux: a
+        // missing path/digest means we cannot attest the binary the loader
+        // actually mapped, so the gate MUST fail (a silent pass would defeat the
+        // point). Platforms where the digest mechanism is intentionally not
+        // implemented (e.g. Windows) never reach this block — that is an
+        // explicit, separately-scoped skip via `#[cfg(target_os = "linux")]`,
+        // NOT a silent pass on Linux.
+        #[cfg(target_os = "linux")]
+        {
+            let (path, digest) = loaded_libmsquic_digest().expect(
+                "msquic attestation FAILED: could not resolve the loaded libmsquic.so \
+                 path/digest from /proc/self/maps — the loaded native binary cannot be \
+                 attested, so the gate fails rather than passing silently",
+            );
+            println!("msquic loaded artifact: path={path} sha256={digest}");
+        }
+
+        assert_eq!(
+            [v[0], v[1], v[2]],
+            expected,
+            "loaded libmsquic {v:?} major/minor/patch != expected {expected:?} \
+             (build id v[3]={} ignored); check the provenance feature / \
+             MSQUIC_EXPECTED_VERSION for this matrix cell",
+            v[3]
+        );
+        assert!(!git.is_empty(), "git hash attestation must be non-empty");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sha256_known_answer() {
+        // FIPS 180-4 example vectors — guards the hand-rolled digest.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+}

--- a/msquic-h3/src/buffer.rs
+++ b/msquic-h3/src/buffer.rs
@@ -248,7 +248,7 @@ mod test {
 mod peak_alloc {
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::cell::Cell;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     thread_local! {
         // `const` init is allocation-free, so reading it from inside the global
@@ -258,6 +258,12 @@ mod peak_alloc {
 
     static LIVE: AtomicUsize = AtomicUsize::new(0);
     static PEAK: AtomicUsize = AtomicUsize::new(0);
+    /// Single-active-measurement guard (O1). The process-global `LIVE`/`PEAK`
+    /// atomics are only meaningful for one measurer at a time; a second
+    /// *concurrent* measurer would silently skew the peak. This flag makes that
+    /// misuse fail loudly instead: [`measure_peak_resident`] claims it on entry
+    /// and releases it on exit, asserting it was not already held.
+    static ACTIVE: AtomicBool = AtomicBool::new(false);
 
     struct Counting;
 
@@ -297,12 +303,19 @@ mod peak_alloc {
     /// the caller until PEAK is read, so the destination buffer is still live at
     /// the peak.
     pub(super) fn measure_peak_resident<R>(op: impl FnOnce() -> R) -> (R, usize) {
+        // O1: fail loudly if a second measurement is already active on any thread
+        // (the shared LIVE/PEAK atomics admit only one measurer at a time).
+        assert!(
+            !ACTIVE.swap(true, Ordering::SeqCst),
+            "concurrent peak_alloc measurement: LIVE/PEAK support only one active measurer"
+        );
         MEASURING.with(|m| m.set(true));
         let baseline = LIVE.load(Ordering::SeqCst);
         PEAK.store(baseline, Ordering::SeqCst); // reset immediately before
         let out = op(); // the single measured copy path
         let peak = PEAK.load(Ordering::SeqCst); // read immediately after
         MEASURING.with(|m| m.set(false));
+        ACTIVE.store(false, Ordering::SeqCst); // release the single-measurement guard
         (out, peak.saturating_sub(baseline)) // attributable delta, baseline excluded
     }
 }

--- a/msquic-h3/src/buffer.rs
+++ b/msquic-h3/src/buffer.rs
@@ -1,67 +1,177 @@
-use std::ffi::c_void;
-
-use bytes::Buf;
+use bytes::Bytes;
 use msquic::BufferRef;
 
-// Assumes buf does not free memory after advance
-pub struct H3Buff<B: Buf> {
-    inner: Box<(Vec<BufferRef>, B)>,
+use crate::error::MAX_ADAPTER_SEND;
+
+/// Classification of a `send_data` payload's `remaining()` length against the
+/// adapter's owned-copy ceiling ([`MAX_ADAPTER_SEND`]).
+///
+/// The split is against the ceiling, **not** the raw `u32` protocol maximum, so
+/// the adapter never materializes a near-`u32::MAX` owned buffer just to have
+/// MsQuic reject the aggregate. The classification is performed up front, before
+/// any allocation, so an oversized request is rejected without a copy.
+pub(crate) enum SendLen {
+    /// Zero-length payload: a successful no-op — no allocation, no native send.
+    Empty,
+    /// `0 < len <= MAX_ADAPTER_SEND`. The ceiling is below `u32::MAX`, so the
+    /// materialized length always fits the `u32` a [`BufferRef`] carries.
+    NonEmpty,
+    /// `len > MAX_ADAPTER_SEND`: reject with `OversizedSend` before any allocation.
+    Oversized,
 }
 
-impl<B: Buf> H3Buff<B> {
-    /// Convert buf slices into buffer ref
-    /// zero copy. This assumes Buf does not free memory.
-    pub fn new(inner: B) -> Self {
-        let meta = vec![];
-        let mut inner = Box::new((meta, inner));
-        while inner.1.has_remaining() {
-            let chunk = inner.1.chunk();
-            // skip 0 buff
-            if chunk.is_empty() {
-                continue;
-            }
-            inner.0.push(BufferRef::from(chunk));
-            inner.1.advance(chunk.len());
+/// Classify a payload length against [`MAX_ADAPTER_SEND`] before any allocation.
+pub(crate) fn classify_send_len(remaining: usize) -> SendLen {
+    if remaining == 0 {
+        SendLen::Empty
+    } else if remaining as u64 > MAX_ADAPTER_SEND {
+        SendLen::Oversized
+    } else {
+        SendLen::NonEmpty
+    }
+}
+
+/// An owned, self-referential send payload handed to MsQuic across the FFI
+/// boundary for the whole lifetime of one `Stream::send`.
+///
+/// `_bytes` owns the heap storage holding the complete wire representation;
+/// `buffers[0]` is a [`BufferRef`] — a `#[repr(transparent)]` wrapper over
+/// `QUIC_BUFFER { Length: u32, Buffer: *mut u8 }` — whose `Buffer` pointer aims
+/// into that heap storage, **not** into this struct. Moving a [`Bytes`] moves
+/// only its `(ptr, len, refcount)` triple and never the referenced heap bytes,
+/// so `buffers[0]` stays valid across any move of the `SendBuffer` — including
+/// `Box::into_raw` / `Box::from_raw` transferred through `client_context`. The
+/// struct is self-referential only in the weak sense that `buffers` borrows the
+/// stable heap allocation owned by `_bytes`; that allocation lives exactly as
+/// long as `_bytes`, i.e. as long as the `SendBuffer` itself.
+pub(crate) struct SendBuffer {
+    buffers: [BufferRef; 1],
+    /// Owns the heap storage that `buffers[0]` points into. Never read directly
+    /// (its leading underscore keeps the crate's `-D warnings` policy happy); it
+    /// exists purely to keep the referenced bytes alive for MsQuic's use.
+    _bytes: Bytes,
+    /// Test-only reclamation counter: incremented once when this buffer is
+    /// dropped, so a seam test can prove the `Box<SendBuffer>` is reconstructed
+    /// and dropped exactly once on the `SendComplete` / immediate-failure path.
+    #[cfg(test)]
+    drop_count: Option<std::sync::Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+// SAFETY: `_bytes` owns immutable, `Send` heap storage; `buffers` holds only
+// inert pointer/length metadata into that storage (`BufferRef` is `!Send` only
+// because of its raw `*mut u8`). The box is transferred to MsQuic through
+// `client_context` and reconstructed + dropped exactly once after `SendComplete`
+// (or reclaimed by the caller on an immediate `Stream::send` failure). No Rust
+// code accesses the bytes while native code owns the box, so dropping it on an
+// MsQuic worker thread is sound.
+unsafe impl Send for SendBuffer {}
+
+// Compile-time guard mirroring the design's `assert_impl_all!(SendBuffer: Send)`:
+// the `unsafe impl Send` above is load-bearing (the eager `Box::into_raw` ->
+// `client_context` -> `Box::from_raw` transfer launders the box through a raw
+// pointer, so the compiler cannot otherwise check the cross-thread drop).
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<SendBuffer>();
+};
+
+impl SendBuffer {
+    /// Materialize a validated, non-empty payload into an owned `SendBuffer`.
+    ///
+    /// `bytes` must be non-empty and no longer than [`MAX_ADAPTER_SEND`] (both
+    /// already guaranteed by [`classify_send_len`] at the call site), so the
+    /// `usize as u32` length cast inside `BufferRef::from` never truncates.
+    pub(crate) fn new(bytes: Bytes) -> Self {
+        debug_assert!(!bytes.is_empty(), "SendBuffer requires a non-empty payload");
+        debug_assert!(
+            bytes.len() as u64 <= MAX_ADAPTER_SEND,
+            "SendBuffer length must be within MAX_ADAPTER_SEND"
+        );
+        // Build the `BufferRef` from the heap slice *before* moving `bytes` into
+        // the struct. The pointer targets the heap allocation, which does not move
+        // when `bytes` is moved, so the reference stays valid for the struct's
+        // whole life (including after the struct is boxed and its box leaked).
+        let buffer = BufferRef::from(&bytes[..]);
+        Self {
+            buffers: [buffer],
+            _bytes: bytes,
+            #[cfg(test)]
+            drop_count: None,
         }
-        Self { inner }
     }
 
-    /// detach
-    /// # Safety
-    /// Must be reattached
-    pub unsafe fn into_raw(self) -> (&'static [BufferRef], *mut c_void) {
-        let inner = self.inner;
-        // unsafe buffers.
-        let buffers = unsafe { std::slice::from_raw_parts(inner.0.as_ptr(), inner.0.len()) };
-        let ptr = Box::into_raw(inner) as *mut _;
-        (buffers, ptr)
+    /// The single `BufferRef` slice to hand to `Stream::send`.
+    pub(crate) fn buffers(&self) -> &[BufferRef] {
+        &self.buffers
     }
+}
 
-    /// attach
-    /// # Safety
-    /// ptr must from into_raw
-    pub unsafe fn from_raw(ptr: *mut c_void) -> Self {
-        let inner = unsafe { Box::from_raw(ptr as *mut (Vec<BufferRef>, B)) };
-        Self { inner }
+#[cfg(test)]
+impl SendBuffer {
+    /// Test constructor attaching a reclamation counter incremented on drop.
+    pub(crate) fn new_counted(
+        bytes: Bytes,
+        counter: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Self {
+        let mut sb = Self::new(bytes);
+        sb.drop_count = Some(counter);
+        sb
+    }
+}
+
+#[cfg(test)]
+impl Drop for SendBuffer {
+    fn drop(&mut self) {
+        if let Some(c) = &self.drop_count {
+            c.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use bytes::{Buf, Bytes, buf::Chain};
+    use bytes::Bytes;
 
-    use super::H3Buff;
+    use super::{SendBuffer, SendLen, classify_send_len};
+    use crate::error::MAX_ADAPTER_SEND;
 
     #[test]
-    fn buff_test() {
-        let b = Bytes::from("hello").chain(Bytes::from("world"));
-        let wrap = H3Buff::new(b);
-        let (buff_ref, ptr) = unsafe { wrap.into_raw() };
-        assert_eq!(buff_ref.len(), 2);
-        assert_eq!(buff_ref[0].as_bytes(), b"hello");
-        assert_eq!(buff_ref[1].as_bytes(), b"world");
-        let wrap2: H3Buff<Chain<Bytes, Bytes>> = unsafe { H3Buff::from_raw(ptr) };
-        assert_eq!(wrap2.inner.0[0].as_bytes(), b"hello");
-        assert_eq!(wrap2.inner.0[1].as_bytes(), b"world");
+    fn classify_send_len_boundaries() {
+        assert!(matches!(classify_send_len(0), SendLen::Empty));
+        assert!(matches!(classify_send_len(1), SendLen::NonEmpty));
+        assert!(matches!(
+            classify_send_len(MAX_ADAPTER_SEND as usize),
+            SendLen::NonEmpty
+        ));
+        assert!(matches!(
+            classify_send_len(MAX_ADAPTER_SEND as usize + 1),
+            SendLen::Oversized
+        ));
+    }
+
+    #[test]
+    fn send_buffer_pointer_stable_after_boxing() {
+        let bytes = Bytes::from_static(b"helloworld");
+        let expected_ptr = bytes.as_ptr();
+        let expected_len = bytes.len();
+
+        let sb = SendBuffer::new(bytes);
+        assert_eq!(sb.buffers().len(), 1);
+        assert_eq!(sb.buffers()[0].as_bytes(), b"helloworld");
+        assert_eq!(sb.buffers()[0].as_bytes().as_ptr(), expected_ptr);
+        assert_eq!(sb.buffers()[0].as_bytes().len(), expected_len);
+
+        // Move into a Box exactly as the send executor does, hand out the raw
+        // pointer, then observe the BufferRef through it: the payload pointer and
+        // length must survive the move into the box unchanged.
+        let raw = Box::into_raw(Box::new(sb));
+        // SAFETY: `raw` came from `Box::into_raw` above and is not aliased.
+        let bufs = unsafe { (*raw).buffers() };
+        assert_eq!(bufs[0].as_bytes(), b"helloworld");
+        assert_eq!(bufs[0].as_bytes().as_ptr(), expected_ptr);
+        assert_eq!(bufs[0].as_bytes().len(), expected_len);
+        // Reclaim exactly once (mirrors the SendComplete / immediate-failure path).
+        // SAFETY: `raw` is the pointer from `Box::into_raw`, reclaimed once here.
+        drop(unsafe { Box::from_raw(raw) });
     }
 }

--- a/msquic-h3/src/buffer.rs
+++ b/msquic-h3/src/buffer.rs
@@ -1,4 +1,4 @@
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use msquic::BufferRef;
 
 use crate::error::MAX_ADAPTER_SEND;
@@ -34,6 +34,13 @@ pub(crate) fn classify_send_len(remaining: usize) -> SendLen {
 /// An owned, self-referential send payload handed to MsQuic across the FFI
 /// boundary for the whole lifetime of one `Stream::send`.
 ///
+/// The type is `pub` **only** so the crate-private [`copy_into_send_buffer`]
+/// helper (also `pub`) can appear in a public signature that the committed
+/// `bench-internals` feature re-exports via `crate::bench_support`; the enclosing
+/// `mod buffer` is never `pub`, so neither the type's name nor `SendBuffer::new`
+/// is nameable outside the crate. A bench can only *bind* the returned value by
+/// inference — it can never write the path `buffer::SendBuffer`.
+///
 /// `_bytes` owns the heap storage holding the complete wire representation;
 /// `buffers[0]` is a [`BufferRef`] — a `#[repr(transparent)]` wrapper over
 /// `QUIC_BUFFER { Length: u32, Buffer: *mut u8 }` — whose `Buffer` pointer aims
@@ -44,7 +51,7 @@ pub(crate) fn classify_send_len(remaining: usize) -> SendLen {
 /// struct is self-referential only in the weak sense that `buffers` borrows the
 /// stable heap allocation owned by `_bytes`; that allocation lives exactly as
 /// long as `_bytes`, i.e. as long as the `SendBuffer` itself.
-pub(crate) struct SendBuffer {
+pub struct SendBuffer {
     buffers: [BufferRef; 1],
     /// Owns the heap storage that `buffers[0]` points into. Never read directly
     /// (its leading underscore keeps the crate's `-D warnings` policy happy); it
@@ -104,6 +111,24 @@ impl SendBuffer {
     pub(crate) fn buffers(&self) -> &[BufferRef] {
         &self.buffers
     }
+}
+
+/// The ONE production copy path: consume the complete [`Buf`] into an owned
+/// [`SendBuffer`] via a single `copy_to_bytes` allocation.
+///
+/// Production `send_data` calls this with `&mut WriteBuf<B>` and the Criterion
+/// bench calls it with `&[u8]`; both implement [`Buf`], so both drive the
+/// identical `src.copy_to_bytes(remaining)` allocation — the benchmark measures
+/// the exact production copy, not a second implementation. The caller must have
+/// already classified the payload as non-empty and within [`MAX_ADAPTER_SEND`]
+/// (via [`classify_send_len`]), matching [`SendBuffer::new`]'s contract.
+///
+/// The helper is `pub` (inside the crate-private `mod buffer`) so a gated
+/// `pub use` under the `bench-internals` feature can re-export it; without that
+/// feature it stays unreachable outside the crate.
+pub fn copy_into_send_buffer(mut src: impl Buf) -> SendBuffer {
+    let remaining = src.remaining();
+    SendBuffer::new(src.copy_to_bytes(remaining))
 }
 
 #[cfg(test)]
@@ -173,5 +198,111 @@ mod test {
         // Reclaim exactly once (mirrors the SendComplete / immediate-failure path).
         // SAFETY: `raw` is the pointer from `Box::into_raw`, reclaimed once here.
         drop(unsafe { Box::from_raw(raw) });
+    }
+
+    #[test]
+    fn copy_into_send_buffer_copies_full_payload() {
+        // `&[u8]` is a `Buf`, exactly the shape the bench drives; assert the owned
+        // copy reproduces the source bytes contiguously in one `BufferRef`.
+        let src: &[u8] = b"the one production copy path";
+        let sb = super::copy_into_send_buffer(src);
+        assert_eq!(sb.buffers().len(), 1);
+        assert_eq!(sb.buffers()[0].as_bytes(), src);
+    }
+
+    #[test]
+    fn send_copy_peak_resident_bound() {
+        // BLOCKING deterministic memory gate (MF-4 point 3): peak resident bytes
+        // attributable to ONE send-copy must not exceed the transient
+        // source+destination doubling plus 1 MiB slack. Thread-scoped counting
+        // (see `peak_alloc`) makes this independent of concurrent test threads.
+        let payload = 16usize << 20;
+        // Source and destination MUST coexist to capture the design's transient
+        // doubling, so both are allocated inside the measured op.
+        let (held, peak_delta) = super::peak_alloc::measure_peak_resident(|| {
+            let src: Vec<u8> = vec![0u8; payload]; // source allocation
+            let dst = super::copy_into_send_buffer(&src[..]); // owned copy (private path)
+            (src, dst) // both live at read
+        });
+        std::hint::black_box(&held);
+        let bound = 2 * payload + (1 << 20);
+        assert!(
+            peak_delta <= bound,
+            "16 MiB per-send peak {peak_delta} exceeds 2*payload + 1 MiB ({bound})"
+        );
+        // A meaningful lower bound too: the single owned copy alone is >= payload,
+        // so a zero/near-zero delta would mean the counter never observed the copy.
+        assert!(
+            peak_delta >= payload,
+            "peak {peak_delta} below one payload ({payload}): allocator counter missed the copy"
+        );
+    }
+}
+
+/// Thread-scoped counting global allocator, installed **only** for the crate's
+/// test binary (`#[cfg(test)]`), never for production. Only allocations made on a
+/// thread that has opted in via [`peak_alloc::measure_peak_resident`] are counted,
+/// so the peak-resident gate is deterministic regardless of how many other test
+/// threads allocate concurrently.
+#[cfg(test)]
+mod peak_alloc {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::cell::Cell;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    thread_local! {
+        // `const` init is allocation-free, so reading it from inside the global
+        // allocator cannot re-enter the allocator.
+        static MEASURING: Cell<bool> = const { Cell::new(false) };
+    }
+
+    static LIVE: AtomicUsize = AtomicUsize::new(0);
+    static PEAK: AtomicUsize = AtomicUsize::new(0);
+
+    struct Counting;
+
+    #[inline]
+    fn measuring() -> bool {
+        MEASURING.try_with(|m| m.get()).unwrap_or(false)
+    }
+
+    // SAFETY: forwards every request to the system allocator unchanged; the only
+    // added work is bookkeeping on process-global atomics, and it never returns a
+    // different pointer than `System` produced.
+    unsafe impl GlobalAlloc for Counting {
+        unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+            let p = unsafe { System.alloc(l) };
+            if !p.is_null() && measuring() {
+                let now = LIVE.fetch_add(l.size(), Ordering::Relaxed) + l.size();
+                PEAK.fetch_max(now, Ordering::Relaxed);
+            }
+            p
+        }
+        unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+            if measuring() {
+                LIVE.fetch_sub(l.size(), Ordering::Relaxed);
+            }
+            unsafe { System.dealloc(p, l) };
+        }
+    }
+
+    #[global_allocator]
+    static A: Counting = Counting;
+
+    /// Peak resident bytes attributable to ONE measured op on the CURRENT thread.
+    ///
+    /// Counting is enabled only for this thread and only for the op's duration, so
+    /// the returned delta excludes every earlier allocation and every allocation
+    /// on other (parallel) test threads. The op's result is returned and held by
+    /// the caller until PEAK is read, so the destination buffer is still live at
+    /// the peak.
+    pub(super) fn measure_peak_resident<R>(op: impl FnOnce() -> R) -> (R, usize) {
+        MEASURING.with(|m| m.set(true));
+        let baseline = LIVE.load(Ordering::SeqCst);
+        PEAK.store(baseline, Ordering::SeqCst); // reset immediately before
+        let out = op(); // the single measured copy path
+        let peak = PEAK.load(Ordering::SeqCst); // read immediately after
+        MEASURING.with(|m| m.set(false));
+        (out, peak.saturating_sub(baseline)) // attributable delta, baseline excluded
     }
 }

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -170,7 +170,6 @@ impl ConnectionTerminal {
 
 /// Why a receive half terminated. The first writer wins for the receive scope.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // recorded on the receive path in Phase 4
 pub(crate) enum ReceiveTerminal {
     /// Clean end of stream (peer FIN / send-shutdown).
     Fin,
@@ -244,7 +243,6 @@ pub(crate) fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
 /// Convert a [`ReceiveTerminal`] into the h3 receive outcome it represents.
 ///
 /// A clean FIN maps to `Ok(None)`; every other terminal maps to an error.
-#[allow(dead_code)] // wired at the receive polling boundary in Phase 4
 pub(crate) fn convert_recv(
     t: ReceiveTerminal,
 ) -> Result<Option<bytes::Bytes>, StreamErrorIncoming> {

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -130,9 +130,11 @@ impl std::error::Error for LocalStreamReset {}
 // the polling boundary via the `convert_*` helpers below.
 // ---------------------------------------------------------------------------
 
-/// Why a connection terminated. The first writer wins for the connection scope.
+/// Why a connection terminated. The first writer wins for the connection scope,
+/// except a *provisional* cause may be refined to a more specific peer/transport
+/// cause before the terminal is externally observed (see
+/// [`ConnectionTerminal::is_provisional`]).
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // recorded in the connection terminal slot in Phase 3
 pub(crate) enum ConnectionTerminal {
     /// Peer closed with an HTTP/3 application error code.
     PeerApplication(u64),
@@ -148,7 +150,22 @@ pub(crate) enum ConnectionTerminal {
     /// Local application-initiated close.
     LocalClose,
     /// Internal adapter failure.
+    #[allow(dead_code)] // constructed by the accepted-stream fail-fast path in Phase 5
     Internal(&'static str),
+}
+
+impl ConnectionTerminal {
+    /// Whether this cause is *provisional* and may still be refined.
+    ///
+    /// A provisional cause (a local close, or — in later phases — a generic
+    /// transport fallback derived without a specific reason) may be replaced by
+    /// a subsequently-published, more-specific peer/transport cause until the
+    /// terminal has been externally observed. Specific peer/transport causes and
+    /// internal failures are authoritative and never refine to a provisional
+    /// value. See the SF-7 / T4 refinement decision in `docs/error-propagation.md`.
+    pub(crate) fn is_provisional(&self) -> bool {
+        matches!(self, ConnectionTerminal::LocalClose)
+    }
 }
 
 /// Why a receive half terminated. The first writer wins for the receive scope.
@@ -189,7 +206,6 @@ pub(crate) enum SendTerminal {
 // ---------------------------------------------------------------------------
 
 /// Convert a [`ConnectionTerminal`] into the h3 connection error it represents.
-#[allow(dead_code)] // wired at the connection polling boundary in Phase 3
 pub(crate) fn convert_conn(t: ConnectionTerminal) -> ConnectionErrorIncoming {
     use ConnectionTerminal as C;
     match t {

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -24,9 +24,8 @@ use crate::msquic::Status;
 pub const MAX_QUIC_VARINT: u64 = (1 << 62) - 1;
 
 /// Maximum single `send_data` payload the adapter will accept before rejecting
-/// with [`OversizedSend`]. Provisional value (16 MiB); the enforcement site is
-/// wired in Phase 6.
-#[allow(dead_code)] // referenced by OversizedSend Display; enforced in Phase 6
+/// with [`OversizedSend`]. Provisional value (16 MiB); enforced by the send-length
+/// classification in [`crate::buffer`] and the `send_data` rejection site.
 pub const MAX_ADAPTER_SEND: u64 = 16 * 1024 * 1024;
 
 /// Clamp an outgoing application error code to the QUIC 62-bit varint maximum.
@@ -47,10 +46,9 @@ pub(crate) fn clamp_application_code(code: u64) -> u64 {
 // ---------------------------------------------------------------------------
 
 /// A `send_data` payload above [`MAX_ADAPTER_SEND`]. One-shot; never stored in
-/// the shared send-terminal slot. Constructed at the send-rejection site in
-/// Phase 6.
+/// the shared send-terminal slot. Constructed at the `send_data` rejection site
+/// and boxed into `StreamErrorIncoming::Unknown`.
 #[derive(Debug)]
-#[allow(dead_code)] // constructed at the send-rejection site in Phase 6
 pub struct OversizedSend {
     /// Requested payload length in bytes (the `remaining()` that was rejected).
     pub len: usize,

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -15,7 +15,7 @@ use std::fmt;
 
 use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
 
-use crate::msquic::Status;
+use crate::msquic::{Status, StatusCode};
 
 /// Maximum value representable by a QUIC 62-bit variable-length integer.
 ///
@@ -106,7 +106,6 @@ impl std::error::Error for LocalConnectionClose {}
 /// `StreamTerminated`: h3 should not poll a reset send stream, and if it does we
 /// surface this rather than pretending the peer terminated the stream.
 #[derive(Debug)]
-#[allow(dead_code)] // constructed by convert_send / reset() in Phase 7
 pub struct LocalStreamReset {
     /// The (already-clamped) local reset code.
     pub code: u64,
@@ -179,9 +178,13 @@ pub(crate) enum ReceiveTerminal {
     Internal(&'static str),
 }
 
-/// Why a send half terminated. The first writer wins for the send scope.
+/// Why a send half terminated. The first writer wins for the send scope, except
+/// the distinct *provisional* cancellation marker ([`SendTerminal::ProvisionalAbort`],
+/// synthesized for a cancelled `SendComplete` with no yet-known cause, MF-2)
+/// which may be refined to a more-specific peer/connection cause — or finalized
+/// to an authoritative [`SendTerminal::Failed`] abort at the closure point —
+/// while it is still unobserved.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // recorded on the send path in Phases 6-7
 pub(crate) enum SendTerminal {
     /// Peer sent `STOP_SENDING` with the given code.
     Stopped(u64),
@@ -189,10 +192,36 @@ pub(crate) enum SendTerminal {
     Connection(ConnectionTerminal),
     /// Local `reset(code)` (already clamped). Not a peer termination.
     LocalReset(u64),
-    /// A native send/start failure carrying its status.
+    /// A native send/start failure carrying its status. Authoritative: even a
+    /// native `QUIC_STATUS_ABORTED` here is a *real* failure, never refinable.
     Failed(Status),
+    /// A *provisional*, still-refinable cancellation synthesized for a cancelled
+    /// `SendComplete` that arrived with no published peer/connection cause (MF-2).
+    /// It is deliberately distinct from a real [`SendTerminal::Failed`]: only this
+    /// marker is refinable, it is never surfaced to the caller (it stays
+    /// unobserved), and it is finalized to `Failed(QUIC_STATUS_ABORTED)` at the
+    /// defined closure point when no richer cause has appeared.
+    ProvisionalAbort,
     /// Internal adapter failure.
     Internal(&'static str),
+}
+
+impl SendTerminal {
+    /// Whether this cause is the *provisional* send cancellation marker that may
+    /// still be refined to a more-specific cause (MF-2).
+    ///
+    /// Only [`SendTerminal::ProvisionalAbort`] is provisional. A specific peer
+    /// `Stopped`, a `Connection` reason, a `LocalReset`, an internal failure, or
+    /// **any** `Failed` status (including a real native `QUIC_STATUS_ABORTED`) is
+    /// authoritative and never refined. See MF-2 in `docs/error-propagation.md`.
+    pub(crate) fn is_provisional(&self) -> bool {
+        matches!(self, SendTerminal::ProvisionalAbort)
+    }
+}
+
+/// The synthesized status for an unclassified send cancellation.
+pub(crate) fn aborted_status() -> Status {
+    Status::new(StatusCode::QUIC_STATUS_ABORTED)
 }
 
 // ---------------------------------------------------------------------------
@@ -222,7 +251,6 @@ pub(crate) fn convert_conn(t: ConnectionTerminal) -> ConnectionErrorIncoming {
 }
 
 /// Convert a [`SendTerminal`] into the h3 stream error it represents.
-#[allow(dead_code)] // wired at the send polling boundary in Phase 7
 pub(crate) fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
     use SendTerminal as S;
     match t {
@@ -232,6 +260,10 @@ pub(crate) fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
         },
         S::LocalReset(code) => StreamErrorIncoming::Unknown(Box::new(LocalStreamReset { code })),
         S::Failed(status) => StreamErrorIncoming::Unknown(Box::new(status)),
+        // A provisional marker is never surfaced to the caller while unobserved;
+        // if it is ever converted (a defensive, non-panicking fallback) it maps to
+        // the same authoritative aborted status its closure-point finalization uses.
+        S::ProvisionalAbort => StreamErrorIncoming::Unknown(Box::new(aborted_status())),
         S::Internal(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
             connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
         },
@@ -254,6 +286,583 @@ pub(crate) fn convert_recv(
         R::Internal(msg) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
             connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
         }),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Send-side reducer (Phase 7).
+//
+// A pure, native-free state machine for the send half. It mutates only
+// [`SendState`] and emits one [`SendCommand`] per input; the frontend executor
+// loops (in `lib.rs`) run the returned command against MsQuic through the
+// [`crate::SendExec`] seam and feed results straight back. Keeping the reducer
+// pure makes every transition exhaustively table-testable with no native handle.
+// See the "Send transitions" / reducer sections of `docs/error-propagation.md`.
+// ---------------------------------------------------------------------------
+
+/// One order-sensitive send event. All send events (data completion, terminal
+/// wake, finish completion) ride a **single** mpsc so chronological finish-vs-
+/// terminal order is preserved by construction (MF-1).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SendEvent {
+    /// A native `SendComplete` for an outstanding data send; `cancelled` is the
+    /// native cancel flag.
+    Complete { cancelled: bool },
+    /// A terminal wake: a peer `STOP_SENDING` or connection shutdown published a
+    /// sticky [`SendTerminal`] into the shared slot and woke the send half.
+    TerminalWake,
+    /// A `SendShutdownComplete`: the graceful (or aborted) finish completed.
+    FinishComplete { graceful: bool },
+}
+
+/// Reducer bookkeeping for the send half. `*_submitting` are transaction
+/// reservations set before a native call so a reentrant/repeated input cannot
+/// emit a second submission; each clears when its matching `*Submitted` arrives.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct SendState {
+    /// A data `SubmitSend` was issued; awaiting `SendSubmitted`.
+    pub(crate) send_submitting: bool,
+    /// A data send is committed and awaiting its `SendComplete`.
+    pub(crate) send_inprogress: bool,
+    /// A `SubmitGraceful` was issued; awaiting `GracefulSubmitted`.
+    pub(crate) finish_submitting: bool,
+    /// Graceful shutdown was submitted (committed on `GracefulSubmitted(Ok)`).
+    pub(crate) finish_started: bool,
+    /// The graceful finish completed (absorbing success).
+    pub(crate) finish_complete: bool,
+    /// A `SubmitReset` was issued; awaiting `ResetSubmitted`.
+    pub(crate) reset_submitting: bool,
+}
+
+impl SendState {
+    /// A fresh, all-false state.
+    pub(crate) fn new() -> Self {
+        SendState::default()
+    }
+
+    /// A native submission is reserved but its `*Submitted` result has not arrived.
+    pub(crate) fn submission_reserved(&self) -> bool {
+        self.send_submitting || self.finish_submitting || self.reset_submitting
+    }
+}
+
+/// Which frontend method initiated a `PublishTerminal`, so the reducer can pick
+/// the correct continuation once the first-writer winner is known.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TerminalContinuation {
+    SendData,
+    PollReady,
+    PollFinish,
+    Reset,
+}
+
+/// Outcome of polling the single send-event channel. `Closed` (a channel closed
+/// with no terminal item) is an adapter-internal fault, distinct from `Pending`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SendPoll {
+    Pending,
+    Event(SendEvent),
+    Closed,
+}
+
+/// `send_data` payload classification, computed from `remaining()` before any
+/// owned bytes are materialized. The `NonEmpty`/`Oversized` split is against
+/// [`MAX_ADAPTER_SEND`], not the raw native `u32::MAX`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SendPayload {
+    Empty,
+    NonEmpty { len: u32 },
+    Oversized { len: usize },
+}
+
+/// One-shot, non-sticky adapter error for `send_data`. Never stored in the
+/// shared slot; a later `poll_ready` is unaffected.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SendOperationError {
+    OversizedSend { len: usize },
+    Misuse(&'static str),
+}
+
+/// Inputs to [`transition`]. Each `terminal` field is the current shared winner
+/// the caller loaded from the send-terminal slot (poison-safe).
+#[derive(Clone, Debug)]
+pub(crate) enum SendInput {
+    /// A `send_data` request; `payload` is classified before allocation.
+    SendRequested {
+        payload: SendPayload,
+        terminal: Option<SendTerminal>,
+    },
+    /// Immediate result of the `SubmitSend` native call.
+    SendSubmitted {
+        result: Result<(), Status>,
+        terminal: Option<SendTerminal>,
+    },
+    /// A `poll_ready` request, carrying the send-channel poll outcome.
+    PollReady {
+        poll: SendPoll,
+        terminal: Option<SendTerminal>,
+    },
+    /// A `poll_finish` request, carrying the send-channel poll outcome.
+    PollFinish {
+        poll: SendPoll,
+        terminal: Option<SendTerminal>,
+    },
+    /// A `reset(code)` request (code already clamped).
+    Reset {
+        code: u64,
+        terminal: Option<SendTerminal>,
+    },
+    /// Immediate result of a `SubmitGraceful` native call.
+    GracefulSubmitted {
+        result: Result<(), Status>,
+        terminal: Option<SendTerminal>,
+    },
+    /// Immediate result of a `SubmitReset` native call.
+    ResetSubmitted {
+        code: u64,
+        result: Result<(), Status>,
+        terminal: Option<SendTerminal>,
+    },
+    /// The actual winner returned by the first-writer publish helper, fed back
+    /// after a `PublishTerminal` command, tagged with its initiating method.
+    TerminalPublished {
+        winner: SendTerminal,
+        continuation: TerminalContinuation,
+    },
+}
+
+/// Commands emitted by [`transition`]. The frontend executor loop runs each and
+/// feeds the result back as a further [`SendInput`].
+#[derive(Clone, Debug)]
+pub(crate) enum SendCommand {
+    /// `Poll::Pending`; the caller has already registered the waker.
+    Pending,
+    /// Infallible no-op (e.g. `reset` after a terminal).
+    NoOp,
+    /// `send_data` success / no-op (empty payload); no bytes submitted.
+    ReturnSent,
+    /// Construct the allocation and call `submit_send`; result -> `SendSubmitted`.
+    SubmitSend,
+    /// Call `submit_graceful`; result -> `GracefulSubmitted`.
+    SubmitGraceful,
+    /// Call `submit_reset(code)`; result -> `ResetSubmitted`.
+    SubmitReset(u64),
+    /// Re-poll the send channel and feed a fresh `PollFinish` in the SAME call,
+    /// so a synchronously-queued `FinishComplete` is drained (or the waker is
+    /// re-armed) before `Pending`.
+    RepollFinish,
+    /// Re-poll the send channel and feed a fresh `PollReady` in the SAME call.
+    /// Emitted after retaining an unobserved provisional cancellation (MF-2): it
+    /// drains a synchronously-queued paired terminal / channel close (the closure
+    /// point) or re-arms the waker before `Pending`, so the provisional value is
+    /// never returned to the caller.
+    RepollReady,
+    /// Publish a local terminal candidate via the first-writer helper; the
+    /// resolved winner is fed back as `TerminalPublished { winner, continuation }`.
+    PublishTerminal {
+        candidate: SendTerminal,
+        continuation: TerminalContinuation,
+    },
+    /// Return a one-shot, non-sticky `send_data` error (oversized / misuse).
+    ReturnImmediateError(SendOperationError),
+    /// `poll_ready` success (`Poll::Ready(Ok(()))`).
+    ReturnReady,
+    /// `poll_finish` success (`Poll::Ready(Ok(()))`).
+    ReturnFinished,
+    /// A terminal winner surfaced to the caller as an error.
+    ReturnError(SendTerminal),
+}
+
+/// Convert a one-shot [`SendOperationError`] into the h3 error `send_data`
+/// returns. Never stored in the shared slot.
+pub(crate) fn convert_send_op(e: SendOperationError) -> StreamErrorIncoming {
+    match e {
+        SendOperationError::OversizedSend { len } => {
+            StreamErrorIncoming::Unknown(Box::new(OversizedSend { len }))
+        }
+        SendOperationError::Misuse(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
+        },
+    }
+}
+
+/// The winner only if it is an *authoritative* (non-provisional) cause. A
+/// provisional cancellation marker ([`SendTerminal::ProvisionalAbort`], MF-2) is
+/// treated as "no definitive winner yet": it is never surfaced to the caller and
+/// never freezes the slot, so an authoritative local candidate (a specific cause,
+/// a `LocalReset`, or the closure-point abort) refines it instead.
+fn definitive(terminal: &Option<SendTerminal>) -> Option<SendTerminal> {
+    terminal.clone().filter(|w| !w.is_provisional())
+}
+
+/// Whether an unobserved provisional cancellation marker is currently retained in
+/// the shared slot (MF-2). Drives the closure-point decisions in the event arms.
+fn provisional_pending(terminal: &Option<SendTerminal>) -> bool {
+    terminal.as_ref().is_some_and(SendTerminal::is_provisional)
+}
+
+/// Pure, native-free send transition. Mutates only `state`; emits one command.
+///
+/// One exhaustive `match` in the normative precedence order: `*Submitted`
+/// bookkeeping first (always clears its reservation before any winner), then
+/// absorbing/queued finish, then method-specific terminal handling, then event
+/// rows. Every impossible pairing is an explicit `Internal` publish, never a panic.
+///
+/// The `terminal` field of every input is the raw shared-slot winner; the reducer
+/// consults it only through [`definitive`] / [`provisional_pending`], so a
+/// provisional MF-2 cancellation marker is never observed by the caller — it is
+/// refined by a paired terminal callback or finalized to an authoritative abort at
+/// the closure point (channel close, finish/reset completion).
+pub(crate) fn transition(state: &mut SendState, input: SendInput) -> SendCommand {
+    use SendCommand::*;
+    use SendInput::*;
+    use TerminalContinuation as K;
+    let aborted = || SendTerminal::Failed(aborted_status());
+
+    match input {
+        // ── Precedence 1: *Submitted bookkeeping. Clears its reservation before
+        //    any winner is applied; a missing reservation is internal.
+        SendSubmitted { result, terminal } => {
+            if !state.send_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("SendSubmitted without reservation"),
+                    continuation: K::SendData,
+                };
+            }
+            state.send_submitting = false;
+            match result {
+                Ok(()) => {
+                    state.send_inprogress = true;
+                    match definitive(&terminal) {
+                        Some(w) => ReturnError(w), // a specific winner raced in
+                        None => ReturnSent,        // send_data's Ok(())
+                    }
+                }
+                // Buffer already reclaimed by the caller on the Err path. A real
+                // native failure is authoritative; it refines a provisional marker.
+                Err(status) => PublishTerminal {
+                    candidate: definitive(&terminal).unwrap_or(SendTerminal::Failed(status)),
+                    continuation: K::SendData,
+                },
+            }
+        }
+        GracefulSubmitted { result, terminal } => {
+            if !state.finish_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("GracefulSubmitted without reservation"),
+                    continuation: K::PollFinish,
+                };
+            }
+            state.finish_submitting = false;
+            match result {
+                Ok(()) => {
+                    state.finish_started = true;
+                    RepollFinish // never Pending directly (drain a queued FinishComplete)
+                }
+                Err(status) => PublishTerminal {
+                    candidate: definitive(&terminal).unwrap_or(SendTerminal::Failed(status)),
+                    continuation: K::PollFinish,
+                },
+            }
+        }
+        ResetSubmitted {
+            code,
+            result,
+            terminal,
+        } => {
+            if !state.reset_submitting {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("ResetSubmitted without reservation"),
+                    continuation: K::Reset,
+                };
+            }
+            state.reset_submitting = false;
+            // Reset completion is a closure point: an authoritative `LocalReset`
+            // (or native failure) refines any retained provisional cancellation.
+            let candidate = match result {
+                Ok(()) => definitive(&terminal).unwrap_or(SendTerminal::LocalReset(code)),
+                Err(status) => definitive(&terminal).unwrap_or(SendTerminal::Failed(status)),
+            };
+            PublishTerminal {
+                candidate,
+                continuation: K::Reset,
+            }
+        }
+
+        // ── Consume the resolved winner (no state mutation).
+        TerminalPublished {
+            winner,
+            continuation,
+        } => {
+            if winner.is_provisional() {
+                // MF-2: an unobserved provisional cancellation is never returned to
+                // the caller. Re-poll to drain a synchronously-queued paired terminal
+                // / channel close (the closure point) or re-arm the waker.
+                match continuation {
+                    K::PollReady => RepollReady,
+                    K::PollFinish => RepollFinish,
+                    // Provisional markers never arise on the send_data / reset paths.
+                    K::SendData | K::Reset => NoOp,
+                }
+            } else {
+                match continuation {
+                    K::SendData | K::PollReady | K::PollFinish => ReturnError(winner),
+                    K::Reset => NoOp, // infallible method; winner stored for a later poll
+                }
+            }
+        }
+
+        // ── send_data request. Terminal wins; else misuse if busy/finishing.
+        SendRequested { payload, terminal } => {
+            if let Some(w) = definitive(&terminal) {
+                return ReturnError(w);
+            }
+            if state.send_inprogress
+                || state.send_submitting
+                || state.finish_submitting
+                || state.finish_started
+                || state.finish_complete
+            {
+                return ReturnImmediateError(SendOperationError::Misuse(
+                    "send_data called while a send is already in progress",
+                ));
+            }
+            match payload {
+                // idle, no winner
+                SendPayload::Empty => ReturnSent, // no-op, no reservation
+                SendPayload::Oversized { len } => {
+                    ReturnImmediateError(SendOperationError::OversizedSend { len }) // state unchanged
+                }
+                SendPayload::NonEmpty { .. } => {
+                    state.send_submitting = true;
+                    SubmitSend
+                }
+            }
+        }
+
+        // ── reset request (infallible; at most one native SubmitReset).
+        Reset { code, terminal } => {
+            // A provisional cancellation does NOT block the reset: reset is a
+            // closure point whose authoritative `LocalReset` refines it.
+            if state.finish_complete || definitive(&terminal).is_some() {
+                return NoOp; // already terminal; nothing to submit
+            }
+            if state.submission_reserved() {
+                return PublishTerminal {
+                    // impossible under serialized callers; never a 2nd native op
+                    candidate: SendTerminal::Internal("reset during submission reservation"),
+                    continuation: K::Reset,
+                };
+            }
+            state.reset_submitting = true; // otherwise, incl. incomplete finish
+            SubmitReset(code)
+        }
+
+        // ── poll_ready request. A present shared terminal is surfaced first.
+        PollReady { poll, terminal } => {
+            if state.submission_reserved() {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("poll_ready during submission reservation"),
+                    continuation: K::PollReady,
+                };
+            }
+            // Method-terminal step: an authoritative winner already in the shared
+            // slot is returned before ordinary event handling. A provisional
+            // cancellation marker is deliberately NOT surfaced here (MF-2).
+            if let Some(w) = definitive(&terminal) {
+                state.send_inprogress = false;
+                return ReturnError(w);
+            }
+            if state.finish_started {
+                // h3 misuse; no native call, non-sticky (reproduced each call).
+                return ReturnError(SendTerminal::Internal("poll_ready after finish"));
+            }
+            // A retained, unobserved provisional cancellation (MF-2) is pending.
+            let provisional = provisional_pending(&terminal);
+            match poll {
+                // Channel close is a closure point: finalize the provisional to an
+                // authoritative abort; otherwise it is an adapter-internal fault.
+                SendPoll::Closed if provisional => PublishTerminal {
+                    candidate: aborted(),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Closed => PublishTerminal {
+                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Event(SendEvent::Complete { cancelled: false }) => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {
+                            candidate: SendTerminal::Internal(
+                                "SendComplete without an outstanding send",
+                            ),
+                            continuation: K::PollReady,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    ReturnReady
+                }
+                SendPoll::Event(SendEvent::Complete { cancelled: true }) => {
+                    if !state.send_inprogress {
+                        return PublishTerminal {
+                            candidate: SendTerminal::Internal(
+                                "cancelled SendComplete without an outstanding send",
+                            ),
+                            continuation: K::PollReady,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    // No authoritative winner (handled above): retain an UNOBSERVED
+                    // provisional cancellation marker in the shared slot (MF-2). It is
+                    // never returned to the caller — the `PublishTerminal` winner is
+                    // fed back as a provisional `TerminalPublished`, which re-polls.
+                    PublishTerminal {
+                        candidate: SendTerminal::ProvisionalAbort,
+                        continuation: K::PollReady,
+                    }
+                }
+                // A lone terminal wake normally means a specific cause was published
+                // (surfaced above). With a provisional pending and no specific cause,
+                // treat it as the closure point and finalize to an authoritative abort.
+                SendPoll::Event(SendEvent::TerminalWake) if provisional => PublishTerminal {
+                    candidate: aborted(),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
+                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Event(SendEvent::FinishComplete { .. }) => PublishTerminal {
+                    candidate: SendTerminal::Internal("finish event observed on poll_ready"),
+                    continuation: K::PollReady,
+                },
+                SendPoll::Pending => {
+                    if state.send_inprogress {
+                        Pending
+                    } else if provisional {
+                        // Retained provisional cancellation, no closure event yet:
+                        // wait (the repoll registered the waker) — never ReturnReady.
+                        Pending
+                    } else {
+                        ReturnReady
+                    }
+                }
+            }
+        }
+
+        // ── poll_finish request. Absorbing finish and a just-completed graceful
+        //    finish both precede the method-terminal step and event handling.
+        PollFinish { poll, terminal } => {
+            if state.finish_complete {
+                return ReturnFinished; // absorbing
+            }
+            if state.submission_reserved() {
+                return PublishTerminal {
+                    candidate: SendTerminal::Internal("poll_finish during submission reservation"),
+                    continuation: K::PollFinish,
+                };
+            }
+            // Documented successful-finish exception: a graceful finish that
+            // actually completed wins even over a present terminal.
+            if let SendPoll::Event(SendEvent::FinishComplete { graceful }) = poll {
+                if !state.finish_started {
+                    return PublishTerminal {
+                        candidate: SendTerminal::Internal(
+                            "finish complete without a started finish",
+                        ),
+                        continuation: K::PollFinish,
+                    };
+                }
+                if graceful {
+                    state.finish_complete = true;
+                    return ReturnFinished;
+                }
+                // graceful == false while finishing is a closure point: an
+                // authoritative winner wins, else finalize to an abort.
+                return PublishTerminal {
+                    candidate: definitive(&terminal).unwrap_or_else(aborted),
+                    continuation: K::PollFinish,
+                };
+            }
+            // Method-terminal step: after the finish exceptions, an authoritative
+            // winner is surfaced before any Pending/SubmitGraceful. A provisional
+            // cancellation marker is deliberately NOT surfaced here (MF-2).
+            if let Some(w) = definitive(&terminal) {
+                state.send_inprogress = false;
+                return ReturnError(w);
+            }
+            let provisional = provisional_pending(&terminal);
+            match poll {
+                // Channel close is a closure point for a retained provisional.
+                SendPoll::Closed if provisional => PublishTerminal {
+                    candidate: aborted(),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Closed => PublishTerminal {
+                    candidate: SendTerminal::Internal("send channel closed without a terminal"),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Event(SendEvent::Complete { cancelled: false })
+                    if !state.finish_started =>
+                {
+                    if !state.send_inprogress {
+                        return PublishTerminal {
+                            candidate: SendTerminal::Internal(
+                                "SendComplete without an outstanding send",
+                            ),
+                            continuation: K::PollFinish,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    state.finish_submitting = true;
+                    SubmitGraceful
+                }
+                SendPoll::Event(SendEvent::Complete { cancelled: true })
+                    if !state.finish_started =>
+                {
+                    if !state.send_inprogress {
+                        return PublishTerminal {
+                            candidate: SendTerminal::Internal(
+                                "cancelled SendComplete without an outstanding send",
+                            ),
+                            continuation: K::PollFinish,
+                        };
+                    }
+                    state.send_inprogress = false;
+                    // Retain an UNOBSERVED provisional cancellation marker (MF-2); the
+                    // provisional `TerminalPublished` re-polls rather than returning it.
+                    PublishTerminal {
+                        candidate: SendTerminal::ProvisionalAbort,
+                        continuation: K::PollFinish,
+                    }
+                }
+                // A lone terminal wake with a provisional pending is the closure point.
+                SendPoll::Event(SendEvent::TerminalWake) if provisional => PublishTerminal {
+                    candidate: aborted(),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Event(SendEvent::TerminalWake) => PublishTerminal {
+                    candidate: SendTerminal::Internal("terminal wake without a terminal"),
+                    continuation: K::PollFinish,
+                },
+                SendPoll::Pending if state.finish_started => Pending,
+                SendPoll::Pending if state.send_inprogress => Pending, // wait for in-flight send
+                // Retained provisional cancellation, no closure event yet: wait for
+                // the closure point rather than submitting a graceful finish on a
+                // cancelled stream (the repoll already registered the waker).
+                SendPoll::Pending if provisional => Pending,
+                SendPoll::Pending => {
+                    state.finish_submitting = true;
+                    SubmitGraceful // idle, not finishing
+                }
+                // Any remaining event/state pair (e.g. a data completion while
+                // finishing) is adapter-internal, never a panic.
+                SendPoll::Event(_) => PublishTerminal {
+                    candidate: SendTerminal::Internal("impossible poll_finish event/state"),
+                    continuation: K::PollFinish,
+                },
+            }
+        }
     }
 }
 
@@ -282,40 +891,688 @@ mod tests {
     }
 }
 
-/// Skeleton table-driven harness for the send-side terminal reducer.
+/// Table-driven tests for the pure send-side reducer (Phase 7).
 ///
-/// The reducer itself (the send-side state machine that resolves provisional
-/// cancellations into concrete [`SendTerminal`] reasons) is implemented in
-/// Phase 7. This scaffold establishes the seam so that phase can drop in
-/// table-driven cases without restructuring the test module.
+/// Every case drives [`transition`] directly against a [`SendState`], so the
+/// full send state machine is exercised with NO native handle. The reducer is
+/// pure (mutates only `state`, emits one [`SendCommand`]); the frontend executor
+/// loops and the shared-slot first-writer refinement (`publish_send`) live in
+/// `lib.rs` and are covered by the `send_seam` tests there.
 #[cfg(test)]
 mod reducer_tests {
-    /// One row of the reducer table: a human-readable name plus the
-    /// (state, event) -> effect triple Phase 7 will populate.
-    #[allow(dead_code)] // fields consumed by the reducer table in Phase 7
-    struct ReducerCase {
-        /// Human-readable case name for assertion messages.
-        name: &'static str,
+    use super::*;
+
+    // `SendCommand`/`SendTerminal` embed `Status`, which is not `PartialEq`, so
+    // these helpers pattern-match rather than compare by value.
+
+    /// A `Connection(LocalClose)` terminal, a convenient concrete winner.
+    fn conn_terminal() -> SendTerminal {
+        SendTerminal::Connection(ConnectionTerminal::LocalClose)
     }
 
-    /// Run one reducer case. Phase 7 replaces this stub body with a call into
-    /// the real reducer and an assertion on the produced effect.
-    #[allow(dead_code)] // exercised once the reducer exists in Phase 7
-    fn run_case(_case: &ReducerCase) {
-        // Placeholder: intentionally empty until the reducer lands in Phase 7.
+    /// Drive the (state, input) -> command reducer once.
+    fn step(state: &mut SendState, input: SendInput) -> SendCommand {
+        transition(state, input)
+    }
+
+    // ── MF-1: chronological finish-vs-terminal ordering via the single source ──
+
+    #[test]
+    fn mf1_finish_first_completes_cleanly_then_absorbs_terminal() {
+        // A finish was submitted; its completion is dequeued BEFORE any terminal
+        // wake. Success is absorbing: the later terminal cannot overwrite it.
+        let mut st = SendState {
+            finish_started: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Event(SendEvent::FinishComplete { graceful: true }),
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::ReturnFinished));
+        assert!(st.finish_complete, "graceful completion marks finish done");
+
+        // A terminal wake dequeued afterwards is absorbed: still a clean finish.
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Event(SendEvent::TerminalWake),
+                terminal: Some(conn_terminal()),
+            },
+        );
+        assert!(
+            matches!(cmd, SendCommand::ReturnFinished),
+            "a later terminal must not overwrite a successful finish"
+        );
     }
 
     #[test]
-    fn reducer_harness_scaffold_compiles() {
-        // Trivial placeholder proving the harness compiles and is wired into the
-        // test runner. Phase 7 fills `cases` with real rows and asserts on
-        // `run_case` outcomes.
-        let cases: &[ReducerCase] = &[ReducerCase {
-            name: "placeholder",
-        }];
-        for case in cases {
-            run_case(case);
+    fn mf1_terminal_first_wins_over_later_finish() {
+        // The terminal wake is dequeued FIRST (its cause already published). The
+        // finish never completes: the terminal is surfaced as the error.
+        let mut st = SendState {
+            finish_started: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Event(SendEvent::TerminalWake),
+                terminal: Some(SendTerminal::Stopped(7)),
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(7)) => {}
+            other => panic!("expected ReturnError(Stopped(7)), got {other:?}"),
         }
-        assert_eq!(cases.len(), 1);
+        assert!(
+            !st.finish_complete,
+            "a terminal-first order must not mark finish complete"
+        );
+    }
+
+    #[test]
+    fn finish_event_not_overwritten_by_later_terminal() {
+        // Absorbing success precedes the method-terminal step even when a winner
+        // is present in the slot.
+        let mut st = SendState {
+            finish_complete: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Pending,
+                terminal: Some(conn_terminal()),
+            },
+        );
+        assert!(matches!(cmd, SendCommand::ReturnFinished));
+    }
+
+    // ── SF-2: poll_ready-after-finish is a non-sticky internal error ──
+
+    #[test]
+    fn poll_ready_after_finish_is_nonsticky_internal() {
+        // The reducer arm returns an Internal error without mutating state (the
+        // frontend guard additionally avoids consuming the channel; see the
+        // liveness test in lib.rs `send_seam`).
+        let mut st = SendState {
+            finish_started: true,
+            ..SendState::new()
+        };
+        let before = st;
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Pending,
+                terminal: None,
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Internal(m)) => {
+                assert_eq!(m, "poll_ready after finish")
+            }
+            other => panic!("expected ReturnError(Internal), got {other:?}"),
+        }
+        assert_eq!(st, before, "poll_ready-after-finish must not mutate state");
+    }
+
+    // ── reset: infallible, at most one clamped native RESET_STREAM ──
+
+    #[test]
+    fn reset_emits_single_submit_reset_then_publishes_local_reset() {
+        let mut st = SendState::new();
+        let code = (1u64 << 62) - 1;
+        let cmd = step(
+            &mut st,
+            SendInput::Reset {
+                code,
+                terminal: None,
+            },
+        );
+        match cmd {
+            SendCommand::SubmitReset(c) => assert_eq!(c, code),
+            other => panic!("expected SubmitReset, got {other:?}"),
+        }
+        assert!(st.reset_submitting, "reset reserves its submission");
+
+        let cmd = step(
+            &mut st,
+            SendInput::ResetSubmitted {
+                code,
+                result: Ok(()),
+                terminal: None,
+            },
+        );
+        match cmd {
+            SendCommand::PublishTerminal {
+                candidate: SendTerminal::LocalReset(c),
+                continuation: TerminalContinuation::Reset,
+            } => assert_eq!(c, code),
+            other => panic!("expected PublishTerminal(LocalReset), got {other:?}"),
+        }
+        assert!(!st.reset_submitting, "the reservation is cleared");
+
+        // The resolved winner is fed back: reset is infallible, so NoOp.
+        let cmd = step(
+            &mut st,
+            SendInput::TerminalPublished {
+                winner: SendTerminal::LocalReset(code),
+                continuation: TerminalContinuation::Reset,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::NoOp));
+    }
+
+    #[test]
+    fn reset_after_terminal_is_noop() {
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::Reset {
+                code: 5,
+                terminal: Some(SendTerminal::Stopped(9)),
+            },
+        );
+        assert!(matches!(cmd, SendCommand::NoOp));
+        assert!(!st.reset_submitting, "no native reset after a terminal");
+    }
+
+    #[test]
+    fn reset_after_finish_complete_is_noop() {
+        let mut st = SendState {
+            finish_complete: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::Reset {
+                code: 5,
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::NoOp));
+    }
+
+    #[test]
+    fn local_reset_loses_to_published_peer_terminal() {
+        // Local reset raced a peer STOP_SENDING that landed before ResetSubmitted:
+        // the callback-published terminal wins, no second native op.
+        let mut st = SendState::new();
+        let _ = step(
+            &mut st,
+            SendInput::Reset {
+                code: 3,
+                terminal: None,
+            },
+        );
+        let cmd = step(
+            &mut st,
+            SendInput::ResetSubmitted {
+                code: 3,
+                result: Ok(()),
+                terminal: Some(SendTerminal::Stopped(9)),
+            },
+        );
+        match cmd {
+            SendCommand::PublishTerminal {
+                candidate: SendTerminal::Stopped(9),
+                continuation: TerminalContinuation::Reset,
+            } => {}
+            other => panic!("expected PublishTerminal(Stopped(9)), got {other:?}"),
+        }
+        assert!(!st.reset_submitting, "reservation cleared on the race");
+    }
+
+    #[test]
+    fn local_reset_loses_to_published_connection_terminal() {
+        // Same race against a connection shutdown.
+        let mut st = SendState::new();
+        let _ = step(
+            &mut st,
+            SendInput::Reset {
+                code: 3,
+                terminal: None,
+            },
+        );
+        let cmd = step(
+            &mut st,
+            SendInput::ResetSubmitted {
+                code: 3,
+                result: Ok(()),
+                terminal: Some(conn_terminal()),
+            },
+        );
+        assert!(matches!(
+            cmd,
+            SendCommand::PublishTerminal {
+                candidate: SendTerminal::Connection(_),
+                continuation: TerminalContinuation::Reset,
+            }
+        ));
+    }
+
+    // ── idempotent finish: exactly one graceful shutdown ──
+
+    #[test]
+    fn idempotent_finish_submits_graceful_once() {
+        let mut st = SendState::new();
+        // First poll_finish on an idle stream submits the graceful shutdown.
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Pending,
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::SubmitGraceful));
+        assert!(st.finish_submitting);
+
+        // The submit succeeds: reservation clears, finish is started, re-poll.
+        let cmd = step(
+            &mut st,
+            SendInput::GracefulSubmitted {
+                result: Ok(()),
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::RepollFinish));
+        assert!(st.finish_started && !st.finish_submitting);
+
+        // A subsequent poll_finish while awaiting completion does NOT re-submit.
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Pending,
+                terminal: None,
+            },
+        );
+        assert!(
+            matches!(cmd, SendCommand::Pending),
+            "no second graceful shutdown while finishing"
+        );
+    }
+
+    // ── *Submitted without a reservation is internal, never a panic ──
+
+    #[test]
+    fn submitted_without_reservation_is_internal() {
+        for input in [
+            SendInput::SendSubmitted {
+                result: Ok(()),
+                terminal: None,
+            },
+            SendInput::GracefulSubmitted {
+                result: Ok(()),
+                terminal: None,
+            },
+            SendInput::ResetSubmitted {
+                code: 1,
+                result: Ok(()),
+                terminal: None,
+            },
+        ] {
+            let mut st = SendState::new();
+            let cmd = step(&mut st, input);
+            assert!(
+                matches!(
+                    cmd,
+                    SendCommand::PublishTerminal {
+                        candidate: SendTerminal::Internal(_),
+                        ..
+                    }
+                ),
+                "a *Submitted without a reservation must publish Internal"
+            );
+        }
+    }
+
+    // ── send_data request precedence ──
+
+    #[test]
+    fn send_requested_terminal_wins() {
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::SendRequested {
+                payload: SendPayload::NonEmpty { len: 4 },
+                terminal: Some(SendTerminal::Stopped(1)),
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(1)) => {}
+            other => panic!("expected ReturnError(Stopped(1)), got {other:?}"),
+        }
+        assert!(!st.send_submitting, "no submission behind a terminal");
+    }
+
+    #[test]
+    fn send_requested_while_busy_is_misuse() {
+        let mut st = SendState {
+            send_inprogress: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::SendRequested {
+                payload: SendPayload::NonEmpty { len: 4 },
+                terminal: None,
+            },
+        );
+        assert!(matches!(
+            cmd,
+            SendCommand::ReturnImmediateError(SendOperationError::Misuse(_))
+        ));
+    }
+
+    #[test]
+    fn send_empty_is_noop_and_oversized_is_immediate_error() {
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::SendRequested {
+                payload: SendPayload::Empty,
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::ReturnSent));
+        assert!(!st.send_submitting, "empty send reserves nothing");
+
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::SendRequested {
+                payload: SendPayload::Oversized { len: 999 },
+                terminal: None,
+            },
+        );
+        assert!(matches!(
+            cmd,
+            SendCommand::ReturnImmediateError(SendOperationError::OversizedSend { len: 999 })
+        ));
+        assert_eq!(
+            st,
+            SendState::new(),
+            "oversized rejection leaves state clean"
+        );
+    }
+
+    #[test]
+    fn send_requested_nonempty_reserves_and_submits() {
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::SendRequested {
+                payload: SendPayload::NonEmpty { len: 8 },
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::SubmitSend));
+        assert!(st.send_submitting);
+
+        let cmd = step(
+            &mut st,
+            SendInput::SendSubmitted {
+                result: Ok(()),
+                terminal: None,
+            },
+        );
+        assert!(matches!(cmd, SendCommand::ReturnSent));
+        assert!(st.send_inprogress && !st.send_submitting);
+    }
+
+    // ── SC-011 / MF-2: send-cancellation retained-provisional / closure point ──
+
+    #[test]
+    fn sc011_cancelled_complete_no_cause_retains_unobserved_provisional() {
+        // A cancelled SendComplete with NO published cause retains the DISTINCT
+        // `ProvisionalAbort` marker in the shared slot (MF-2). It is provisional
+        // (refinable) and, crucially, is fed back as a provisional `TerminalPublished`
+        // that RE-POLLS rather than returning — the caller never observes it.
+        let mut st = SendState {
+            send_inprogress: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Event(SendEvent::Complete { cancelled: true }),
+                terminal: None,
+            },
+        );
+        match cmd {
+            SendCommand::PublishTerminal {
+                candidate,
+                continuation: TerminalContinuation::PollReady,
+            } => {
+                assert!(candidate.is_provisional(), "retains a provisional marker");
+                assert!(
+                    matches!(candidate, SendTerminal::ProvisionalAbort),
+                    "the marker is the distinct ProvisionalAbort, not a real Failed"
+                );
+            }
+            other => panic!("expected PublishTerminal(ProvisionalAbort), got {other:?}"),
+        }
+        assert!(!st.send_inprogress);
+
+        // The provisional winner fed back must NOT be returned to the caller; it
+        // re-polls to reach the closure point / drain a paired terminal.
+        let cmd = step(
+            &mut st,
+            SendInput::TerminalPublished {
+                winner: SendTerminal::ProvisionalAbort,
+                continuation: TerminalContinuation::PollReady,
+            },
+        );
+        assert!(
+            matches!(cmd, SendCommand::RepollReady),
+            "a provisional winner re-polls (unobserved), never ReturnError"
+        );
+    }
+
+    #[test]
+    fn mf2_provisional_refines_to_specific_before_observation() {
+        // Cancellation-FIRST order: after the provisional is retained, a paired peer
+        // cause published into the slot is surfaced on the re-poll — the caller's
+        // FIRST observation is the refined specific cause, never the abort.
+        let mut st = SendState {
+            send_inprogress: false, // cleared by the prior cancelled completion
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Pending,
+                terminal: Some(SendTerminal::Stopped(9)), // refined in the slot
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(9)) => {}
+            other => panic!("expected refined ReturnError(Stopped(9)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mf2_provisional_channel_close_is_closure_point_to_authoritative_abort() {
+        // Channel close with a retained provisional and no richer cause is the
+        // closure point: it finalizes to an AUTHORITATIVE (non-provisional) abort.
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Closed,
+                terminal: Some(SendTerminal::ProvisionalAbort),
+            },
+        );
+        match cmd {
+            SendCommand::PublishTerminal {
+                candidate,
+                continuation: TerminalContinuation::PollReady,
+            } => {
+                assert!(
+                    !candidate.is_provisional(),
+                    "closure abort is authoritative"
+                );
+                assert!(matches!(candidate, SendTerminal::Failed(_)));
+            }
+            other => panic!("expected authoritative Failed at closure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mf2_provisional_pending_channel_pending_waits_not_ready() {
+        // While a provisional is retained and no closure event has arrived, an idle
+        // Pending poll must WAIT (never spuriously report ReturnReady/ready).
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Pending,
+                terminal: Some(SendTerminal::ProvisionalAbort),
+            },
+        );
+        assert!(
+            matches!(cmd, SendCommand::Pending),
+            "a retained provisional must wait, not report ready"
+        );
+    }
+
+    #[test]
+    fn mf2_provisional_finish_abort_is_closure_point() {
+        // poll_finish observing a graceful==false finish while a provisional is
+        // retained finalizes to an authoritative abort (closure point).
+        let mut st = SendState {
+            finish_started: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Event(SendEvent::FinishComplete { graceful: false }),
+                terminal: Some(SendTerminal::ProvisionalAbort),
+            },
+        );
+        match cmd {
+            SendCommand::PublishTerminal { candidate, .. } => {
+                assert!(!candidate.is_provisional());
+                assert!(matches!(candidate, SendTerminal::Failed(_)));
+            }
+            other => panic!("expected authoritative Failed at finish closure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sc011_cancelled_complete_with_peer_stop_surfaces_peer_cause() {
+        // Peer STOP_SENDING already published: the method-terminal step surfaces
+        // the specific peer cause ahead of the cancelled-completion synthesis.
+        let mut st = SendState {
+            send_inprogress: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Event(SendEvent::Complete { cancelled: true }),
+                terminal: Some(SendTerminal::Stopped(5)),
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(5)) => {}
+            other => panic!("expected ReturnError(Stopped(5)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sc011_cancelled_complete_with_connection_surfaces_connection_cause() {
+        // Connection shutdown published with an outstanding send: the connection
+        // cause wins over the provisional abort.
+        let mut st = SendState {
+            send_inprogress: true,
+            ..SendState::new()
+        };
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Event(SendEvent::Complete { cancelled: true }),
+                terminal: Some(conn_terminal()),
+            },
+        );
+        assert!(matches!(
+            cmd,
+            SendCommand::ReturnError(SendTerminal::Connection(_))
+        ));
+    }
+
+    // ── STOP_SENDING observable with no send in flight ──
+
+    #[test]
+    fn stop_sending_without_send_observable_at_poll_ready_and_finish() {
+        // No outstanding send; a sticky peer terminal is surfaced before any
+        // early Ok on both poll_ready and poll_finish.
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Pending,
+                terminal: Some(SendTerminal::Stopped(3)),
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(3)) => {}
+            other => panic!("poll_ready: expected Stopped(3), got {other:?}"),
+        }
+
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::PollFinish {
+                poll: SendPoll::Pending,
+                terminal: Some(SendTerminal::Stopped(3)),
+            },
+        );
+        match cmd {
+            SendCommand::ReturnError(SendTerminal::Stopped(3)) => {}
+            other => panic!("poll_finish: expected Stopped(3), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn terminal_wake_without_terminal_is_internal() {
+        // A wake with no published cause is an adapter fault, never a panic.
+        let mut st = SendState::new();
+        let cmd = step(
+            &mut st,
+            SendInput::PollReady {
+                poll: SendPoll::Event(SendEvent::TerminalWake),
+                terminal: None,
+            },
+        );
+        assert!(matches!(
+            cmd,
+            SendCommand::PublishTerminal {
+                candidate: SendTerminal::Internal(_),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn provisional_abort_is_refinable_but_specific_is_not() {
+        // is_provisional gates the shared-slot refinement (publish_send in lib.rs).
+        // MF-2 (Item 2): ONLY the distinct synthesized `ProvisionalAbort` marker is
+        // provisional/refinable; a real native `Failed` — even `QUIC_STATUS_ABORTED`
+        // — is authoritative and NEVER refinable.
+        assert!(SendTerminal::ProvisionalAbort.is_provisional());
+        assert!(
+            !SendTerminal::Failed(aborted_status()).is_provisional(),
+            "a REAL native Failed(ABORTED) is authoritative, not provisional"
+        );
+        assert!(!SendTerminal::Stopped(1).is_provisional());
+        assert!(!conn_terminal().is_provisional());
+        assert!(!SendTerminal::LocalReset(1).is_provisional());
+        assert!(!SendTerminal::Internal("x").is_provisional());
     }
 }

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -1,0 +1,309 @@
+//! Error vocabulary for the msquic <-> h3 adapter.
+//!
+//! This module introduces the shared, adapter-owned error types, the scoped
+//! terminal enums that record *why* a connection, receive half, or send half
+//! ended, and the pure conversion helpers that mint fresh `h3` error values at
+//! the polling boundary. It also defines the outgoing application-code clamp.
+//!
+//! Most of the terminal enums and conversion helpers are wired into the FFI
+//! callbacks and polling paths in later phases (Phase 3 onwards); they are
+//! introduced here so the vocabulary exists in one place. The `#[allow(dead_code)]`
+//! attributes below are scoped to individual not-yet-wired items and each notes
+//! the phase that consumes it.
+
+use std::fmt;
+
+use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
+
+use crate::msquic::Status;
+
+/// Maximum value representable by a QUIC 62-bit variable-length integer.
+///
+/// Outgoing application error codes must never exceed this or msquic rejects the
+/// encode. See [`clamp_application_code`].
+pub const MAX_QUIC_VARINT: u64 = (1 << 62) - 1;
+
+/// Maximum single `send_data` payload the adapter will accept before rejecting
+/// with [`OversizedSend`]. Provisional value (16 MiB); the enforcement site is
+/// wired in Phase 6.
+#[allow(dead_code)] // referenced by OversizedSend Display; enforced in Phase 6
+pub const MAX_ADAPTER_SEND: u64 = 16 * 1024 * 1024;
+
+/// Clamp an outgoing application error code to the QUIC 62-bit varint maximum.
+///
+/// `(1 << 62) - 1` passes unchanged; `1 << 62` and above clamp down to the
+/// maximum. Applied at every site where an application code crosses the FFI
+/// boundary (connection close, `stop_sending`, and — in Phase 7 — `reset`).
+pub(crate) fn clamp_application_code(code: u64) -> u64 {
+    code.min(MAX_QUIC_VARINT)
+}
+
+// ---------------------------------------------------------------------------
+// Adapter-owned error types.
+//
+// Each is `Debug + Display + Error + Send + Sync` so it can be `Arc`'d into
+// `ConnectionErrorIncoming::Undefined(Arc<dyn Error + Send + Sync>)` or boxed
+// into `StreamErrorIncoming::Unknown(Box<dyn Error + Send + Sync>)`.
+// ---------------------------------------------------------------------------
+
+/// A `send_data` payload above [`MAX_ADAPTER_SEND`]. One-shot; never stored in
+/// the shared send-terminal slot. Constructed at the send-rejection site in
+/// Phase 6.
+#[derive(Debug)]
+#[allow(dead_code)] // constructed at the send-rejection site in Phase 6
+pub struct OversizedSend {
+    /// Requested payload length in bytes (the `remaining()` that was rejected).
+    pub len: usize,
+}
+
+impl fmt::Display for OversizedSend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "send_data payload of {} bytes exceeds MAX_ADAPTER_SEND ({} bytes)",
+            self.len, MAX_ADAPTER_SEND
+        )
+    }
+}
+
+impl std::error::Error for OversizedSend {}
+
+/// A non-application transport shutdown. Both the QUIC status and the wire
+/// transport error code are retained for diagnostics; the transport code is a
+/// QUIC transport code, not an HTTP/3 application code.
+#[derive(Debug)]
+pub struct MsQuicTransportError {
+    /// The QUIC status that accompanied the transport shutdown.
+    pub status: Status,
+    /// The wire transport error code (diagnostic only).
+    pub error_code: u64,
+}
+
+impl fmt::Display for MsQuicTransportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "QUIC transport shutdown: status {} (transport error_code {})",
+            self.status, self.error_code
+        )
+    }
+}
+
+impl std::error::Error for MsQuicTransportError {}
+
+/// A local (application-initiated) connection close. Carries no peer code: the
+/// required mapping is explicit that we must not invent one.
+#[derive(Debug)]
+pub struct LocalConnectionClose;
+
+impl fmt::Display for LocalConnectionClose {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("connection closed locally by the application")
+    }
+}
+
+impl std::error::Error for LocalConnectionClose {}
+
+/// A local reset via `SendStream::reset(code)`. Distinct from a peer
+/// `StreamTerminated`: h3 should not poll a reset send stream, and if it does we
+/// surface this rather than pretending the peer terminated the stream.
+#[derive(Debug)]
+#[allow(dead_code)] // constructed by convert_send / reset() in Phase 7
+pub struct LocalStreamReset {
+    /// The (already-clamped) local reset code.
+    pub code: u64,
+}
+
+impl fmt::Display for LocalStreamReset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "send stream reset locally with code {}", self.code)
+    }
+}
+
+impl std::error::Error for LocalStreamReset {}
+
+// ---------------------------------------------------------------------------
+// Scoped terminal enums.
+//
+// Small, adapter-owned reasons recorded in callback-facing state. `Clone` where
+// multiple consumers need the reason. Converted to fresh h3 error values only at
+// the polling boundary via the `convert_*` helpers below.
+// ---------------------------------------------------------------------------
+
+/// Why a connection terminated. The first writer wins for the connection scope.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // recorded in the connection terminal slot in Phase 3
+pub(crate) enum ConnectionTerminal {
+    /// Peer closed with an HTTP/3 application error code.
+    PeerApplication(u64),
+    /// Idle or handshake timeout.
+    Timeout,
+    /// Non-application transport shutdown.
+    Transport {
+        /// The QUIC status that accompanied the shutdown.
+        status: Status,
+        /// The wire transport error code (diagnostic only).
+        error_code: u64,
+    },
+    /// Local application-initiated close.
+    LocalClose,
+    /// Internal adapter failure.
+    Internal(&'static str),
+}
+
+/// Why a receive half terminated. The first writer wins for the receive scope.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // recorded on the receive path in Phase 4
+pub(crate) enum ReceiveTerminal {
+    /// Clean end of stream (peer FIN / send-shutdown).
+    Fin,
+    /// Peer reset the stream with the given code.
+    Reset(u64),
+    /// The whole connection terminated.
+    Connection(ConnectionTerminal),
+    /// Internal adapter failure.
+    Internal(&'static str),
+}
+
+/// Why a send half terminated. The first writer wins for the send scope.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // recorded on the send path in Phases 6-7
+pub(crate) enum SendTerminal {
+    /// Peer sent `STOP_SENDING` with the given code.
+    Stopped(u64),
+    /// The whole connection terminated.
+    Connection(ConnectionTerminal),
+    /// Local `reset(code)` (already clamped). Not a peer termination.
+    LocalReset(u64),
+    /// A native send/start failure carrying its status.
+    Failed(Status),
+    /// Internal adapter failure.
+    Internal(&'static str),
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers.
+//
+// These are the *only* places that mint h3 error values from adapter terminals.
+// Pure functions; wired into the polling boundary in later phases.
+// ---------------------------------------------------------------------------
+
+/// Convert a [`ConnectionTerminal`] into the h3 connection error it represents.
+#[allow(dead_code)] // wired at the connection polling boundary in Phase 3
+pub(crate) fn convert_conn(t: ConnectionTerminal) -> ConnectionErrorIncoming {
+    use ConnectionTerminal as C;
+    match t {
+        C::PeerApplication(code) => ConnectionErrorIncoming::ApplicationClose { error_code: code },
+        C::Timeout => ConnectionErrorIncoming::Timeout,
+        C::Transport { status, error_code } => {
+            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(MsQuicTransportError {
+                status,
+                error_code,
+            }))
+        }
+        C::LocalClose => {
+            ConnectionErrorIncoming::Undefined(std::sync::Arc::new(LocalConnectionClose))
+        }
+        C::Internal(msg) => ConnectionErrorIncoming::InternalError(msg.to_string()),
+    }
+}
+
+/// Convert a [`SendTerminal`] into the h3 stream error it represents.
+#[allow(dead_code)] // wired at the send polling boundary in Phase 7
+pub(crate) fn convert_send(t: SendTerminal) -> StreamErrorIncoming {
+    use SendTerminal as S;
+    match t {
+        S::Stopped(code) => StreamErrorIncoming::StreamTerminated { error_code: code },
+        S::Connection(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: convert_conn(reason),
+        },
+        S::LocalReset(code) => StreamErrorIncoming::Unknown(Box::new(LocalStreamReset { code })),
+        S::Failed(status) => StreamErrorIncoming::Unknown(Box::new(status)),
+        S::Internal(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
+        },
+    }
+}
+
+/// Convert a [`ReceiveTerminal`] into the h3 receive outcome it represents.
+///
+/// A clean FIN maps to `Ok(None)`; every other terminal maps to an error.
+#[allow(dead_code)] // wired at the receive polling boundary in Phase 4
+pub(crate) fn convert_recv(
+    t: ReceiveTerminal,
+) -> Result<Option<bytes::Bytes>, StreamErrorIncoming> {
+    use ReceiveTerminal as R;
+    match t {
+        R::Fin => Ok(None),
+        R::Reset(code) => Err(StreamErrorIncoming::StreamTerminated { error_code: code }),
+        R::Connection(reason) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: convert_conn(reason),
+        }),
+        R::Internal(msg) => Err(StreamErrorIncoming::ConnectionErrorIncoming {
+            connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_application_code_table() {
+        // (name, input, expected)
+        let cases: &[(&str, u64, u64)] = &[
+            ("small value unchanged", 42, 42),
+            ("zero unchanged", 0, 0),
+            ("max varint unchanged", (1u64 << 62) - 1, (1u64 << 62) - 1),
+            ("one over max clamps", 1u64 << 62, (1u64 << 62) - 1),
+            ("u64::MAX clamps", u64::MAX, (1u64 << 62) - 1),
+        ];
+        for (name, input, expected) in cases {
+            assert_eq!(clamp_application_code(*input), *expected, "case: {name}");
+        }
+    }
+
+    #[test]
+    fn max_quic_varint_value() {
+        assert_eq!(MAX_QUIC_VARINT, (1u64 << 62) - 1);
+    }
+}
+
+/// Skeleton table-driven harness for the send-side terminal reducer.
+///
+/// The reducer itself (the send-side state machine that resolves provisional
+/// cancellations into concrete [`SendTerminal`] reasons) is implemented in
+/// Phase 7. This scaffold establishes the seam so that phase can drop in
+/// table-driven cases without restructuring the test module.
+#[cfg(test)]
+mod reducer_tests {
+    /// One row of the reducer table: a human-readable name plus the
+    /// (state, event) -> effect triple Phase 7 will populate.
+    #[allow(dead_code)] // fields consumed by the reducer table in Phase 7
+    struct ReducerCase {
+        /// Human-readable case name for assertion messages.
+        name: &'static str,
+    }
+
+    /// Run one reducer case. Phase 7 replaces this stub body with a call into
+    /// the real reducer and an assertion on the produced effect.
+    #[allow(dead_code)] // exercised once the reducer exists in Phase 7
+    fn run_case(_case: &ReducerCase) {
+        // Placeholder: intentionally empty until the reducer lands in Phase 7.
+    }
+
+    #[test]
+    fn reducer_harness_scaffold_compiles() {
+        // Trivial placeholder proving the harness compiles and is wired into the
+        // test runner. Phase 7 fills `cases` with real rows and asserts on
+        // `run_case` outcomes.
+        let cases: &[ReducerCase] = &[ReducerCase {
+            name: "placeholder",
+        }];
+        for case in cases {
+            run_case(case);
+        }
+        assert_eq!(cases.len(), 1);
+    }
+}

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -889,6 +889,152 @@ mod tests {
     fn max_quic_varint_value() {
         assert_eq!(MAX_QUIC_VARINT, (1u64 << 62) - 1);
     }
+
+    /// Error-mapping matrix (Phases 3–7): every adapter terminal → h3 result row
+    /// from the design's "Required mapping" conversion table, asserted through the
+    /// authoritative `convert_conn` / `convert_recv` / `convert_send` helpers.
+    /// These are the ONLY sites that mint h3 error values, so proving the table
+    /// here proves the whole propagation surface's terminal-to-h3 contract.
+    #[test]
+    fn convert_conn_matrix() {
+        // PeerApplication(code) → ApplicationClose { code }
+        match convert_conn(ConnectionTerminal::PeerApplication(0x42)) {
+            ConnectionErrorIncoming::ApplicationClose { error_code } => {
+                assert_eq!(error_code, 0x42)
+            }
+            other => panic!("PeerApplication → {other:?}"),
+        }
+        // Timeout → Timeout
+        assert!(matches!(
+            convert_conn(ConnectionTerminal::Timeout),
+            ConnectionErrorIncoming::Timeout
+        ));
+        // Transport { status, error_code } → Undefined(MsQuicTransportError)
+        match convert_conn(ConnectionTerminal::Transport {
+            status: Status::new(StatusCode::QUIC_STATUS_TLS_ERROR),
+            error_code: 7,
+        }) {
+            ConnectionErrorIncoming::Undefined(e) => {
+                let t = e
+                    .downcast_ref::<MsQuicTransportError>()
+                    .expect("Transport → MsQuicTransportError");
+                // Both the wire transport error code AND the accompanying QUIC
+                // status must be preserved verbatim through the conversion.
+                assert_eq!(t.error_code, 7, "transport error code preserved");
+                assert_eq!(
+                    t.status
+                        .try_as_status_code()
+                        .expect("known transport status"),
+                    StatusCode::QUIC_STATUS_TLS_ERROR,
+                    "transport status preserved verbatim"
+                );
+            }
+            other => panic!("Transport → {other:?}"),
+        }
+        // LocalClose → Undefined(LocalConnectionClose)
+        match convert_conn(ConnectionTerminal::LocalClose) {
+            ConnectionErrorIncoming::Undefined(e) => {
+                assert!(e.downcast_ref::<LocalConnectionClose>().is_some());
+            }
+            other => panic!("LocalClose → {other:?}"),
+        }
+        // Internal(msg) → InternalError(msg)
+        match convert_conn(ConnectionTerminal::Internal("boom")) {
+            ConnectionErrorIncoming::InternalError(m) => assert_eq!(m, "boom"),
+            other => panic!("Internal → {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_recv_matrix() {
+        // Fin → Ok(None)
+        assert!(matches!(convert_recv(ReceiveTerminal::Fin), Ok(None)));
+        // Reset(code) → StreamTerminated { code }
+        match convert_recv(ReceiveTerminal::Reset(0x55)) {
+            Err(StreamErrorIncoming::StreamTerminated { error_code }) => {
+                assert_eq!(error_code, 0x55)
+            }
+            other => panic!("Reset → {other:?}"),
+        }
+        // Connection(reason) → ConnectionErrorIncoming using the conn conversion
+        match convert_recv(ReceiveTerminal::Connection(ConnectionTerminal::Timeout)) {
+            Err(StreamErrorIncoming::ConnectionErrorIncoming { connection_error }) => {
+                assert!(matches!(connection_error, ConnectionErrorIncoming::Timeout));
+            }
+            other => panic!("Connection → {other:?}"),
+        }
+        // Internal(msg) → ConnectionErrorIncoming(InternalError)
+        match convert_recv(ReceiveTerminal::Internal("recv-boom")) {
+            Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(m),
+            }) => assert_eq!(m, "recv-boom"),
+            other => panic!("Internal → {other:?}"),
+        }
+    }
+
+    #[test]
+    fn convert_send_matrix() {
+        // Stopped(code) → StreamTerminated { code }
+        match convert_send(SendTerminal::Stopped(0x66)) {
+            StreamErrorIncoming::StreamTerminated { error_code } => assert_eq!(error_code, 0x66),
+            other => panic!("Stopped → {other:?}"),
+        }
+        // Connection(reason) → ConnectionErrorIncoming using the conn conversion
+        match convert_send(SendTerminal::Connection(
+            ConnectionTerminal::PeerApplication(9),
+        )) {
+            StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            } => assert_eq!(error_code, 9),
+            other => panic!("Connection → {other:?}"),
+        }
+        // LocalReset(code) → Unknown(LocalStreamReset)
+        match convert_send(SendTerminal::LocalReset(0x77)) {
+            StreamErrorIncoming::Unknown(e) => {
+                let r = e
+                    .downcast_ref::<LocalStreamReset>()
+                    .expect("LocalReset → LocalStreamReset");
+                assert_eq!(r.code, 0x77);
+            }
+            other => panic!("LocalReset → {other:?}"),
+        }
+        // Failed(status) → Unknown(status), preserving the exact QUIC status.
+        match convert_send(SendTerminal::Failed(Status::new(
+            StatusCode::QUIC_STATUS_ABORTED,
+        ))) {
+            StreamErrorIncoming::Unknown(e) => {
+                let s = e.downcast_ref::<Status>().expect("Failed → Status");
+                assert_eq!(
+                    s.try_as_status_code().expect("known failed status"),
+                    StatusCode::QUIC_STATUS_ABORTED,
+                    "failed send status preserved verbatim"
+                );
+            }
+            other => panic!("Failed → {other:?}"),
+        }
+        // ProvisionalAbort → Unknown(aborted status) (defensive fallback); the
+        // synthesized status is the authoritative QUIC_STATUS_ABORTED.
+        match convert_send(SendTerminal::ProvisionalAbort) {
+            StreamErrorIncoming::Unknown(e) => {
+                let s = e
+                    .downcast_ref::<Status>()
+                    .expect("ProvisionalAbort → Status");
+                assert_eq!(
+                    s.try_as_status_code().expect("known provisional status"),
+                    StatusCode::QUIC_STATUS_ABORTED,
+                    "provisional abort maps to the aborted status"
+                );
+            }
+            other => panic!("ProvisionalAbort → {other:?}"),
+        }
+        // Internal(msg) → ConnectionErrorIncoming(InternalError)
+        match convert_send(SendTerminal::Internal("send-boom")) {
+            StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(m),
+            } => assert_eq!(m, "send-boom"),
+            other => panic!("Internal → {other:?}"),
+        }
+    }
 }
 
 /// Table-driven tests for the pure send-side reducer (Phase 7).

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -20,7 +20,7 @@ use msquic::{
 };
 
 mod buffer;
-pub use buffer::*;
+use buffer::{SendBuffer, SendLen, classify_send_len};
 mod error;
 use error::{
     ConnectionTerminal, ReceiveTerminal, clamp_application_code, convert_conn, convert_recv,
@@ -638,6 +638,9 @@ pub struct StreamOpener {
     conn: Arc<ConnHandle>,
     bidi_temp: Option<OpeningStream>,
     uni_temp: Option<OpeningStream>,
+    /// Connection-scoped open seam (prod = [`StreamOpenExecutor`]); lets a test
+    /// substitute the native open/start without a live connection.
+    open_exec: Box<dyn OpenExec>,
 }
 
 impl Clone for StreamOpener {
@@ -646,6 +649,9 @@ impl Clone for StreamOpener {
             conn: self.conn.clone(),
             bidi_temp: None,
             uni_temp: None,
+            // An in-flight OpeningStream is not shared, so a clone starts with
+            // empty temps and a fresh production open seam.
+            open_exec: Box::new(StreamOpenExecutor),
         }
     }
 }
@@ -720,7 +726,13 @@ impl<B: Buf> OpenStreams<B> for StreamOpener {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<Self::BidiStream, StreamErrorIncoming>> {
-        Self::poll_open_inner(&self.conn, false, &mut self.bidi_temp, cx)
+        Self::poll_open_inner(
+            &self.conn,
+            self.open_exec.as_ref(),
+            false,
+            &mut self.bidi_temp,
+            cx,
+        )
     }
 
     #[cfg_attr(
@@ -733,6 +745,7 @@ impl<B: Buf> OpenStreams<B> for StreamOpener {
     ) -> std::task::Poll<Result<Self::SendStream, StreamErrorIncoming>> {
         let res = ready!(Self::poll_open_inner(
             &self.conn,
+            self.open_exec.as_ref(),
             true,
             &mut self.uni_temp,
             cx
@@ -764,6 +777,7 @@ impl StreamOpener {
             conn,
             bidi_temp: None,
             uni_temp: None,
+            open_exec: Box::new(StreamOpenExecutor),
         }
     }
 
@@ -775,6 +789,7 @@ impl StreamOpener {
     /// `StartComplete` outcome and validated before an `H3Stream` is built.
     fn poll_open_inner(
         conn: &Arc<ConnHandle>,
+        open_exec: &dyn OpenExec,
         uni: bool,
         holder: &mut Option<OpeningStream>,
         cx: &mut std::task::Context<'_>,
@@ -789,7 +804,7 @@ impl StreamOpener {
         }
         // 2. Create + start the native stream if none is in flight.
         if holder.is_none() {
-            match H3Stream::open_and_start(conn, uni) {
+            match open_exec.submit_open_start(conn, uni) {
                 Ok(opening) => *holder = Some(opening),
                 Err(status) => {
                     // A shutdown may have raced the open; prefer the terminal.
@@ -904,7 +919,12 @@ pub struct H3Stream {
 }
 #[derive(Debug)]
 pub struct H3SendStream {
-    stream: Arc<msquic::Stream>,
+    /// Every native send-side verb goes through `exec`; the production
+    /// [`StreamExecutor`] (held here) owns the `Arc<msquic::Stream>` that keeps
+    /// the send half's native handle alive. This ownership is independent of the
+    /// recv half (which holds its own `Arc` clone), and it lets a test inject a
+    /// double without a live connection.
+    exec: Box<dyn SendExec>,
     sctx: SendStreamReceiveCtx,
 }
 #[derive(Debug)]
@@ -913,9 +933,101 @@ pub struct H3RecvStream {
     rctx: RecvStreamReceiveCtx,
 }
 
-struct BufPtr(*const c_void);
-unsafe impl Send for BufPtr {}
-unsafe impl Sync for BufPtr {}
+/// Send-side command-executor seam: acts on an already-open stream. Stored behind
+/// a trait object in [`H3SendStream`] so a test double (the Phase 8 `CountingExec`)
+/// can replace it without a live connection. The production implementation is
+/// [`StreamExecutor`].
+///
+/// `Send + Sync` keep `H3SendStream` `Send + Sync` (as it was when it held the
+/// `Arc<msquic::Stream>` directly).
+trait SendExec: std::fmt::Debug + Send + Sync {
+    /// Box the already-validated non-empty [`SendBuffer`], `Box::into_raw` it as
+    /// `client_context`, and call `Stream::send`. On an immediate `Err` the box is
+    /// reconstructed and dropped here (MsQuic took no ownership and will deliver no
+    /// `SendComplete`), before returning.
+    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status>;
+    /// `Stream::shutdown(GRACEFUL)` — the FIN for a graceful finish.
+    fn submit_graceful(&mut self) -> Result<(), Status>;
+    /// `Stream::shutdown(ABORT_SEND)` with an already-clamped application code.
+    /// Unused until Phase 7's send reset; defined here so the seam is complete.
+    #[allow(dead_code)] // wired at the reset call site in Phase 7
+    fn submit_reset(&mut self, code: u64) -> Result<(), Status>;
+}
+
+/// Production send-side seam. Owns the `Arc<msquic::Stream>` and issues real
+/// native send/shutdown downcalls.
+#[derive(Debug)]
+struct StreamExecutor {
+    stream: Arc<msquic::Stream>,
+}
+
+impl SendExec for StreamExecutor {
+    fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
+        // Box the self-referential SendBuffer and hand its raw pointer to MsQuic
+        // as `client_context`. `buf`'s single `BufferRef` points into the owned
+        // `Bytes` heap storage and stays valid because the box is not moved again
+        // until the `SendComplete` callback (or the immediate-failure reclaim
+        // below) reconstructs it.
+        let cc: *mut SendBuffer = Box::into_raw(Box::new(buf));
+        // SAFETY: `cc` is a live `Box<SendBuffer>` leaked just above; `(*cc)` is a
+        // unique, valid reference. Its `buffers` memory stays valid until the
+        // `SendComplete` callback reconstructs and drops the box (`Stream::send`'s
+        // documented contract). FIN is not set on a data send — a graceful finish
+        // is a separate `submit_graceful` shutdown call.
+        let res = unsafe {
+            self.stream
+                .send((*cc).buffers(), SendFlags::NONE, cc as *const c_void)
+        };
+        if let Err(status) = res {
+            // Immediate failure: MsQuic took no ownership and delivers no
+            // `SendComplete`, so reclaim the box here (mirroring the callback drop)
+            // before returning. Reclaimed exactly once.
+            // SAFETY: `cc` is the pointer from `Box::into_raw` above; MsQuic did
+            // not take ownership on an error, so this is the sole reclamation.
+            drop(unsafe { Box::from_raw(cc) });
+            return Err(status);
+        }
+        Ok(())
+    }
+
+    fn submit_graceful(&mut self) -> Result<(), Status> {
+        // GRACEFUL FIN; the error_code is ignored for a graceful shutdown.
+        self.stream.shutdown(StreamShutdownFlags::GRACEFUL, 0)
+    }
+
+    fn submit_reset(&mut self, code: u64) -> Result<(), Status> {
+        self.stream.shutdown(StreamShutdownFlags::ABORT_SEND, code)
+    }
+}
+
+/// Connection-scoped open seam: *creates and starts* the native stream, returning
+/// the pre-ID [`OpeningStream`]. Separate from [`SendExec`] because it cannot act
+/// on an `Arc<Stream>` that does not exist yet. Stored in [`StreamOpener`] so a
+/// test can substitute the native open/start. Production is [`StreamOpenExecutor`].
+trait OpenExec: std::fmt::Debug + Send + Sync {
+    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status>;
+}
+
+/// Production open seam: the real `Stream::open` + `Stream::start`.
+#[derive(Debug)]
+struct StreamOpenExecutor;
+
+impl OpenExec for StreamOpenExecutor {
+    fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
+        H3Stream::open_and_start(conn, uni)
+    }
+}
+
+#[cfg(test)]
+impl H3SendStream {
+    /// Test/internal constructor: inject any [`SendExec`] (including the seam-test
+    /// double) plus a send-side context whose channel senders the test retains.
+    /// No live connection or native stream is required — the send path touches
+    /// only `exec` and `sctx`.
+    fn with_exec(exec: Box<dyn SendExec>, sctx: SendStreamReceiveCtx) -> Self {
+        H3SendStream { exec, sctx }
+    }
+}
 
 /// Explicit receive-side event delivered from the stream callback to the
 /// frontend receive half.
@@ -938,8 +1050,8 @@ enum ReceiveEvent {
 
 struct StreamSendCtx {
     start: Option<oneshot::Sender<Result<u64, Status>>>,
-    // cancelled, client_context
-    send: Option<mpsc::UnboundedSender<(bool, BufPtr)>>,
+    // send-completion signal: `cancelled`
+    send: Option<mpsc::UnboundedSender<bool>>,
     shutdown: Option<oneshot::Sender<()>>,
     receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,
     /// First-writer-wins guard for the receive scope: once a `Fin`, `Reset`, or
@@ -974,8 +1086,10 @@ struct SendStreamReceiveCtx {
     /// Cached, validated stream identity (see [`RecvStreamReceiveCtx::id`]); read
     /// by `send_id` without a native query.
     id: h3::quic::StreamId,
-    // cancelled, client_context
-    send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
+    // send-completion signal: `cancelled`. The owned `SendBuffer` behind the
+    // completed send is already reclaimed by the callback, so only the outcome
+    // flag crosses this channel.
+    send: mpsc::UnboundedReceiver<bool>,
     send_inprogress: bool,
     shutdown: oneshot::Receiver<()>,
 }
@@ -987,7 +1101,7 @@ struct SendStreamReceiveCtx {
 #[derive(Debug)]
 struct PreIdReceivers {
     start: oneshot::Receiver<Result<u64, Status>>,
-    send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
+    send: mpsc::UnboundedReceiver<bool>,
     shutdown: oneshot::Receiver<()>,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
@@ -1011,7 +1125,7 @@ struct OpeningStream {
 /// be polled independently while these wait for `finalize`).
 #[derive(Debug)]
 struct PreIdTail {
-    send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
+    send: mpsc::UnboundedReceiver<bool>,
     shutdown: oneshot::Receiver<()>,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
@@ -1033,7 +1147,9 @@ impl OpeningStream {
         } = tail;
         H3Stream {
             send: H3SendStream {
-                stream: stream.clone(),
+                exec: Box::new(StreamExecutor {
+                    stream: stream.clone(),
+                }),
                 sctx: SendStreamReceiveCtx {
                     id,
                     send,
@@ -1130,11 +1246,24 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             cancelled,
             client_context,
         } => {
+            // Owned-buffer reclamation (Phase 6): reconstruct and drop the
+            // `Box<SendBuffer>` handed to MsQuic as `client_context` BEFORE
+            // enqueueing the completion, so the allocation is reclaimed exactly
+            // once even if the frontend receiver is gone. MsQuic guarantees
+            // `SendComplete` ends its use of the submitted buffers.
+            //
+            // SAFETY: every successful adapter send passes exactly one
+            // `Box::into_raw(Box<SendBuffer>)` as `client_context`, and MsQuic
+            // returns that same pointer here exactly once. A null pointer means no
+            // owned buffer was attached (e.g. a test-synthesized event), so it is
+            // skipped rather than dereferenced.
+            if let Some(cc) = std::ptr::NonNull::new(client_context as *mut SendBuffer) {
+                drop(unsafe { Box::from_raw(cc.as_ptr()) });
+            }
             if let Some(send) = ctx.send.as_ref() {
-                // NOTE: on delivery failure (frontend gone) the buffer behind
-                // `client_context` is not reclaimed here; that structural
-                // reclamation lands in Phase 6. Phase 1 only removes the panic.
-                let _ = send.unbounded_send((cancelled, BufPtr(client_context)));
+                // The buffer is already reclaimed above; only the outcome flag is
+                // forwarded to `poll_ready`. A gone frontend is a safe no-op.
+                let _ = send.unbounded_send(cancelled);
             }
         }
         StreamEvent::Receive { buffers, flags, .. } => {
@@ -1298,11 +1427,10 @@ impl<B: Buf> SendStream<B> for H3SendStream {
             return std::task::Poll::Ready(Ok(()));
         }
         match ready!(self.sctx.send.poll_next_unpin(cx)) {
-            Some((cancelled, ptr)) => {
+            Some(cancelled) => {
                 self.sctx.send_inprogress = false;
-                // reattach buff
-                let _: H3Buff<h3::quic::WriteBuf<B>> =
-                    unsafe { H3Buff::from_raw(ptr.0 as *mut c_void) };
+                // The owned `SendBuffer` was already reclaimed by the
+                // `SendComplete` callback; only the outcome flag arrives here.
                 match cancelled {
                     true => std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(
                         Status::from(StatusCode::QUIC_STATUS_ABORTED).into(),
@@ -1326,16 +1454,39 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         data: T,
     ) -> Result<(), StreamErrorIncoming> {
         if self.sctx.send_inprogress {
-            panic!("send while send is in progress.");
+            // A send is already outstanding: h3 should have gated this behind
+            // `poll_ready`. This is an adapter-internal misuse — report it rather
+            // than panicking across the executor / FFI boundary.
+            return Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(
+                    "send_data called while a send is already in progress".to_string(),
+                ),
+            });
         }
-        let data: h3::quic::WriteBuf<B> = data.into();
-        let buff = H3Buff::new(data);
-        let (buff_ref, ptr) = unsafe { buff.into_raw() };
-        unsafe { self.stream.send(buff_ref, SendFlags::NONE, ptr) }
-            .inspect_err(|_| {
-                // reattach buff
-                let _: H3Buff<h3::quic::WriteBuf<B>> = unsafe { H3Buff::from_raw(ptr) };
-            })
+        let mut data: h3::quic::WriteBuf<B> = data.into();
+        let remaining = data.remaining();
+        // Validate the complete length against the adapter ceiling BEFORE any
+        // allocation or native submission (see the owned-buffer design).
+        match classify_send_len(remaining) {
+            // Empty payload is a successful no-op: no allocation, no native send,
+            // `send_inprogress` stays false.
+            SendLen::Empty => return Ok(()),
+            // Above the ceiling: reject without materializing a buffer or
+            // transmitting. Non-sticky, leaves all state unchanged.
+            SendLen::Oversized => {
+                return Err(StreamErrorIncoming::Unknown(Box::new(OversizedSend {
+                    len: remaining,
+                })));
+            }
+            // `0 < len <= MAX_ADAPTER_SEND`: materialize and submit below.
+            SendLen::NonEmpty => {}
+        }
+        // Materialize the complete wire representation into owned `Bytes` while the
+        // generic `B` is still on this thread, then submit through the send seam.
+        let bytes = data.copy_to_bytes(remaining);
+        let buf = SendBuffer::new(bytes);
+        self.exec
+            .submit_send(buf)
             .map_err(|e| StreamErrorIncoming::Unknown(e.into()))?;
         self.sctx.send_inprogress = true;
         Ok(())
@@ -1350,8 +1501,8 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), StreamErrorIncoming>> {
-        // Graceful sends a Fin to peer.
-        if let Err(e) = self.stream.shutdown(StreamShutdownFlags::GRACEFUL, 0) {
+        // Graceful sends a Fin to peer (through the send seam).
+        if let Err(e) = self.exec.submit_graceful() {
             return std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(e.into())));
         }
         // poll the ctx
@@ -2576,5 +2727,270 @@ mod stream_open_identity {
         // Close the connection (single native ConnectionClose) before the
         // registration is dropped.
         drop(conn);
+    }
+}
+
+/// Phase 6 (Owned `SendBuffer` & command-executor seam) unit tests.
+///
+/// These prove the send seam mechanism WITHOUT a live connection: an injected
+/// [`SendExec`] test double (`CountingExec`) shares the exact allocation/reclaim
+/// contract as the production `StreamExecutor`, and the retained `client_context`
+/// is replayed through the PRODUCTION [`stream_callback`] — the real reconstruct+
+/// drop path — so the exactly-once ownership guarantee is exercised, not mocked.
+/// The comprehensive `CountingExec` matrix + loopback ordering test are Phase 8.
+#[cfg(test)]
+mod send_seam {
+    use std::collections::VecDeque;
+    use std::ffi::c_void;
+    use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+    use std::sync::{Arc, Mutex, PoisonError};
+
+    use bytes::Bytes;
+    use h3::proto::frame::Frame;
+    use h3::quic::{SendStream, StreamErrorIncoming};
+
+    use crate::error::MAX_ADAPTER_SEND;
+    use crate::msquic::{Status, StatusCode, StreamEvent};
+    use crate::{
+        ConnectionErrorIncoming, H3SendStream, OversizedSend, SendBuffer, SendExec,
+        SendStreamReceiveCtx, StreamSendCtx, stream_callback, stream_ctx_channel,
+    };
+
+    /// Shared, inspectable counters + `client_context` slots. A clone is kept by
+    /// the test so every counter stays readable after the `CountingExec` is moved
+    /// into `H3SendStream` behind `Box<dyn SendExec>`.
+    #[derive(Clone, Debug, Default)]
+    struct CountingHandle {
+        sends: Arc<AtomicUsize>,
+        gracefuls: Arc<AtomicUsize>,
+        resets: Arc<AtomicUsize>,
+        /// Total `Box<SendBuffer>` created (`Box::into_raw`).
+        allocs: Arc<AtomicUsize>,
+        /// In-exec reclamations (immediate-failure arm only).
+        reclaims: Arc<AtomicUsize>,
+        /// Raw pointers "native" holds; the test replays each through
+        /// `stream_callback` (the production reclaim path).
+        client_ctx: Arc<Mutex<VecDeque<usize>>>,
+    }
+
+    /// Test double for the send seam. Mirrors `StreamExecutor`'s box/into_raw and
+    /// immediate-failure reclaim EXACTLY, so a scripted result models the real
+    /// allocation and ownership handoff without a native stream.
+    #[derive(Debug)]
+    struct CountingExec {
+        h: CountingHandle,
+        script: VecDeque<Result<(), Status>>,
+    }
+
+    impl CountingExec {
+        fn new(h: CountingHandle, script: VecDeque<Result<(), Status>>) -> Self {
+            Self { h, script }
+        }
+    }
+
+    impl SendExec for CountingExec {
+        fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
+            self.h.sends.fetch_add(1, Relaxed);
+            // Mirror StreamExecutor EXACTLY: box + into_raw BEFORE inspecting the
+            // scripted result, so both arms model the real allocation.
+            let cc = Box::into_raw(Box::new(buf));
+            self.h.allocs.fetch_add(1, Relaxed);
+            match self.script.pop_front().unwrap_or(Ok(())) {
+                Ok(()) => {
+                    // Native accepted ownership: retain the pointer so the test can
+                    // replay the native SendComplete through stream_callback. The
+                    // box is NOT dropped here; it is outstanding until that callback.
+                    self.h
+                        .client_ctx
+                        .lock()
+                        .unwrap_or_else(PoisonError::into_inner)
+                        .push_back(cc as usize);
+                    Ok(())
+                }
+                Err(status) => {
+                    // Immediate failure: MsQuic takes no ownership and delivers no
+                    // SendComplete, so the caller reclaims here and now — exactly as
+                    // StreamExecutor's immediate-Err arm does.
+                    // SAFETY: `cc` is the pointer from `Box::into_raw` above; this is
+                    // its sole reclamation (native took no ownership on Err).
+                    drop(unsafe { Box::from_raw(cc) });
+                    self.h.reclaims.fetch_add(1, Relaxed);
+                    Err(status)
+                }
+            }
+        }
+        fn submit_graceful(&mut self) -> Result<(), Status> {
+            self.h.gracefuls.fetch_add(1, Relaxed);
+            Ok(())
+        }
+        fn submit_reset(&mut self, _code: u64) -> Result<(), Status> {
+            self.h.resets.fetch_add(1, Relaxed);
+            Ok(())
+        }
+    }
+
+    /// Build a send-side context with NO live connection: an id-bearing set of
+    /// channel halves. Returns the frontend `SendStreamReceiveCtx` plus the
+    /// callback-owned `StreamSendCtx` (kept so the test can drive `stream_callback`).
+    fn test_send_ctx() -> (SendStreamReceiveCtx, StreamSendCtx) {
+        let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
+        let (ctx, sctx, _rctx) = stream_ctx_channel(id);
+        (sctx, ctx)
+    }
+
+    #[test]
+    fn send_data_wires_through_seam_and_signals_ready() {
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new())); // all-Ok script
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+
+        // Valid WriteBuf<Bytes>: an h3 DATA frame, built via the real
+        // From<Frame<B>> impl. send_data classifies it NonEmpty and submits.
+        SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"hello world")))
+            .unwrap();
+        assert_eq!(h.sends.load(Relaxed), 1);
+        assert_eq!(h.allocs.load(Relaxed), 1); // one Box<SendBuffer> created
+        assert_eq!(h.reclaims.load(Relaxed), 0); // not the immediate-failure arm
+        assert_eq!(h.client_ctx.lock().unwrap().len(), 1); // outstanding: "native" holds it
+
+        // Replay the native SendComplete through the PRODUCTION callback path.
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: false,
+                client_context: cc as *const c_void,
+            },
+        )
+        .unwrap();
+
+        // The callback reconstructed+dropped the box and enqueued exactly one
+        // completion (`cancelled == false`); a second poll is empty. reclaims stays
+        // 0 (reclaim happened in the callback, not the immediate-failure arm).
+        assert!(
+            !s.sctx.send.try_recv().unwrap(),
+            "completion must report cancelled == false"
+        );
+        assert!(s.sctx.send.try_recv().is_err());
+        assert_eq!(h.reclaims.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn send_buffer_reclaimed_exactly_once_via_callback() {
+        // Concrete exactly-once proof: a drop-counted SendBuffer submitted (Ok) and
+        // reclaimed by the production stream_callback increments its counter from 0
+        // (outstanding) to exactly 1 (reclaimed once).
+        let counter = Arc::new(AtomicUsize::new(0));
+        let buf = SendBuffer::new_counted(Bytes::from_static(b"payload"), counter.clone());
+        let h = CountingHandle::default();
+        let mut exec = CountingExec::new(h.clone(), VecDeque::new());
+
+        exec.submit_send(buf).unwrap();
+        assert_eq!(h.allocs.load(Relaxed), 1);
+        assert_eq!(
+            counter.load(Relaxed),
+            0,
+            "outstanding buffer must not be dropped yet"
+        );
+        assert_eq!(h.client_ctx.lock().unwrap().len(), 1);
+
+        let (_sctx, mut ctx) = test_send_ctx();
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: false,
+                client_context: cc as *const c_void,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            counter.load(Relaxed),
+            1,
+            "callback must reconstruct+drop the Box<SendBuffer> exactly once"
+        );
+        assert_eq!(h.reclaims.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn immediate_send_failure_reclaims_without_completion() {
+        let h = CountingHandle::default();
+        let mut script = VecDeque::new();
+        script.push_back(Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER)));
+        let exec = Box::new(CountingExec::new(h.clone(), script));
+        let (sctx, _ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+
+        // submit_send returns Err; send_data surfaces the error.
+        assert!(
+            SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"hello world")))
+                .is_err()
+        );
+
+        // One allocation, one immediate in-exec reclamation, nothing outstanding,
+        // and ZERO SendComplete callbacks (native took no ownership, emitted none).
+        assert_eq!(h.sends.load(Relaxed), 1);
+        assert_eq!(h.allocs.load(Relaxed), 1);
+        assert_eq!(h.reclaims.load(Relaxed), 1);
+        assert!(h.client_ctx.lock().unwrap().is_empty());
+        assert!(s.sctx.send.try_recv().is_err()); // no Complete event ever enqueued
+    }
+
+    #[test]
+    fn oversized_send_rejected_before_allocation() {
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, _ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+
+        // A payload just past the ceiling: rejected before any copy or submission.
+        let payload = Bytes::from(vec![0u8; MAX_ADAPTER_SEND as usize + 1]);
+        let err = SendStream::<Bytes>::send_data(&mut s, Frame::Data(payload))
+            .expect_err("oversized send must be rejected");
+
+        match err {
+            StreamErrorIncoming::Unknown(e) => {
+                assert!(
+                    e.downcast_ref::<OversizedSend>().is_some(),
+                    "expected OversizedSend, got {e:?}"
+                );
+            }
+            other => panic!("expected Unknown(OversizedSend), got {other:?}"),
+        }
+        // No allocation and no native submission occurred, and no send is in flight.
+        assert_eq!(h.sends.load(Relaxed), 0);
+        assert_eq!(h.allocs.load(Relaxed), 0);
+        assert!(s.sctx.send.try_recv().is_err());
+    }
+
+    #[test]
+    fn send_data_while_in_progress_returns_internal_error() {
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new())); // all-Ok
+        let (sctx, _ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+
+        // First send succeeds and marks a send in progress.
+        SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"first"))).unwrap();
+        assert_eq!(h.sends.load(Relaxed), 1);
+
+        // Second send while the first is still outstanding is an internal error
+        // (not a panic), and does not allocate or submit again.
+        let err =
+            SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"second")))
+                .expect_err("send while in progress must error");
+        match err {
+            StreamErrorIncoming::ConnectionErrorIncoming { connection_error } => {
+                assert!(
+                    matches!(connection_error, ConnectionErrorIncoming::InternalError(_)),
+                    "expected InternalError, got {connection_error:?}"
+                );
+            }
+            other => panic!("expected ConnectionErrorIncoming::InternalError, got {other:?}"),
+        }
+        assert_eq!(h.sends.load(Relaxed), 1, "no second native submission");
+        assert_eq!(h.allocs.load(Relaxed), 1, "no second allocation");
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -23,7 +23,9 @@ mod buffer;
 use buffer::{SendBuffer, SendLen, classify_send_len};
 mod error;
 use error::{
-    ConnectionTerminal, ReceiveTerminal, clamp_application_code, convert_conn, convert_recv,
+    ConnectionTerminal, ReceiveTerminal, SendCommand, SendEvent, SendInput, SendPayload, SendPoll,
+    SendState, SendTerminal, clamp_application_code, convert_conn, convert_recv, convert_send,
+    convert_send_op, transition,
 };
 pub use error::{LocalConnectionClose, LocalStreamReset, MsQuicTransportError, OversizedSend};
 mod listener;
@@ -71,7 +73,8 @@ pub(crate) fn new_conn_terminal_slot() -> ConnTerminalSlot {
 /// (an accept frontend delivering the terminal to h3) has frozen the value.
 /// After the freeze point the winner is immutable. This is the connection-scope
 /// SF-7 / T4 rule; it is deliberately independent of the send-scope cancellation
-/// state (MF-2), which lives in the send reducer and is never written here.
+/// state (MF-2), which lives in the send-terminal slot (as an unobserved
+/// [`SendTerminal::ProvisionalAbort`] marker) and is never written here.
 #[derive(Debug, Default)]
 pub(crate) struct ConnTerminalState {
     terminal: Option<ConnectionTerminal>,
@@ -117,6 +120,60 @@ impl ConnTerminalState {
 /// Record a connection terminal reason into the shared slot.
 fn record_conn_terminal(slot: &ConnTerminalSlot, candidate: ConnectionTerminal) {
     lock_recover(slot).record(candidate);
+}
+
+/// Shared, thread-safe slot recording the sticky *why* a send half terminated.
+///
+/// Written by the stream FFI callback (peer `STOP_SENDING`, connection shutdown)
+/// and by the send-side reducer's local candidates (immediate send/graceful/reset
+/// failure, `LocalReset`, internal faults). A single first-writer owns the slot,
+/// except the distinct unobserved provisional cancellation marker
+/// ([`SendTerminal::ProvisionalAbort`], MF-2), which is refined to a later specific
+/// cause or finalized to an authoritative abort at the closure point. Both the
+/// callback and the send frontend hold a clone, so a peer/connection terminal is
+/// observable from `poll_ready`/`poll_finish` even with no send in flight. Never
+/// written into the connection terminal slot (the provisional stays send-scoped).
+pub(crate) type SendTerminalSlot = Arc<Mutex<Option<SendTerminal>>>;
+
+/// Create a fresh, empty send-terminal slot.
+fn new_send_terminal_slot() -> SendTerminalSlot {
+    Arc::new(Mutex::new(None))
+}
+
+/// Read the current sticky send winner (poison-safe clone; `None` if unset).
+fn load_winner(slot: &SendTerminalSlot) -> Option<SendTerminal> {
+    lock_recover(slot).clone()
+}
+
+/// First-writer publish of a local send-terminal candidate, returning whichever
+/// value now owns the slot.
+///
+/// The distinct provisional cancellation marker ([`SendTerminal::ProvisionalAbort`],
+/// MF-2) already in the slot is refined by a later authoritative candidate (a
+/// specific peer/connection cause, a `LocalReset`, or the closure-point abort); an
+/// authoritative winner is never overwritten. The callback and the reducer race
+/// into the same slot; whichever authoritative cause lands first wins, and the
+/// unobserved provisional marker never permanently masks it.
+fn publish_send(slot: &SendTerminalSlot, candidate: SendTerminal) -> SendTerminal {
+    let mut guard = lock_recover(slot);
+    match &*guard {
+        // Empty slot: this candidate wins. Return it directly (no re-clone/unwrap).
+        None => {
+            *guard = Some(candidate.clone());
+            candidate
+        }
+        Some(existing) => {
+            if existing.is_provisional() && !candidate.is_provisional() {
+                // Refine the unobserved provisional marker to the authoritative cause.
+                *guard = Some(candidate.clone());
+                candidate
+            } else {
+                // First authoritative writer (or a provisional that cannot refine an
+                // existing value) keeps the slot; surface the current owner.
+                existing.clone()
+            }
+        }
+    }
 }
 
 /// Classify a transport shutdown status into a connection terminal reason.
@@ -764,10 +821,8 @@ impl<B: Buf> OpenStreams<B> for StreamOpener {
         // before the downcall. A concurrent peer/transport cause may still
         // refine it until an accept frontend observes the terminal.
         record_conn_terminal(self.conn.terminal(), ConnectionTerminal::LocalClose);
-        self.conn.shutdown(
-            ConnectionShutdownFlags::NONE,
-            clamp_application_code(code.value()),
-        );
+        self.open_exec
+            .submit_conn_shutdown(&self.conn, clamp_application_code(code.value()));
     }
 }
 
@@ -929,7 +984,7 @@ pub struct H3SendStream {
 }
 #[derive(Debug)]
 pub struct H3RecvStream {
-    stream: Arc<msquic::Stream>,
+    exec: Box<dyn RecvExec>,
     rctx: RecvStreamReceiveCtx,
 }
 
@@ -949,8 +1004,7 @@ trait SendExec: std::fmt::Debug + Send + Sync {
     /// `Stream::shutdown(GRACEFUL)` — the FIN for a graceful finish.
     fn submit_graceful(&mut self) -> Result<(), Status>;
     /// `Stream::shutdown(ABORT_SEND)` with an already-clamped application code.
-    /// Unused until Phase 7's send reset; defined here so the seam is complete.
-    #[allow(dead_code)] // wired at the reset call site in Phase 7
+    /// Wired at the `SendStream::reset` call site (Phase 7).
     fn submit_reset(&mut self, code: u64) -> Result<(), Status>;
 }
 
@@ -1000,12 +1054,41 @@ impl SendExec for StreamExecutor {
     }
 }
 
+/// Receive-side command-executor seam: the recv half's only native downcall is
+/// `stop_sending` (`Stream::shutdown(ABORT_RECEIVE)`). Stored behind a trait
+/// object in [`H3RecvStream`] so a test double can assert the *actual* clamped
+/// code submitted with no live stream. Production is [`RecvStreamExecutor`],
+/// which also owns the recv half's `Arc<msquic::Stream>` clone (SF-1), keeping
+/// the native handle alive for as long as the recv half exists.
+trait RecvExec: std::fmt::Debug + Send + Sync {
+    /// `Stream::shutdown(ABORT_RECEIVE)` with an already-clamped application code.
+    fn submit_stop_sending(&self, code: u64) -> Result<(), Status>;
+}
+
+/// Production receive-side seam. Owns the `Arc<msquic::Stream>` and issues the
+/// real native `ABORT_RECEIVE` shutdown.
+#[derive(Debug)]
+struct RecvStreamExecutor {
+    stream: Arc<msquic::Stream>,
+}
+
+impl RecvExec for RecvStreamExecutor {
+    fn submit_stop_sending(&self, code: u64) -> Result<(), Status> {
+        self.stream
+            .shutdown(StreamShutdownFlags::ABORT_RECEIVE, code)
+    }
+}
+
 /// Connection-scoped open seam: *creates and starts* the native stream, returning
 /// the pre-ID [`OpeningStream`]. Separate from [`SendExec`] because it cannot act
 /// on an `Arc<Stream>` that does not exist yet. Stored in [`StreamOpener`] so a
 /// test can substitute the native open/start. Production is [`StreamOpenExecutor`].
 trait OpenExec: std::fmt::Debug + Send + Sync {
     fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status>;
+    /// `Connection::shutdown(NONE)` for `OpenStreams::close`, with an
+    /// already-clamped application code. Behind the seam so a test double can
+    /// assert the *actual* submitted value without a live connection.
+    fn submit_conn_shutdown(&self, conn: &ConnHandle, code: u64);
 }
 
 /// Production open seam: the real `Stream::open` + `Stream::start`.
@@ -1015,6 +1098,9 @@ struct StreamOpenExecutor;
 impl OpenExec for StreamOpenExecutor {
     fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
         H3Stream::open_and_start(conn, uni)
+    }
+    fn submit_conn_shutdown(&self, conn: &ConnHandle, code: u64) {
+        conn.shutdown(ConnectionShutdownFlags::NONE, code);
     }
 }
 
@@ -1026,6 +1112,31 @@ impl H3SendStream {
     /// only `exec` and `sctx`.
     fn with_exec(exec: Box<dyn SendExec>, sctx: SendStreamReceiveCtx) -> Self {
         H3SendStream { exec, sctx }
+    }
+}
+
+#[cfg(test)]
+impl H3RecvStream {
+    /// Test constructor: inject any [`RecvExec`] (the clamp-recording double) plus
+    /// a receive-side context. No live stream is required — `stop_sending` touches
+    /// only `exec` and `rctx`.
+    fn with_exec(exec: Box<dyn RecvExec>, rctx: RecvStreamReceiveCtx) -> Self {
+        H3RecvStream { exec, rctx }
+    }
+}
+
+#[cfg(test)]
+impl StreamOpener {
+    /// Test constructor: inject any [`OpenExec`] (the clamp-recording double) so
+    /// `close` can be exercised against a real (unstarted) `ConnHandle` without
+    /// any native shutdown reaching the wire.
+    fn with_open_exec(conn: Arc<ConnHandle>, open_exec: Box<dyn OpenExec>) -> Self {
+        Self {
+            conn,
+            bidi_temp: None,
+            uni_temp: None,
+            open_exec,
+        }
     }
 }
 
@@ -1050,9 +1161,13 @@ enum ReceiveEvent {
 
 struct StreamSendCtx {
     start: Option<oneshot::Sender<Result<u64, Status>>>,
-    // send-completion signal: `cancelled`
-    send: Option<mpsc::UnboundedSender<bool>>,
-    shutdown: Option<oneshot::Sender<()>>,
+    /// Single ordered send-event channel (MF-1): data `SendComplete`, terminal
+    /// wakes, and finish completion all ride this one FIFO so chronological
+    /// finish-vs-terminal order is preserved by construction.
+    send: Option<mpsc::UnboundedSender<SendEvent>>,
+    /// Shared sticky send-terminal slot; the callback publishes peer
+    /// `STOP_SENDING` and connection-shutdown reasons here (first-writer).
+    send_terminal: SendTerminalSlot,
     receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,
     /// First-writer-wins guard for the receive scope: once a `Fin`, `Reset`, or
     /// `Connection` terminal has been published, later receive events are
@@ -1086,12 +1201,15 @@ struct SendStreamReceiveCtx {
     /// Cached, validated stream identity (see [`RecvStreamReceiveCtx::id`]); read
     /// by `send_id` without a native query.
     id: h3::quic::StreamId,
-    // send-completion signal: `cancelled`. The owned `SendBuffer` behind the
-    // completed send is already reclaimed by the callback, so only the outcome
-    // flag crosses this channel.
-    send: mpsc::UnboundedReceiver<bool>,
-    send_inprogress: bool,
-    shutdown: oneshot::Receiver<()>,
+    /// Shared sticky send-terminal slot (see [`SendTerminalSlot`]). Loaded on
+    /// every reducer input as the current winner; local candidates are published
+    /// here via the first-writer helper.
+    send_terminal: SendTerminalSlot,
+    /// Single ordered send-event source (MF-1): data completion, terminal wake,
+    /// and finish completion. The reducer observes it only as a [`SendPoll`].
+    send: mpsc::UnboundedReceiver<SendEvent>,
+    /// Pure send-side reducer bookkeeping (replaces the old `send_inprogress`).
+    reducer: SendState,
 }
 
 /// Frontend *receiver* ends held by an [`OpeningStream`] until the stream ID is
@@ -1101,8 +1219,9 @@ struct SendStreamReceiveCtx {
 #[derive(Debug)]
 struct PreIdReceivers {
     start: oneshot::Receiver<Result<u64, Status>>,
-    send: mpsc::UnboundedReceiver<bool>,
-    shutdown: oneshot::Receiver<()>,
+    send: mpsc::UnboundedReceiver<SendEvent>,
+    /// Shared send-terminal slot clone, moved into the send half by `finalize`.
+    send_terminal: SendTerminalSlot,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
 
@@ -1125,8 +1244,8 @@ struct OpeningStream {
 /// be polled independently while these wait for `finalize`).
 #[derive(Debug)]
 struct PreIdTail {
-    send: mpsc::UnboundedReceiver<bool>,
-    shutdown: oneshot::Receiver<()>,
+    send: mpsc::UnboundedReceiver<SendEvent>,
+    send_terminal: SendTerminalSlot,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
 
@@ -1142,7 +1261,7 @@ impl OpeningStream {
         } = self;
         let PreIdTail {
             send,
-            shutdown,
+            send_terminal,
             receive,
         } = tail;
         H3Stream {
@@ -1152,13 +1271,13 @@ impl OpeningStream {
                 }),
                 sctx: SendStreamReceiveCtx {
                     id,
+                    send_terminal,
                     send,
-                    send_inprogress: false,
-                    shutdown,
+                    reducer: SendState::new(),
                 },
             },
             recv: H3RecvStream {
-                stream,
+                exec: Box::new(RecvStreamExecutor { stream }),
                 rctx: RecvStreamReceiveCtx {
                     id,
                     receive,
@@ -1177,20 +1296,20 @@ impl OpeningStream {
 fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
     let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
     let (send_tx, send_rx) = mpsc::unbounded();
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let send_terminal = new_send_terminal_slot();
     let (receive_tx, receive_rx) = mpsc::unbounded();
     (
         StreamSendCtx {
             start: Some(start_tx),
             send: Some(send_tx),
-            shutdown: Some(shutdown_tx),
+            send_terminal: send_terminal.clone(),
             receive: Some(receive_tx),
             receive_terminal_sent: false,
         },
         PreIdReceivers {
             start: start_rx,
             send: send_rx,
-            shutdown: shutdown_rx,
+            send_terminal,
             receive: receive_rx,
         },
     )
@@ -1207,16 +1326,16 @@ fn stream_ctx_channel(
     let PreIdReceivers {
         start: _,
         send,
-        shutdown,
+        send_terminal,
         receive,
     } = recv;
     (
         ctx,
         SendStreamReceiveCtx {
             id,
+            send_terminal,
             send,
-            send_inprogress: false,
-            shutdown,
+            reducer: SendState::new(),
         },
         RecvStreamReceiveCtx {
             id,
@@ -1262,8 +1381,9 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             }
             if let Some(send) = ctx.send.as_ref() {
                 // The buffer is already reclaimed above; only the outcome flag is
-                // forwarded to `poll_ready`. A gone frontend is a safe no-op.
-                let _ = send.unbounded_send(cancelled);
+                // forwarded to the reducer via the single ordered channel (MF-1).
+                // A gone frontend is a safe no-op.
+                let _ = send.unbounded_send(SendEvent::Complete { cancelled });
             }
         }
         StreamEvent::Receive { buffers, flags, .. } => {
@@ -1305,10 +1425,21 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             // `StreamTerminated { error_code }`, distinct from a graceful FIN.
             publish_recv_terminal(ctx, ReceiveEvent::Reset(error_code));
         }
-        StreamEvent::SendShutdownComplete { graceful: _ } => {
-            // Peer acknowledged shutdown.
-            if let Some(shutdown) = ctx.shutdown.take() {
-                let _ = shutdown.send(());
+        StreamEvent::PeerReceiveAborted { error_code } => {
+            // Peer STOP_SENDING on OUR send half: publish the sticky send terminal
+            // and wake the send frontend through the single ordered channel so
+            // `poll_ready`/`poll_finish` observe `Stopped(code)` even with no send
+            // in flight (SC-003). First-writer / MF-2 refinement is in `publish_send`.
+            publish_send(&ctx.send_terminal, SendTerminal::Stopped(error_code));
+            if let Some(send) = ctx.send.as_ref() {
+                let _ = send.unbounded_send(SendEvent::TerminalWake);
+            }
+        }
+        StreamEvent::SendShutdownComplete { graceful } => {
+            // Graceful finish (or abort) completed: an ordinary send event on the
+            // single ordered channel (MF-1), so finish-vs-terminal order holds.
+            if let Some(send) = ctx.send.as_ref() {
+                let _ = send.unbounded_send(SendEvent::FinishComplete { graceful });
             }
         }
         StreamEvent::ShutdownComplete {
@@ -1321,7 +1452,9 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
         } => {
             // A connection-caused stream shutdown surfaces the connection error
             // on the receive half (reusing the Phase-3 connection terminal +
-            // convert helpers). A stream-local shutdown publishes no terminal.
+            // convert helpers) and, symmetrically, publishes it as the sticky
+            // send terminal so the send half observes the same reason. A
+            // stream-local shutdown publishes no terminal.
             if connection_shutdown {
                 let reason = classify_conn_shutdown(
                     connection_shutdown_by_app,
@@ -1329,12 +1462,12 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
                     connection_error_code,
                     connection_close_status,
                 );
-                publish_recv_terminal(ctx, ReceiveEvent::Connection(reason));
+                publish_recv_terminal(ctx, ReceiveEvent::Connection(reason.clone()));
+                publish_send(&ctx.send_terminal, SendTerminal::Connection(reason));
             }
             // close all channels
             ctx.receive.take();
             ctx.send.take();
-            ctx.shutdown.take();
             ctx.start.take();
         }
         _ => {}
@@ -1374,7 +1507,7 @@ impl H3Stream {
             start: recv.start,
             tail: PreIdTail {
                 send: recv.send,
-                shutdown: recv.shutdown,
+                send_terminal: recv.send_terminal,
                 receive: recv.receive,
             },
         }
@@ -1404,7 +1537,7 @@ impl H3Stream {
             start: recv.start,
             tail: PreIdTail {
                 send: recv.send,
-                shutdown: recv.shutdown,
+                send_terminal: recv.send_terminal,
                 receive: recv.receive,
             },
         })
@@ -1412,8 +1545,7 @@ impl H3Stream {
 }
 
 impl<B: Buf> SendStream<B> for H3SendStream {
-    // Seems like poll_ready is called after send_data is called.
-    // To ensure data is sent.
+    // h3 calls `poll_ready` after `send_data` to await the in-flight send.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, level = "trace", ret)
@@ -1422,26 +1554,56 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), StreamErrorIncoming>> {
-        if !self.sctx.send_inprogress {
-            // no send is current so ready to get more.
-            return std::task::Poll::Ready(Ok(()));
+        use std::task::Poll;
+        // SF-2 non-consuming finish guard: once a finish has started, `poll_ready`
+        // must NOT poll (and thereby consume) the shared send channel — a consumed
+        // `FinishComplete` would be lost and hang a later `poll_finish`. Resolve
+        // purely from non-consuming state: a published terminal winner is surfaced;
+        // otherwise the finish-after-poll_ready misuse (non-sticky).
+        if self.sctx.reducer.finish_started {
+            return match load_winner(&self.sctx.send_terminal) {
+                Some(w) => Poll::Ready(Err(convert_send(w))),
+                None => Poll::Ready(Err(convert_send(SendTerminal::Internal(
+                    "poll_ready after finish",
+                )))),
+            };
         }
-        match ready!(self.sctx.send.poll_next_unpin(cx)) {
-            Some(cancelled) => {
-                self.sctx.send_inprogress = false;
-                // The owned `SendBuffer` was already reclaimed by the
-                // `SendComplete` callback; only the outcome flag arrives here.
-                match cancelled {
-                    true => std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(
-                        Status::from(StatusCode::QUIC_STATUS_ABORTED).into(),
-                    ))),
-                    false => std::task::Poll::Ready(Ok(())),
+        // First input polls the channel; subsequent inputs are fed results.
+        let mut input = SendInput::PollReady {
+            poll: self.poll_send_channel(cx),
+            terminal: load_winner(&self.sctx.send_terminal),
+        };
+        loop {
+            match transition(&mut self.sctx.reducer, input) {
+                SendCommand::Pending => return Poll::Pending, // waker already registered
+                SendCommand::ReturnReady => return Poll::Ready(Ok(())),
+                SendCommand::ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
+                SendCommand::RepollReady => {
+                    // Re-poll the channel in THIS call so a synchronously-queued
+                    // paired terminal / channel close (the closure point) is drained
+                    // or the waker re-armed — the retained provisional cancellation
+                    // (MF-2) is never returned to the caller.
+                    input = SendInput::PollReady {
+                        poll: self.poll_send_channel(cx),
+                        terminal: load_winner(&self.sctx.send_terminal),
+                    };
+                }
+                SendCommand::PublishTerminal {
+                    candidate,
+                    continuation,
+                } => {
+                    let winner = publish_send(&self.sctx.send_terminal, candidate);
+                    input = SendInput::TerminalPublished {
+                        winner,
+                        continuation,
+                    };
+                }
+                _ => {
+                    return Poll::Ready(Err(convert_send(SendTerminal::Internal(
+                        "unexpected poll_ready command",
+                    ))));
                 }
             }
-            // closed.
-            None => std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(
-                Status::from(StatusCode::QUIC_STATUS_ABORTED).into(),
-            ))),
         }
     }
 
@@ -1453,46 +1615,54 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         &mut self,
         data: T,
     ) -> Result<(), StreamErrorIncoming> {
-        if self.sctx.send_inprogress {
-            // A send is already outstanding: h3 should have gated this behind
-            // `poll_ready`. This is an adapter-internal misuse — report it rather
-            // than panicking across the executor / FFI boundary.
-            return Err(StreamErrorIncoming::ConnectionErrorIncoming {
-                connection_error: ConnectionErrorIncoming::InternalError(
-                    "send_data called while a send is already in progress".to_string(),
-                ),
-            });
-        }
-        let mut data: h3::quic::WriteBuf<B> = data.into();
-        let remaining = data.remaining();
-        // Validate the complete length against the adapter ceiling BEFORE any
-        // allocation or native submission (see the owned-buffer design).
-        match classify_send_len(remaining) {
-            // Empty payload is a successful no-op: no allocation, no native send,
-            // `send_inprogress` stays false.
-            SendLen::Empty => return Ok(()),
-            // Above the ceiling: reject without materializing a buffer or
-            // transmitting. Non-sticky, leaves all state unchanged.
-            SendLen::Oversized => {
-                return Err(StreamErrorIncoming::Unknown(Box::new(OversizedSend {
-                    len: remaining,
-                })));
+        // The generic `WriteBuf<B>` stays on this frontend stack; only its length
+        // classification enters the reducer. Owned bytes are materialized solely
+        // when the reducer returns `SubmitSend`, so nothing is copied on a
+        // terminal / misuse / oversized / empty path.
+        let mut wb: h3::quic::WriteBuf<B> = data.into();
+        let payload = classify_payload(wb.remaining());
+        let mut input = SendInput::SendRequested {
+            payload,
+            terminal: load_winner(&self.sctx.send_terminal),
+        };
+        loop {
+            match transition(&mut self.sctx.reducer, input) {
+                SendCommand::ReturnSent => return Ok(()),
+                SendCommand::ReturnImmediateError(e) => return Err(convert_send_op(e)),
+                SendCommand::ReturnError(t) => return Err(convert_send(t)),
+                SendCommand::SubmitSend => {
+                    // The single production copy path: materialize the complete
+                    // wire representation into owned `Bytes` while `B` is still on
+                    // this thread, then hand it to the seam (which reclaims the box
+                    // itself on an immediate `Err`).
+                    let remaining = wb.remaining();
+                    let buf = SendBuffer::new(wb.copy_to_bytes(remaining));
+                    let res = self.exec.submit_send(buf);
+                    input = SendInput::SendSubmitted {
+                        result: res,
+                        terminal: load_winner(&self.sctx.send_terminal),
+                    };
+                }
+                SendCommand::PublishTerminal {
+                    candidate,
+                    continuation,
+                } => {
+                    let winner = publish_send(&self.sctx.send_terminal, candidate);
+                    input = SendInput::TerminalPublished {
+                        winner,
+                        continuation,
+                    };
+                }
+                _ => {
+                    return Err(convert_send(SendTerminal::Internal(
+                        "unexpected send_data command",
+                    )));
+                }
             }
-            // `0 < len <= MAX_ADAPTER_SEND`: materialize and submit below.
-            SendLen::NonEmpty => {}
         }
-        // Materialize the complete wire representation into owned `Bytes` while the
-        // generic `B` is still on this thread, then submit through the send seam.
-        let bytes = data.copy_to_bytes(remaining);
-        let buf = SendBuffer::new(bytes);
-        self.exec
-            .submit_send(buf)
-            .map_err(|e| StreamErrorIncoming::Unknown(e.into()))?;
-        self.sctx.send_inprogress = true;
-        Ok(())
     }
 
-    // Send FIN signal to peer.
+    // Send FIN signal to peer (graceful shutdown), idempotently.
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, level = "trace", ret)
@@ -1501,31 +1671,123 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), StreamErrorIncoming>> {
-        // Graceful sends a Fin to peer (through the send seam).
-        if let Err(e) = self.exec.submit_graceful() {
-            return std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(e.into())));
+        use std::task::Poll;
+        let mut input = SendInput::PollFinish {
+            poll: self.poll_send_channel(cx),
+            terminal: load_winner(&self.sctx.send_terminal),
+        };
+        loop {
+            match transition(&mut self.sctx.reducer, input) {
+                SendCommand::Pending => return Poll::Pending,
+                SendCommand::ReturnFinished => return Poll::Ready(Ok(())),
+                SendCommand::ReturnError(t) => return Poll::Ready(Err(convert_send(t))),
+                SendCommand::SubmitGraceful => {
+                    let res = self.exec.submit_graceful();
+                    input = SendInput::GracefulSubmitted {
+                        result: res,
+                        terminal: load_winner(&self.sctx.send_terminal),
+                    };
+                }
+                SendCommand::RepollFinish => {
+                    // Re-poll the channel in THIS call so a synchronously-queued
+                    // `FinishComplete` is drained (or the waker re-armed) — never
+                    // defer to a later poll (that recreates the lost-waker bug).
+                    input = SendInput::PollFinish {
+                        poll: self.poll_send_channel(cx),
+                        terminal: load_winner(&self.sctx.send_terminal),
+                    };
+                }
+                SendCommand::PublishTerminal {
+                    candidate,
+                    continuation,
+                } => {
+                    let winner = publish_send(&self.sctx.send_terminal, candidate);
+                    input = SendInput::TerminalPublished {
+                        winner,
+                        continuation,
+                    };
+                }
+                _ => {
+                    return Poll::Ready(Err(convert_send(SendTerminal::Internal(
+                        "unexpected poll_finish command",
+                    ))));
+                }
+            }
         }
-        // poll the ctx
-        let rx = &mut self.sctx.shutdown;
-        let p = Pin::new(rx);
-        // if backend is closed return error.
-        let res = ready!(std::future::Future::poll(p, cx)).map_err(|_| {
-            StreamErrorIncoming::Unknown(Status::from(StatusCode::QUIC_STATUS_ABORTED).into())
-        });
-        std::task::Poll::Ready(res)
     }
 
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, level = "trace", ret)
     )]
-    fn reset(&mut self, _reset_code: u64) {
-        panic!("reset not supported")
+    fn reset(&mut self, reset_code: u64) {
+        // Infallible: issues at most one native `RESET_STREAM` with a clamped code
+        // through the seam, records the terminal for a later poll, and clears the
+        // reset reservation. A callback-published peer/connection terminal wins
+        // over this local reset (no second native op).
+        let mut input = SendInput::Reset {
+            code: clamp_application_code(reset_code),
+            terminal: load_winner(&self.sctx.send_terminal),
+        };
+        loop {
+            match transition(&mut self.sctx.reducer, input) {
+                SendCommand::NoOp => return, // already terminal / published
+                SendCommand::SubmitReset(c) => {
+                    let res = self.exec.submit_reset(c);
+                    input = SendInput::ResetSubmitted {
+                        code: c,
+                        result: res,
+                        terminal: load_winner(&self.sctx.send_terminal),
+                    };
+                }
+                SendCommand::PublishTerminal {
+                    candidate,
+                    continuation,
+                } => {
+                    let winner = publish_send(&self.sctx.send_terminal, candidate);
+                    input = SendInput::TerminalPublished {
+                        winner,
+                        continuation,
+                    };
+                }
+                // reset consumes any terminal; nothing to surface to h3 now.
+                _ => return,
+            }
+        }
     }
 
     fn send_id(&self) -> h3::quic::StreamId {
         // Cached at construction; no native query, so this never panics.
         self.sctx.id
+    }
+}
+
+impl H3SendStream {
+    /// Poll the single ordered send-event channel (MF-1) into a [`SendPoll`].
+    ///
+    /// A closed channel with no queued event is an adapter-internal fault
+    /// (`SendPoll::Closed`), distinct from `Pending`; the reducer surfaces a
+    /// published terminal winner ahead of it, so a normal connection-shutdown
+    /// close still yields the terminal reason rather than `Closed`.
+    fn poll_send_channel(&mut self, cx: &mut std::task::Context<'_>) -> SendPoll {
+        match self.sctx.send.poll_next_unpin(cx) {
+            std::task::Poll::Ready(Some(ev)) => SendPoll::Event(ev),
+            std::task::Poll::Ready(None) => SendPoll::Closed,
+            std::task::Poll::Pending => SendPoll::Pending,
+        }
+    }
+}
+
+/// Classify a `send_data` payload length into a [`SendPayload`] before any
+/// allocation. The `NonEmpty` upper bound is `MAX_ADAPTER_SEND` (< `u32::MAX`),
+/// so the `as u32` cast never truncates.
+fn classify_payload(remaining: usize) -> SendPayload {
+    match classify_send_len(remaining) {
+        SendLen::Empty => SendPayload::Empty,
+        SendLen::Oversized => SendPayload::Oversized { len: remaining },
+        SendLen::NonEmpty => SendPayload::NonEmpty {
+            len: remaining as u32,
+        },
     }
 }
 
@@ -1606,11 +1868,10 @@ impl RecvStream for H3RecvStream {
         tracing::instrument(skip_all, level = "trace", ret)
     )]
     fn stop_sending(&mut self, error_code: u64) {
-        // Close the send path (code already clamped, Phase 2).
-        let _ = self.stream.shutdown(
-            StreamShutdownFlags::ABORT_RECEIVE,
-            clamp_application_code(error_code),
-        );
+        // Close the send path (code clamped here through the seam, Phase 2/7).
+        let _ = self
+            .exec
+            .submit_stop_sending(clamp_application_code(error_code));
         // SF-6: sticky local end-of-stream. Subsequent `poll_data` returns a
         // clean `Ok(None)` and injects NO receive terminal (`terminal`
         // untouched). Set unconditionally via the local-state seam: the FFI
@@ -2764,6 +3025,8 @@ mod send_seam {
         sends: Arc<AtomicUsize>,
         gracefuls: Arc<AtomicUsize>,
         resets: Arc<AtomicUsize>,
+        /// Every clamped code submitted to `submit_reset`, in order.
+        reset_codes: Arc<Mutex<Vec<u64>>>,
         /// Total `Box<SendBuffer>` created (`Box::into_raw`).
         allocs: Arc<AtomicUsize>,
         /// In-exec reclamations (immediate-failure arm only).
@@ -2823,8 +3086,13 @@ mod send_seam {
             self.h.gracefuls.fetch_add(1, Relaxed);
             Ok(())
         }
-        fn submit_reset(&mut self, _code: u64) -> Result<(), Status> {
+        fn submit_reset(&mut self, code: u64) -> Result<(), Status> {
             self.h.resets.fetch_add(1, Relaxed);
+            self.h
+                .reset_codes
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(code);
             Ok(())
         }
     }
@@ -2868,8 +3136,9 @@ mod send_seam {
         // The callback reconstructed+dropped the box and enqueued exactly one
         // completion (`cancelled == false`); a second poll is empty. reclaims stays
         // 0 (reclaim happened in the callback, not the immediate-failure arm).
-        assert!(
-            !s.sctx.send.try_recv().unwrap(),
+        assert_eq!(
+            s.sctx.send.try_recv().unwrap(),
+            crate::error::SendEvent::Complete { cancelled: false },
             "completion must report cancelled == false"
         );
         assert!(s.sctx.send.try_recv().is_err());
@@ -2992,5 +3261,571 @@ mod send_seam {
         }
         assert_eq!(h.sends.load(Relaxed), 1, "no second native submission");
         assert_eq!(h.allocs.load(Relaxed), 1, "no second allocation");
+    }
+
+    // ── Phase 7 frontend tests (reducer-driven send state machine) ──
+
+    /// A leaked no-op waker gives a `'static` context reusable across polls.
+    fn noop_cx() -> std::task::Context<'static> {
+        let waker = Box::leak(Box::new(futures::task::noop_waker()));
+        std::task::Context::from_waker(waker)
+    }
+
+    #[test]
+    fn reset_issues_one_clamped_reset_stream_via_seam() {
+        // reset submits exactly one native RESET_STREAM whose code is clamped to
+        // the varint max at/below/above the ceiling; a second reset is a no-op.
+        let max = (1u64 << 62) - 1;
+        for (input, expected) in [(max, max), (1u64 << 62, max), (u64::MAX, max)] {
+            let h = CountingHandle::default();
+            let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+            let (sctx, _ctx) = test_send_ctx();
+            let mut s = H3SendStream::with_exec(exec, sctx);
+
+            // Infallible: returns `()`, never panics.
+            SendStream::<Bytes>::reset(&mut s, input);
+            assert_eq!(h.resets.load(Relaxed), 1, "exactly one native reset");
+            assert_eq!(
+                h.reset_codes.lock().unwrap().as_slice(),
+                &[expected],
+                "submitted reset code must be clamped (input {input:#x})"
+            );
+            assert!(
+                !s.sctx.reducer.reset_submitting,
+                "the reset reservation is cleared"
+            );
+
+            // A second reset finds the terminal already recorded: no second op.
+            SendStream::<Bytes>::reset(&mut s, input);
+            assert_eq!(h.resets.load(Relaxed), 1, "no second native reset");
+        }
+    }
+
+    #[test]
+    fn sf2_finish_completion_survives_intervening_poll_ready() {
+        // SF-2: an intervening poll_ready after finish must NOT consume the queued
+        // finish completion; a later poll_finish still observes it (no hang/loss).
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        // Start finish on an idle stream: one graceful shutdown, then Pending.
+        assert!(matches!(
+            SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+            std::task::Poll::Pending
+        ));
+        assert_eq!(h.gracefuls.load(Relaxed), 1);
+
+        // The native completion is queued on the single ordered channel.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendShutdownComplete { graceful: true },
+        )
+        .unwrap();
+
+        // SF-2 guard: poll_ready returns WITHOUT polling (consuming) the channel.
+        assert!(
+            matches!(
+                SendStream::<Bytes>::poll_ready(&mut s, &mut cx),
+                std::task::Poll::Ready(Err(_))
+            ),
+            "poll_ready after finish is a non-consuming error"
+        );
+
+        // The finish completion was preserved: poll_finish still completes cleanly.
+        assert!(
+            matches!(
+                SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+                std::task::Poll::Ready(Ok(()))
+            ),
+            "queued finish completion must survive the intervening poll_ready"
+        );
+        assert_eq!(
+            h.gracefuls.load(Relaxed),
+            1,
+            "graceful submitted exactly once"
+        );
+    }
+
+    #[test]
+    fn poll_finish_is_idempotent_one_graceful() {
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        // First poll_finish submits the graceful shutdown.
+        assert!(matches!(
+            SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+            std::task::Poll::Pending
+        ));
+        // Second poll_finish BEFORE completion must not re-submit.
+        assert!(matches!(
+            SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+            std::task::Poll::Pending
+        ));
+        assert_eq!(h.gracefuls.load(Relaxed), 1, "no second graceful shutdown");
+
+        // Complete the finish; subsequent polls are absorbing Ok, still one graceful.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendShutdownComplete { graceful: true },
+        )
+        .unwrap();
+        assert!(matches!(
+            SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+            std::task::Poll::Ready(Ok(()))
+        ));
+        assert!(matches!(
+            SendStream::<Bytes>::poll_finish(&mut s, &mut cx),
+            std::task::Poll::Ready(Ok(()))
+        ));
+        assert_eq!(h.gracefuls.load(Relaxed), 1);
+    }
+
+    #[test]
+    fn peer_stop_sending_observable_without_send_in_flight() {
+        // SC-003: a peer STOP_SENDING with no send in flight is observable at both
+        // poll_ready and poll_finish as StreamTerminated{code}.
+        for use_finish in [false, true] {
+            let h = CountingHandle::default();
+            let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+            let (sctx, mut ctx) = test_send_ctx();
+            let mut s = H3SendStream::with_exec(exec, sctx);
+            let mut cx = noop_cx();
+
+            stream_callback(&mut ctx, StreamEvent::PeerReceiveAborted { error_code: 42 }).unwrap();
+
+            let got = if use_finish {
+                SendStream::<Bytes>::poll_finish(&mut s, &mut cx)
+            } else {
+                SendStream::<Bytes>::poll_ready(&mut s, &mut cx)
+            };
+            match got {
+                std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated {
+                    error_code,
+                })) => assert_eq!(error_code, 42),
+                other => panic!("expected StreamTerminated{{42}}, got {other:?}"),
+            }
+            assert_eq!(h.sends.load(Relaxed), 0, "no send was ever issued");
+        }
+    }
+
+    #[test]
+    fn reset_loses_to_published_peer_terminal_no_native_op() {
+        // Local reset racing peer STOP_SENDING, terminal-first order: the
+        // callback-published terminal wins, no native reset is issued.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        stream_callback(&mut ctx, StreamEvent::PeerReceiveAborted { error_code: 9 }).unwrap();
+        SendStream::<Bytes>::reset(&mut s, 5); // infallible; sees the terminal
+        assert_eq!(
+            h.resets.load(Relaxed),
+            0,
+            "no native reset behind a terminal"
+        );
+        assert!(
+            !s.sctx.reducer.reset_submitting,
+            "no reservation left behind"
+        );
+
+        // The stable winner is the peer terminal, not the local reset code.
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(error_code, 9)
+            }
+            other => panic!("expected StreamTerminated{{9}}, got {other:?}"),
+        }
+        SendStream::<Bytes>::reset(&mut s, 5);
+        assert_eq!(h.resets.load(Relaxed), 0, "still no native reset");
+    }
+
+    #[test]
+    fn reset_loses_to_published_connection_terminal_no_native_op() {
+        // Local reset racing a connection shutdown, terminal-first order.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        stream_callback(
+            &mut ctx,
+            StreamEvent::ShutdownComplete {
+                connection_shutdown: true,
+                app_close_in_progress: false,
+                connection_shutdown_by_app: true,
+                connection_closed_remotely: true,
+                connection_error_code: 7,
+                connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+            },
+        )
+        .unwrap();
+        SendStream::<Bytes>::reset(&mut s, 5);
+        assert_eq!(
+            h.resets.load(Relaxed),
+            0,
+            "no native reset behind a terminal"
+        );
+        assert!(!s.sctx.reducer.reset_submitting);
+
+        match SendStream::<Bytes>::poll_finish(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 7),
+            other => panic!("expected connection ApplicationClose{{7}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reset_first_stays_stable_winner_with_single_native_reset() {
+        // The other order: local reset genuinely completes first (empty slot), so
+        // it issues exactly one native reset and remains the stable winner even
+        // when a peer terminal is published afterwards (first-writer, non-provisional).
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        SendStream::<Bytes>::reset(&mut s, 5);
+        assert_eq!(h.resets.load(Relaxed), 1);
+        assert!(
+            !s.sctx.reducer.reset_submitting,
+            "the reset reservation is cleared after ResetSubmitted"
+        );
+
+        // A later peer STOP_SENDING cannot overwrite the specific LocalReset winner
+        // nor trigger a second native reset.
+        stream_callback(&mut ctx, StreamEvent::PeerReceiveAborted { error_code: 9 }).unwrap();
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(_))) => {}
+            other => panic!("expected Unknown(LocalStreamReset), got {other:?}"),
+        }
+        assert_eq!(h.resets.load(Relaxed), 1, "still exactly one native reset");
+    }
+
+    #[test]
+    fn reset_first_stays_stable_winner_over_connection_shutdown() {
+        // Item 3(b): the reset-first vs CONNECTION-shutdown race (connection variant
+        // of the peer race above). Local reset completes first (empty slot), so it
+        // issues exactly one native reset and remains the stable winner even when a
+        // connection shutdown is published afterwards; the reservation is cleared.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        SendStream::<Bytes>::reset(&mut s, 5);
+        assert_eq!(h.resets.load(Relaxed), 1);
+        assert!(
+            !s.sctx.reducer.reset_submitting,
+            "the reset reservation is cleared after ResetSubmitted"
+        );
+
+        // A later connection shutdown cannot overwrite the specific LocalReset
+        // winner nor trigger a second native reset.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::ShutdownComplete {
+                connection_shutdown: true,
+                app_close_in_progress: false,
+                connection_shutdown_by_app: true,
+                connection_closed_remotely: true,
+                connection_error_code: 7,
+                connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+            },
+        )
+        .unwrap();
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(_))) => {}
+            other => panic!("expected Unknown(LocalStreamReset), got {other:?}"),
+        }
+        assert_eq!(h.resets.load(Relaxed), 1, "still exactly one native reset");
+    }
+
+    /// Submit one non-empty send through the seam and drive it in-progress, then
+    /// replay a *cancelled* native `SendComplete` through the PRODUCTION callback
+    /// (reconstruct+drop the retained `client_context`). Leaves the cancelled
+    /// completion queued on the single ordered channel, an outstanding-send seam.
+    fn submit_then_cancel(h: &CountingHandle, s: &mut H3SendStream, ctx: &mut StreamSendCtx) {
+        SendStream::<Bytes>::send_data(s, Frame::Data(Bytes::from_static(b"payload"))).unwrap();
+        assert_eq!(h.sends.load(Relaxed), 1, "one native submission");
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            ctx,
+            StreamEvent::SendComplete {
+                cancelled: true,
+                client_context: cc as *const std::ffi::c_void,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn mf2_cancellation_first_refines_to_peer_stop_before_observation() {
+        // Item 3(a): cancellation-FIRST order with an outstanding send. The cancelled
+        // completion is processed BEFORE the paired peer cause; the provisional stays
+        // UNOBSERVED (Pending), then the peer cause published before observation is the
+        // caller's FIRST observed terminal, and it is stable afterwards.
+        // FIRST observation is the refined specific cause, never Failed(ABORTED).
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        submit_then_cancel(&h, &mut s, &mut ctx);
+
+        // Process the cancelled completion with NO cause yet: unobserved, Pending.
+        assert!(
+            matches!(
+                SendStream::<Bytes>::poll_ready(&mut s, &mut cx),
+                std::task::Poll::Pending
+            ),
+            "a no-cause cancellation must NOT freeze/return a provisional abort"
+        );
+
+        // The paired peer cause is published before the caller observes anything.
+        stream_callback(&mut ctx, StreamEvent::PeerReceiveAborted { error_code: 9 }).unwrap();
+
+        // FIRST observation is the refined specific cause, never Failed(ABORTED).
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(error_code, 9)
+            }
+            other => panic!("expected refined StreamTerminated{{9}}, got {other:?}"),
+        }
+        // Stable after observation (frozen): the same class every later poll.
+        match SendStream::<Bytes>::poll_finish(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(error_code, 9)
+            }
+            other => panic!("expected stable StreamTerminated{{9}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mf2_cancellation_first_refines_to_connection_before_observation() {
+        // Item 3(a), connection variant: cancellation-FIRST, then a connection
+        // shutdown refines the unobserved provisional to the connection cause.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        submit_then_cancel(&h, &mut s, &mut ctx);
+
+        assert!(
+            matches!(
+                SendStream::<Bytes>::poll_ready(&mut s, &mut cx),
+                std::task::Poll::Pending
+            ),
+            "unobserved provisional cancellation waits for the closure point"
+        );
+
+        // Connection shutdown publishes Connection(reason) then closes the channel.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::ShutdownComplete {
+                connection_shutdown: true,
+                app_close_in_progress: false,
+                connection_shutdown_by_app: true,
+                connection_closed_remotely: true,
+                connection_error_code: 7,
+                connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+            },
+        )
+        .unwrap();
+
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 7),
+            other => panic!("expected refined connection ApplicationClose{{7}}, got {other:?}"),
+        }
+        // Stable after observation.
+        assert!(matches!(
+            SendStream::<Bytes>::poll_ready(&mut s, &mut cx),
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming { .. }))
+        ));
+    }
+
+    #[test]
+    fn mf2_terminal_first_peer_stop_with_outstanding_send() {
+        // The other callback order (terminal-FIRST) with an outstanding send: the
+        // peer cause is published before the cancelled completion is processed, so it
+        // is surfaced directly — the provisional is never even synthesized.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        // Peer STOP_SENDING (publishes Stopped + TerminalWake) BEFORE the cancelled
+        // completion, mirroring MsQuic's documented PeerReceiveAborted ordering.
+        SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"payload")))
+            .unwrap();
+        stream_callback(&mut ctx, StreamEvent::PeerReceiveAborted { error_code: 4 }).unwrap();
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: true,
+                client_context: cc as *const std::ffi::c_void,
+            },
+        )
+        .unwrap();
+
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(error_code, 4)
+            }
+            other => panic!("expected StreamTerminated{{4}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mf2_cancellation_only_closure_yields_authoritative_abort() {
+        // The truly no-cause case: a cancelled completion followed by the channel
+        // closing with NO published cause reaches the closure point and yields an
+        // authoritative Failed(ABORTED) (Unknown), never a hang.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        submit_then_cancel(&h, &mut s, &mut ctx);
+        assert!(matches!(
+            SendStream::<Bytes>::poll_ready(&mut s, &mut cx),
+            std::task::Poll::Pending
+        ));
+
+        // Close the channel with no cause published (the closure point / stream drop).
+        ctx.send.take();
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(_))) => {}
+            other => panic!("expected authoritative Unknown(ABORTED) at closure, got {other:?}"),
+        }
+    }
+}
+
+/// Phase 7 downcall clamp tests: the recv-side `stop_sending` and the
+/// connection-side `OpenStreams::close` route their outgoing application codes
+/// through `clamp_application_code` before the native shutdown. Each is exercised
+/// through its executor seam so the *actual* submitted value is asserted at the
+/// varint boundary (`(1<<62)-1`, `1<<62`, `u64::MAX`) with no live stream and no
+/// native shutdown reaching the wire.
+#[cfg(test)]
+mod downcall_clamp {
+    use std::sync::{Arc, Mutex};
+
+    use bytes::Bytes;
+    use h3::error::Code;
+    use h3::quic::{OpenStreams, RecvStream};
+
+    use crate::error::clamp_application_code;
+    use crate::msquic::{Connection, ConnectionEvent, ConnectionRef, RegistrationConfig, Status};
+    use crate::registration::RundownGuard;
+    use crate::{
+        ConnHandle, H3RecvStream, OpenExec, OpeningStream, RecvExec, Registration, StreamOpener,
+        new_conn_terminal_slot, stream_ctx_channel,
+    };
+
+    /// Recording recv-side seam: captures every clamped `stop_sending` code.
+    #[derive(Debug, Default)]
+    struct RecordingRecvExec {
+        codes: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl RecvExec for RecordingRecvExec {
+        fn submit_stop_sending(&self, code: u64) -> Result<(), Status> {
+            self.codes.lock().unwrap().push(code);
+            Ok(())
+        }
+    }
+
+    /// Recording open-side seam: captures every clamped `close` code; never opens.
+    #[derive(Debug, Default)]
+    struct RecordingOpenExec {
+        codes: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl OpenExec for RecordingOpenExec {
+        fn submit_open_start(
+            &self,
+            _conn: &ConnHandle,
+            _uni: bool,
+        ) -> Result<OpeningStream, Status> {
+            unimplemented!("close-clamp test never opens a stream")
+        }
+        fn submit_conn_shutdown(&self, _conn: &ConnHandle, code: u64) {
+            self.codes.lock().unwrap().push(code);
+        }
+    }
+
+    const BOUNDARY: [(u64, u64); 3] = [
+        ((1u64 << 62) - 1, (1u64 << 62) - 1),
+        (1u64 << 62, (1u64 << 62) - 1),
+        (u64::MAX, (1u64 << 62) - 1),
+    ];
+
+    #[test]
+    fn stop_sending_submits_clamped_code_via_seam() {
+        for (input, expected) in BOUNDARY {
+            let rec = RecordingRecvExec::default();
+            let codes = rec.codes.clone();
+            let id: h3::quic::StreamId = 0u64.try_into().unwrap();
+            let (_ctx, _sctx, rctx) = stream_ctx_channel(id);
+            let mut r = H3RecvStream::with_exec(Box::new(rec), rctx);
+
+            RecvStream::stop_sending(&mut r, input);
+            assert_eq!(
+                codes.lock().unwrap().as_slice(),
+                &[expected],
+                "stop_sending must submit the clamped code (input {input:#x})"
+            );
+            // Cross-check the clamp helper agrees with the submitted value.
+            assert_eq!(clamp_application_code(input), expected);
+        }
+    }
+
+    #[test]
+    fn open_streams_close_submits_clamped_code_via_seam() {
+        // A single real (unstarted) connection is reused; the recording seam
+        // records the clamped code without any native shutdown reaching the wire.
+        let reg = Registration::new(&RegistrationConfig::default()).unwrap();
+
+        for (input, expected) in BOUNDARY {
+            let inner =
+                Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
+            let guard = RundownGuard::new(reg.state().clone());
+            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+
+            let rec = RecordingOpenExec::default();
+            let codes = rec.codes.clone();
+            let mut opener = StreamOpener::with_open_exec(conn, Box::new(rec));
+
+            OpenStreams::<Bytes>::close(&mut opener, Code::from(input), b"");
+            assert_eq!(
+                codes.lock().unwrap().as_slice(),
+                &[expected],
+                "close must submit the clamped code (input {input:#x})"
+            );
+            assert_eq!(clamp_application_code(input), expected);
+            // Drop the opener (and its ConnHandle) before the next iteration so the
+            // native ConnectionClose runs while the registration is still alive.
+            drop(opener);
+        }
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -14,9 +14,9 @@ use h3::quic::{
     BidiStream, ConnectionErrorIncoming, OpenStreams, RecvStream, SendStream, StreamErrorIncoming,
 };
 use msquic::{
-    Configuration, ConnectionEvent, ConnectionRef, ConnectionShutdownFlags, ReceiveFlags,
-    SendFlags, Status, StatusCode, StreamEvent, StreamOpenFlags, StreamRef, StreamShutdownFlags,
-    StreamStartFlags,
+    BufferRef, Configuration, ConnectionEvent, ConnectionRef, ConnectionShutdownFlags,
+    ReceiveFlags, SendFlags, Status, StatusCode, StreamEvent, StreamOpenFlags, StreamRef,
+    StreamShutdownFlags, StreamStartFlags,
 };
 
 mod buffer;
@@ -136,6 +136,19 @@ impl ConnTerminalState {
 /// Record a connection terminal reason into the shared slot.
 fn record_conn_terminal(slot: &ConnTerminalSlot, candidate: ConnectionTerminal) {
     lock_recover(slot).record(candidate);
+}
+
+/// Freeze the shared connection terminal slot and return its winner.
+///
+/// This is the *stream-side* observation point of the SF-7 / T4 refinement rule
+/// (FR-013): a stream's `poll_data` / `poll_ready` / `poll_finish` freezes the
+/// shared connection winner exactly as the accept frontends' [`observe_terminal`]
+/// does, so a provisional cause refined *before* the stream observes surfaces the
+/// refined value, and a refinement attempted *after* observation is rejected.
+/// `None` only if no reason was ever recorded; the stream callback always records
+/// its fallback before signalling the halves, so this is a defensive fallback.
+fn observe_conn_winner(slot: &ConnTerminalSlot) -> Option<ConnectionTerminal> {
+    lock_recover(slot).observe()
 }
 
 /// Shared, thread-safe slot recording the sticky *why* a send half terminated.
@@ -514,7 +527,7 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
             let id = accept_stream_id(ctx, query)?;
             // Success: only NOW take native ownership and attach.
             let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
-            let h3 = crate::H3Stream::attach(owned, id);
+            let h3 = crate::H3Stream::attach(owned, id, ctx.terminal.clone());
             let target = if flags.contains(StreamOpenFlags::UNIDIRECTIONAL) {
                 ctx.uni.as_ref()
             } else {
@@ -1029,33 +1042,58 @@ struct StreamExecutor {
     stream: Arc<msquic::Stream>,
 }
 
+/// Shared owned-buffer submission transaction (Phase 6 exactly-once contract).
+///
+/// This is the ONE place that performs the `Box::into_raw` → hand-off →
+/// immediate-`Err` `Box::from_raw` ownership dance for a send. It boxes the
+/// already-validated non-empty [`SendBuffer`], leaks it as the `client_context`
+/// raw pointer, and invokes `native` with the buffer slice and that pointer. On
+/// an immediate `Err` (MsQuic took no ownership and will deliver no
+/// `SendComplete`) the box is reconstructed and dropped here — the sole
+/// reclamation — before the error is returned; on `Ok` the box stays outstanding
+/// until the `SendComplete` callback reclaims it.
+///
+/// Both the production [`StreamExecutor`] and the test `CountingExec` route
+/// through this helper, so a regression in the ownership handoff cannot pass in
+/// one and fail in the other.
+fn submit_owned_send(
+    buf: SendBuffer,
+    native: impl FnOnce(&[BufferRef], *const c_void) -> Result<(), Status>,
+) -> Result<(), Status> {
+    // Box the self-referential SendBuffer and hand its raw pointer to `native`
+    // as `client_context`. `buf`'s single `BufferRef` points into the owned
+    // `Bytes` heap storage and stays valid because the box is not moved again
+    // until the `SendComplete` callback (or the immediate-failure reclaim below)
+    // reconstructs it.
+    let cc: *mut SendBuffer = Box::into_raw(Box::new(buf));
+    // SAFETY: `cc` is a live `Box<SendBuffer>` leaked just above; `(*cc)` is a
+    // unique, valid reference. Its `buffers` memory stays valid until the
+    // `SendComplete` callback reconstructs and drops the box (`Stream::send`'s
+    // documented contract) or the immediate-failure reclaim below runs.
+    let res = unsafe { native((*cc).buffers(), cc as *const c_void) };
+    if let Err(status) = res {
+        // Immediate failure: MsQuic took no ownership and delivers no
+        // `SendComplete`, so reclaim the box here (mirroring the callback drop)
+        // before returning. Reclaimed exactly once.
+        // SAFETY: `cc` is the pointer from `Box::into_raw` above; MsQuic did not
+        // take ownership on an error, so this is the sole reclamation.
+        drop(unsafe { Box::from_raw(cc) });
+        return Err(status);
+    }
+    Ok(())
+}
+
 impl SendExec for StreamExecutor {
     fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
-        // Box the self-referential SendBuffer and hand its raw pointer to MsQuic
-        // as `client_context`. `buf`'s single `BufferRef` points into the owned
-        // `Bytes` heap storage and stays valid because the box is not moved again
-        // until the `SendComplete` callback (or the immediate-failure reclaim
-        // below) reconstructs it.
-        let cc: *mut SendBuffer = Box::into_raw(Box::new(buf));
-        // SAFETY: `cc` is a live `Box<SendBuffer>` leaked just above; `(*cc)` is a
-        // unique, valid reference. Its `buffers` memory stays valid until the
-        // `SendComplete` callback reconstructs and drops the box (`Stream::send`'s
-        // documented contract). FIN is not set on a data send — a graceful finish
-        // is a separate `submit_graceful` shutdown call.
-        let res = unsafe {
-            self.stream
-                .send((*cc).buffers(), SendFlags::NONE, cc as *const c_void)
-        };
-        if let Err(status) = res {
-            // Immediate failure: MsQuic took no ownership and delivers no
-            // `SendComplete`, so reclaim the box here (mirroring the callback drop)
-            // before returning. Reclaimed exactly once.
-            // SAFETY: `cc` is the pointer from `Box::into_raw` above; MsQuic did
-            // not take ownership on an error, so this is the sole reclamation.
-            drop(unsafe { Box::from_raw(cc) });
-            return Err(status);
-        }
-        Ok(())
+        // The single owned-buffer ownership transaction (shared with the test
+        // seam). FIN is not set on a data send — a graceful finish is a separate
+        // `submit_graceful` shutdown call.
+        submit_owned_send(buf, |buffers, cc| {
+            // SAFETY: `buffers` borrows the boxed `SendBuffer`'s stable heap
+            // storage (valid for the whole `Stream::send` call), and `cc` is the
+            // matching `client_context` MsQuic returns once in `SendComplete`.
+            unsafe { self.stream.send(buffers, SendFlags::NONE, cc) }
+        })
     }
 
     fn submit_graceful(&mut self) -> Result<(), Status> {
@@ -1182,6 +1220,12 @@ struct StreamSendCtx {
     /// Shared sticky send-terminal slot; the callback publishes peer
     /// `STOP_SENDING` and connection-shutdown reasons here (first-writer).
     send_terminal: SendTerminalSlot,
+    /// Shared connection terminal slot (FR-013). On a CONNECTION-caused stream
+    /// shutdown the callback publishes its derived fallback here (respecting
+    /// first-writer / refinement) rather than into a detached per-stream copy, so
+    /// a later refinement of the shared slot reaches the stream's observation
+    /// points.
+    conn_terminal: ConnTerminalSlot,
     receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,
     /// First-writer-wins guard for the receive scope: once a `Fin`, `Reset`, or
     /// `Connection` terminal has been published, later receive events are
@@ -1203,6 +1247,11 @@ struct RecvStreamReceiveCtx {
     /// stored here and every later `poll_data` returns the same class without
     /// re-polling the channel.
     terminal: Option<ReceiveTerminal>,
+    /// Shared connection terminal slot (FR-013). On a connection-caused receive
+    /// terminal, `poll_data` resolves *and freezes* the shared winner here (the
+    /// same freeze-on-observation the accept frontends use) before storing the
+    /// sticky reason, so the receive half reports the refined connection cause.
+    conn_terminal: ConnTerminalSlot,
     /// SF-6: local, sticky end-of-stream flag set by OUR OWN `stop_sending`.
     /// Distinct from `terminal` (a peer/connection-caused reason); when set,
     /// `poll_data` returns a clean `Ok(None)` and `terminal` is left untouched.
@@ -1219,6 +1268,12 @@ struct SendStreamReceiveCtx {
     /// every reducer input as the current winner; local candidates are published
     /// here via the first-writer helper.
     send_terminal: SendTerminalSlot,
+    /// Shared connection terminal slot (FR-013). When the send winner is a
+    /// `Connection` terminal, `poll_ready` / `poll_finish` resolve *and freeze*
+    /// this shared slot (via [`SendStreamReceiveCtx::observe_send_winner`]) so the
+    /// send half reports the refined connection cause consistently with the
+    /// receive half and the accept frontends.
+    conn_terminal: ConnTerminalSlot,
     /// Single ordered send-event source (MF-1): data completion, terminal wake,
     /// and finish completion. The reducer observes it only as a [`SendPoll`].
     send: mpsc::UnboundedReceiver<SendEvent>,
@@ -1236,6 +1291,9 @@ struct PreIdReceivers {
     send: mpsc::UnboundedReceiver<SendEvent>,
     /// Shared send-terminal slot clone, moved into the send half by `finalize`.
     send_terminal: SendTerminalSlot,
+    /// Shared connection terminal slot clone, moved into BOTH halves by
+    /// `finalize` so each observation point can resolve+freeze the same winner.
+    conn_terminal: ConnTerminalSlot,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
 
@@ -1260,6 +1318,9 @@ struct OpeningStream {
 struct PreIdTail {
     send: mpsc::UnboundedReceiver<SendEvent>,
     send_terminal: SendTerminalSlot,
+    /// Shared connection terminal slot clone, split into both halves' ctxs by
+    /// `finalize`.
+    conn_terminal: ConnTerminalSlot,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
 }
 
@@ -1276,6 +1337,7 @@ impl OpeningStream {
         let PreIdTail {
             send,
             send_terminal,
+            conn_terminal,
             receive,
         } = tail;
         H3Stream {
@@ -1286,6 +1348,7 @@ impl OpeningStream {
                 sctx: SendStreamReceiveCtx {
                     id,
                     send_terminal,
+                    conn_terminal: conn_terminal.clone(),
                     send,
                     reducer: SendState::new(),
                 },
@@ -1296,6 +1359,7 @@ impl OpeningStream {
                     id,
                     receive,
                     terminal: None,
+                    conn_terminal,
                     receive_closed: false,
                 },
             },
@@ -1307,7 +1371,11 @@ impl OpeningStream {
 /// required or produced. Builds the callback-owned [`StreamSendCtx`] (senders)
 /// and returns the matching receiver ends bundled, so an [`OpeningStream`] can
 /// hold them until `StartComplete` yields the ID.
-fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
+///
+/// `conn_terminal` is the connection's SHARED terminal slot (FR-013), cloned into
+/// the callback ctx (the writer of the connection-caused fallback) and carried in
+/// the receivers so both frontend halves resolve+freeze the same winner.
+fn stream_ctx_channel_pre_id(conn_terminal: ConnTerminalSlot) -> (StreamSendCtx, PreIdReceivers) {
     let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
     let (send_tx, send_rx) = mpsc::unbounded();
     let send_terminal = new_send_terminal_slot();
@@ -1317,6 +1385,7 @@ fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
             start: Some(start_tx),
             send: Some(send_tx),
             send_terminal: send_terminal.clone(),
+            conn_terminal: conn_terminal.clone(),
             receive: Some(receive_tx),
             receive_terminal_sent: false,
         },
@@ -1324,6 +1393,7 @@ fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
             start: start_rx,
             send: send_rx,
             send_terminal,
+            conn_terminal,
             receive: receive_rx,
         },
     )
@@ -1331,16 +1401,30 @@ fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
 
 /// ID-bearing stream channel builder used where the identity is already known
 /// (accepted streams and tests). Splits the pre-ID receivers into the two
-/// frontend halves' ctxs directly.
+/// frontend halves' ctxs directly. Creates a fresh, standalone connection
+/// terminal slot; tests that need to drive connection-terminal refinement use
+/// [`stream_ctx_channel_with_conn`] to inject a shared slot.
 #[cfg(test)]
 fn stream_ctx_channel(
     id: h3::quic::StreamId,
 ) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
-    let (ctx, recv) = stream_ctx_channel_pre_id();
+    stream_ctx_channel_with_conn(id, new_conn_terminal_slot())
+}
+
+/// ID-bearing stream channel builder sharing an explicit connection terminal
+/// slot with the caller, so a test can record/refine the connection terminal and
+/// observe how the stream halves resolve+freeze it (FR-013).
+#[cfg(test)]
+fn stream_ctx_channel_with_conn(
+    id: h3::quic::StreamId,
+    conn_terminal: ConnTerminalSlot,
+) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
+    let (ctx, recv) = stream_ctx_channel_pre_id(conn_terminal);
     let PreIdReceivers {
         start: _,
         send,
         send_terminal,
+        conn_terminal,
         receive,
     } = recv;
     (
@@ -1348,6 +1432,7 @@ fn stream_ctx_channel(
         SendStreamReceiveCtx {
             id,
             send_terminal,
+            conn_terminal: conn_terminal.clone(),
             send,
             reducer: SendState::new(),
         },
@@ -1355,6 +1440,7 @@ fn stream_ctx_channel(
             id,
             receive,
             terminal: None,
+            conn_terminal,
             receive_closed: false,
         },
     )
@@ -1387,17 +1473,31 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             //
             // SAFETY: every successful adapter send passes exactly one
             // `Box::into_raw(Box<SendBuffer>)` as `client_context`, and MsQuic
-            // returns that same pointer here exactly once. A null pointer means no
-            // owned buffer was attached (e.g. a test-synthesized event), so it is
-            // skipped rather than dereferenced.
-            if let Some(cc) = std::ptr::NonNull::new(client_context as *mut SendBuffer) {
-                drop(unsafe { Box::from_raw(cc.as_ptr()) });
-            }
-            if let Some(send) = ctx.send.as_ref() {
-                // The buffer is already reclaimed above; only the outcome flag is
-                // forwarded to the reducer via the single ordered channel (MF-1).
-                // A gone frontend is a safe no-op.
-                let _ = send.unbounded_send(SendEvent::Complete { cancelled });
+            // returns that same pointer here exactly once.
+            match std::ptr::NonNull::new(client_context as *mut SendBuffer) {
+                Some(cc) => {
+                    // Non-null: exactly-once reclaim, then forward the outcome flag
+                    // to the reducer via the single ordered channel (MF-1). A gone
+                    // frontend is a safe no-op.
+                    drop(unsafe { Box::from_raw(cc.as_ptr()) });
+                    if let Some(send) = ctx.send.as_ref() {
+                        let _ = send.unbounded_send(SendEvent::Complete { cancelled });
+                    }
+                }
+                None => {
+                    // A null context breaks the ownership invariant (every
+                    // successful send attaches one `Box<SendBuffer>`). Do NOT emit a
+                    // normal `Complete`: publish an internal send terminal and wake
+                    // the send half so `poll_ready` / `poll_finish` surface the
+                    // internal error rather than a false readiness (docs:717-723).
+                    publish_send(
+                        &ctx.send_terminal,
+                        SendTerminal::Internal("SendComplete missing client context"),
+                    );
+                    if let Some(send) = ctx.send.as_ref() {
+                        let _ = send.unbounded_send(SendEvent::TerminalWake);
+                    }
+                }
             }
         }
         StreamEvent::Receive { buffers, flags, .. } => {
@@ -1465,9 +1565,15 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             ..
         } => {
             // A connection-caused stream shutdown surfaces the connection error
-            // on the receive half (reusing the Phase-3 connection terminal +
-            // convert helpers) and, symmetrically, publishes it as the sticky
-            // send terminal so the send half observes the same reason. A
+            // on the receive half and, symmetrically, publishes it as the sticky
+            // send terminal so the send half observes the same reason. The derived
+            // fallback is PUBLISHED into the SHARED connection slot (respecting
+            // first-writer / refinement) rather than finalized as a detached
+            // per-stream copy, so a later refinement of that shared slot (e.g. a
+            // provisional `LocalClose` refined to a specific peer/transport cause)
+            // still reaches this stream's observation points (FR-013). The reason
+            // carried on the receive marker / send terminal is only a defensive
+            // fallback: each observation point re-resolves the shared winner. A
             // stream-local shutdown publishes no terminal.
             if connection_shutdown {
                 let reason = classify_conn_shutdown(
@@ -1476,6 +1582,7 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
                     connection_error_code,
                     connection_close_status,
                 );
+                record_conn_terminal(&ctx.conn_terminal, reason.clone());
                 publish_recv_terminal(ctx, ReceiveEvent::Connection(reason.clone()));
                 publish_send(&ctx.send_terminal, SendTerminal::Connection(reason));
             }
@@ -1510,8 +1617,16 @@ impl H3Stream {
     /// Attach to a peer-accepted stream whose identity was already validated
     /// from the borrowed `StreamRef` (see [`accept_stream_id`]). Takes native
     /// ownership of `stream` (the caller must have confirmed success first).
-    pub(crate) fn attach(stream: msquic::Stream, id: h3::quic::StreamId) -> Self {
-        let (mut ctx, recv) = stream_ctx_channel_pre_id();
+    ///
+    /// `conn_terminal` is the accepting connection's SHARED terminal slot, so an
+    /// accepted stream reports the same refinable connection cause the accept
+    /// frontends do (FR-013).
+    pub(crate) fn attach(
+        stream: msquic::Stream,
+        id: h3::quic::StreamId,
+        conn_terminal: ConnTerminalSlot,
+    ) -> Self {
+        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn_terminal);
         let handler = move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
         stream.set_callback_handler(handler);
         // The ID is known, so finalize straight away. An accepted stream never
@@ -1522,6 +1637,7 @@ impl H3Stream {
             tail: PreIdTail {
                 send: recv.send,
                 send_terminal: recv.send_terminal,
+                conn_terminal: recv.conn_terminal,
                 receive: recv.receive,
             },
         }
@@ -1535,8 +1651,8 @@ impl H3Stream {
         feature = "tracing",
         tracing::instrument(skip_all, level = "trace", err, ret)
     )]
-    fn open_and_start(conn: &msquic::Connection, uni: bool) -> Result<OpeningStream, Status> {
-        let (mut ctx, recv) = stream_ctx_channel_pre_id();
+    fn open_and_start(conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
+        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone());
         let handler = move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
 
         let flag = match uni {
@@ -1544,6 +1660,7 @@ impl H3Stream {
             false => StreamOpenFlags::NONE,
         };
 
+        // `conn` derefs to the native `msquic::Connection` for the open downcall.
         let s = msquic::Stream::open(conn, flag, handler)?;
         s.start(StreamStartFlags::NONE)?; // id arrives later via StartComplete
         Ok(OpeningStream {
@@ -1552,6 +1669,7 @@ impl H3Stream {
             tail: PreIdTail {
                 send: recv.send,
                 send_terminal: recv.send_terminal,
+                conn_terminal: recv.conn_terminal,
                 receive: recv.receive,
             },
         })
@@ -1575,7 +1693,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         // purely from non-consuming state: a published terminal winner is surfaced;
         // otherwise the finish-after-poll_ready misuse (non-sticky).
         if self.sctx.reducer.finish_started {
-            return match load_winner(&self.sctx.send_terminal) {
+            return match self.sctx.observe_send_winner() {
                 Some(w) => Poll::Ready(Err(convert_send(w))),
                 None => Poll::Ready(Err(convert_send(SendTerminal::Internal(
                     "poll_ready after finish",
@@ -1585,7 +1703,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         // First input polls the channel; subsequent inputs are fed results.
         let mut input = SendInput::PollReady {
             poll: self.poll_send_channel(cx),
-            terminal: load_winner(&self.sctx.send_terminal),
+            terminal: self.sctx.observe_send_winner(),
         };
         loop {
             match transition(&mut self.sctx.reducer, input) {
@@ -1599,7 +1717,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     // (MF-2) is never returned to the caller.
                     input = SendInput::PollReady {
                         poll: self.poll_send_channel(cx),
-                        terminal: load_winner(&self.sctx.send_terminal),
+                        terminal: self.sctx.observe_send_winner(),
                     };
                 }
                 SendCommand::PublishTerminal {
@@ -1637,7 +1755,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         let payload = classify_payload(wb.remaining());
         let mut input = SendInput::SendRequested {
             payload,
-            terminal: load_winner(&self.sctx.send_terminal),
+            terminal: self.sctx.observe_send_winner(),
         };
         loop {
             match transition(&mut self.sctx.reducer, input) {
@@ -1655,7 +1773,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     let res = self.exec.submit_send(buf);
                     input = SendInput::SendSubmitted {
                         result: res,
-                        terminal: load_winner(&self.sctx.send_terminal),
+                        terminal: self.sctx.observe_send_winner(),
                     };
                 }
                 SendCommand::PublishTerminal {
@@ -1689,7 +1807,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         use std::task::Poll;
         let mut input = SendInput::PollFinish {
             poll: self.poll_send_channel(cx),
-            terminal: load_winner(&self.sctx.send_terminal),
+            terminal: self.sctx.observe_send_winner(),
         };
         loop {
             match transition(&mut self.sctx.reducer, input) {
@@ -1700,7 +1818,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     let res = self.exec.submit_graceful();
                     input = SendInput::GracefulSubmitted {
                         result: res,
-                        terminal: load_winner(&self.sctx.send_terminal),
+                        terminal: self.sctx.observe_send_winner(),
                     };
                 }
                 SendCommand::RepollFinish => {
@@ -1709,7 +1827,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     // defer to a later poll (that recreates the lost-waker bug).
                     input = SendInput::PollFinish {
                         poll: self.poll_send_channel(cx),
-                        terminal: load_winner(&self.sctx.send_terminal),
+                        terminal: self.sctx.observe_send_winner(),
                     };
                 }
                 SendCommand::PublishTerminal {
@@ -1740,9 +1858,15 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         // through the seam, records the terminal for a later poll, and clears the
         // reset reservation. A callback-published peer/connection terminal wins
         // over this local reset (no second native op).
+        //
+        // `reset()` returns NO observable terminal to the caller, so it must read
+        // the send winner WITHOUT freezing the shared connection slot
+        // (`peek_send_winner`, not `observe_send_winner`): freezing here would
+        // prematurely retain a provisional `LocalClose` over a later peer/transport
+        // refinement that a subsequent genuine caller observation should surface.
         let mut input = SendInput::Reset {
             code: clamp_application_code(reset_code),
-            terminal: load_winner(&self.sctx.send_terminal),
+            terminal: self.sctx.peek_send_winner(),
         };
         loop {
             match transition(&mut self.sctx.reducer, input) {
@@ -1752,7 +1876,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     input = SendInput::ResetSubmitted {
                         code: c,
                         result: res,
-                        terminal: load_winner(&self.sctx.send_terminal),
+                        terminal: self.sctx.peek_send_winner(),
                     };
                 }
                 SendCommand::PublishTerminal {
@@ -1789,6 +1913,49 @@ impl H3SendStream {
             std::task::Poll::Ready(Some(ev)) => SendPoll::Event(ev),
             std::task::Poll::Ready(None) => SendPoll::Closed,
             std::task::Poll::Pending => SendPoll::Pending,
+        }
+    }
+}
+
+impl SendStreamReceiveCtx {
+    /// Load the current send winner, resolving a CONNECTION-caused terminal
+    /// against the SHARED connection slot at this send observation point (FR-013).
+    ///
+    /// When the send winner is a [`SendTerminal::Connection`], the shared
+    /// connection slot is resolved *and frozen* (the same freeze-on-observation
+    /// the accept frontends and `poll_data` apply), so `poll_ready` / `poll_finish`
+    /// report the REFINED connection cause and a later refinement is rejected. The
+    /// carried reason is only a defensive fallback if the shared slot was never
+    /// recorded. A non-connection winner (a peer `Stopped`, a `LocalReset`, an
+    /// internal fault, or the send-scoped provisional marker) is returned
+    /// unchanged and never freezes the connection slot — keeping send-scope and
+    /// connection-scope separation intact.
+    fn observe_send_winner(&self) -> Option<SendTerminal> {
+        match load_winner(&self.send_terminal)? {
+            SendTerminal::Connection(fallback) => Some(SendTerminal::Connection(
+                observe_conn_winner(&self.conn_terminal).unwrap_or(fallback),
+            )),
+            other => Some(other),
+        }
+    }
+
+    /// Non-freezing counterpart of [`Self::observe_send_winner`] for INTERNAL,
+    /// non-caller-observing winner reads (notably `reset()` bookkeeping).
+    ///
+    /// Resolves a CONNECTION-caused send winner against the shared connection
+    /// slot with a non-freezing [`peek_conn_terminal`] read, so the shared slot
+    /// is NOT frozen. `reset()` returns no observable terminal to the caller, so
+    /// freezing there would be premature: a provisional connection `LocalClose`
+    /// followed by `reset()` and a later peer refinement would wrongly retain the
+    /// stale `LocalClose`. Freeze-on-observation stays exclusive to genuine caller
+    /// observation points (`poll_data` / `poll_ready` / `poll_finish`). Non-connection
+    /// winners are returned unchanged, identically to `observe_send_winner`.
+    fn peek_send_winner(&self) -> Option<SendTerminal> {
+        match load_winner(&self.send_terminal)? {
+            SendTerminal::Connection(fallback) => Some(SendTerminal::Connection(
+                peek_conn_terminal(&self.conn_terminal).unwrap_or(fallback),
+            )),
+            other => Some(other),
         }
     }
 }
@@ -1842,8 +2009,15 @@ impl RecvStreamReceiveCtx {
             Some(ReceiveEvent::Data(b)) => Poll::Ready(Ok(Some(b))),
             Some(ReceiveEvent::Fin) => self.store_and_convert(ReceiveTerminal::Fin),
             Some(ReceiveEvent::Reset(code)) => self.store_and_convert(ReceiveTerminal::Reset(code)),
-            Some(ReceiveEvent::Connection(reason)) => {
-                self.store_and_convert(ReceiveTerminal::Connection(reason))
+            Some(ReceiveEvent::Connection(fallback)) => {
+                // Observation point (FR-013): resolve *and freeze* the SHARED
+                // connection winner (a refinement landing before now is honoured;
+                // one landing after is rejected) and cache it as the sticky recv
+                // terminal, so subsequent polls replay the same frozen value. The
+                // carried `fallback` is only used if the shared slot was somehow
+                // never recorded (the callback always records before signalling).
+                let winner = observe_conn_winner(&self.conn_terminal).unwrap_or(fallback);
+                self.store_and_convert(ReceiveTerminal::Connection(winner))
             }
             // A closed channel without an explicit terminal event is an internal
             // fault, not a clean end-of-stream.
@@ -2551,8 +2725,12 @@ mod receive_events {
     use bytes::Bytes;
     use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
 
+    use crate::error::ConnectionTerminal;
     use crate::msquic::{BufferRef, ReceiveFlags, Status, StatusCode, StreamEvent};
-    use crate::{RecvStreamReceiveCtx, stream_callback, stream_ctx_channel};
+    use crate::{
+        RecvStreamReceiveCtx, new_conn_terminal_slot, record_conn_terminal, stream_callback,
+        stream_ctx_channel, stream_ctx_channel_with_conn,
+    };
 
     fn noop_context() -> Context<'static> {
         // A leaked no-op waker gives a `'static` context usable across polls.
@@ -2726,6 +2904,83 @@ mod receive_events {
         // No terminal was injected: the sticky recv terminal slot stays empty.
         assert!(rrx.terminal.is_none());
         assert!(rrx.receive_closed);
+    }
+
+    /// A connection-caused stream `ShutdownComplete` whose derived fallback is the
+    /// PROVISIONAL `LocalClose` (by_app && !closed_remotely). The callback records
+    /// this into the shared connection slot and enqueues the receive marker.
+    fn provisional_local_close(ctx: &mut crate::StreamSendCtx) {
+        let ev = StreamEvent::ShutdownComplete {
+            connection_shutdown: true,
+            app_close_in_progress: false,
+            connection_shutdown_by_app: true,
+            connection_closed_remotely: false,
+            connection_error_code: 0,
+            connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+        };
+        assert!(stream_callback(ctx, ev).is_ok());
+    }
+
+    #[test]
+    fn f1_recv_refinement_before_observation_surfaces_refined_cause() {
+        // FR-013: a provisional connection fallback (LocalClose) recorded by the
+        // stream callback is refined on the SHARED slot to a specific peer cause
+        // BEFORE the stream observes it at poll_data → poll_data reports the
+        // REFINED cause (ApplicationClose), not the stale LocalClose.
+        let slot = new_conn_terminal_slot();
+        let (mut ctx, _srx, mut rrx) =
+            stream_ctx_channel_with_conn(4u64.try_into().unwrap(), slot.clone());
+        provisional_local_close(&mut ctx);
+        // A concurrent connection-callback refinement lands before observation.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(9));
+
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9),
+            other => panic!("expected refined ApplicationClose{{9}}, got {other:?}"),
+        }
+        // The shared slot is now frozen: a later refinement is rejected.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(11));
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9, "sticky: the first observed cause persists"),
+            other => panic!("expected stable ApplicationClose{{9}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f1_recv_refinement_after_observation_is_rejected() {
+        // FR-013 freeze-on-observation: once poll_data has OBSERVED the connection
+        // winner (freezing the shared slot), a later refinement is rejected and the
+        // stream keeps reporting the observed value.
+        let slot = new_conn_terminal_slot();
+        let (mut ctx, _srx, mut rrx) =
+            stream_ctx_channel_with_conn(4u64.try_into().unwrap(), slot.clone());
+        provisional_local_close(&mut ctx);
+        // Observe FIRST — this freezes the shared slot at the provisional LocalClose.
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::Undefined(e),
+            })) => assert!(
+                e.downcast_ref::<crate::LocalConnectionClose>().is_some(),
+                "expected LocalConnectionClose, got {e:?}"
+            ),
+            other => panic!("expected LocalConnectionClose (Undefined), got {other:?}"),
+        }
+        // A refinement AFTER observation is rejected (frozen); the stream still
+        // reports the observed LocalClose.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(9));
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::Undefined(e),
+            })) => assert!(
+                e.downcast_ref::<crate::LocalConnectionClose>().is_some(),
+                "post-observation refinement must be rejected, got {e:?}"
+            ),
+            other => panic!("expected frozen LocalConnectionClose, got {other:?}"),
+        }
     }
 }
 
@@ -3004,11 +3259,12 @@ mod send_seam {
     use h3::proto::frame::Frame;
     use h3::quic::{SendStream, StreamErrorIncoming};
 
-    use crate::error::MAX_ADAPTER_SEND;
+    use crate::error::{ConnectionTerminal, MAX_ADAPTER_SEND};
     use crate::msquic::{Status, StatusCode, StreamEvent};
     use crate::{
-        ConnectionErrorIncoming, H3SendStream, OversizedSend, SendBuffer, SendExec,
-        SendStreamReceiveCtx, StreamSendCtx, stream_callback, stream_ctx_channel,
+        ConnTerminalSlot, ConnectionErrorIncoming, H3SendStream, OversizedSend, SendBuffer,
+        SendExec, SendStreamReceiveCtx, StreamSendCtx, new_conn_terminal_slot,
+        record_conn_terminal, stream_callback, stream_ctx_channel, stream_ctx_channel_with_conn,
     };
 
     /// Shared, inspectable counters + `client_context` slots. A clone is kept by
@@ -3030,9 +3286,10 @@ mod send_seam {
         client_ctx: Arc<Mutex<VecDeque<usize>>>,
     }
 
-    /// Test double for the send seam. Mirrors `StreamExecutor`'s box/into_raw and
-    /// immediate-failure reclaim EXACTLY, so a scripted result models the real
-    /// allocation and ownership handoff without a native stream.
+    /// Test double for the send seam. Routes its owned-buffer submission through
+    /// the SHARED production transaction (`crate::submit_owned_send`), so a
+    /// scripted result models the real allocation and ownership handoff — the same
+    /// code path `StreamExecutor::submit_send` uses — without a native stream.
     #[derive(Debug)]
     struct CountingExec {
         h: CountingHandle,
@@ -3048,33 +3305,36 @@ mod send_seam {
     impl SendExec for CountingExec {
         fn submit_send(&mut self, buf: SendBuffer) -> Result<(), Status> {
             self.h.sends.fetch_add(1, Relaxed);
-            // Mirror StreamExecutor EXACTLY: box + into_raw BEFORE inspecting the
-            // scripted result, so both arms model the real allocation.
-            let cc = Box::into_raw(Box::new(buf));
-            self.h.allocs.fetch_add(1, Relaxed);
-            match self.script.pop_front().unwrap_or(Ok(())) {
-                Ok(()) => {
+            let scripted = self.script.pop_front().unwrap_or(Ok(()));
+            let h = self.h.clone();
+            // Route through the SHARED production ownership transaction
+            // (`submit_owned_send`) so this test double exercises the exact
+            // `Box::into_raw` / immediate-`Err` `Box::from_raw` handoff the real
+            // `StreamExecutor` uses — a regression there cannot pass here.
+            let res = crate::submit_owned_send(buf, |_buffers, cc| {
+                h.allocs.fetch_add(1, Relaxed);
+                match scripted {
                     // Native accepted ownership: retain the pointer so the test can
                     // replay the native SendComplete through stream_callback. The
-                    // box is NOT dropped here; it is outstanding until that callback.
-                    self.h
-                        .client_ctx
-                        .lock()
-                        .unwrap_or_else(PoisonError::into_inner)
-                        .push_back(cc as usize);
-                    Ok(())
+                    // helper leaves the box outstanding (not dropped) on `Ok`.
+                    Ok(()) => {
+                        h.client_ctx
+                            .lock()
+                            .unwrap_or_else(PoisonError::into_inner)
+                            .push_back(cc as usize);
+                        Ok(())
+                    }
+                    // Immediate failure: `submit_owned_send` reclaims the box here
+                    // and now (its sole reclamation), exactly as StreamExecutor's
+                    // immediate-`Err` arm does.
+                    Err(status) => Err(status),
                 }
-                Err(status) => {
-                    // Immediate failure: MsQuic takes no ownership and delivers no
-                    // SendComplete, so the caller reclaims here and now — exactly as
-                    // StreamExecutor's immediate-Err arm does.
-                    // SAFETY: `cc` is the pointer from `Box::into_raw` above; this is
-                    // its sole reclamation (native took no ownership on Err).
-                    drop(unsafe { Box::from_raw(cc) });
-                    self.h.reclaims.fetch_add(1, Relaxed);
-                    Err(status)
-                }
+            });
+            if res.is_err() {
+                // The shared helper performed the in-exec reclamation on `Err`.
+                self.h.reclaims.fetch_add(1, Relaxed);
             }
+            res
         }
         fn submit_graceful(&mut self) -> Result<(), Status> {
             self.h.gracefuls.fetch_add(1, Relaxed);
@@ -3098,6 +3358,158 @@ mod send_seam {
         let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
         let (ctx, sctx, _rctx) = stream_ctx_channel(id);
         (sctx, ctx)
+    }
+
+    /// Like [`test_send_ctx`] but sharing an explicit connection terminal slot, so
+    /// an FR-013 test can refine the connection cause and observe how the send half
+    /// resolves+freezes it.
+    fn test_send_ctx_with_conn(
+        conn_terminal: ConnTerminalSlot,
+    ) -> (SendStreamReceiveCtx, StreamSendCtx) {
+        let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
+        let (ctx, sctx, _rctx) = stream_ctx_channel_with_conn(id, conn_terminal);
+        (sctx, ctx)
+    }
+
+    /// A connection-caused stream `ShutdownComplete` whose derived fallback is the
+    /// PROVISIONAL `LocalClose` (by_app && !closed_remotely): the callback records
+    /// it into the shared connection slot and publishes `Connection(LocalClose)`
+    /// into the send-terminal slot.
+    fn provisional_local_close(ctx: &mut StreamSendCtx) {
+        stream_callback(
+            ctx,
+            StreamEvent::ShutdownComplete {
+                connection_shutdown: true,
+                app_close_in_progress: false,
+                connection_shutdown_by_app: true,
+                connection_closed_remotely: false,
+                connection_error_code: 0,
+                connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn f1_send_refinement_before_observation_surfaces_refined_cause() {
+        // FR-013 (send side): a provisional connection fallback (LocalClose) is
+        // refined on the SHARED slot to a specific peer application close BEFORE
+        // the send half observes it at poll_ready → poll_ready reports the REFINED
+        // ApplicationClose, not the stale LocalClose.
+        let slot = new_conn_terminal_slot();
+        let exec = Box::new(CountingExec::new(
+            CountingHandle::default(),
+            VecDeque::new(),
+        ));
+        let (sctx, mut ctx) = test_send_ctx_with_conn(slot.clone());
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        provisional_local_close(&mut ctx);
+        // Refinement lands on the shared slot before the send half observes.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(9));
+
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9),
+            other => panic!("expected refined ApplicationClose{{9}}, got {other:?}"),
+        }
+        // Frozen after observation: a later refinement is rejected, and a
+        // subsequent poll_finish reports the same refined cause.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(11));
+        match SendStream::<Bytes>::poll_finish(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9, "stable refined cause across observers"),
+            other => panic!("expected stable ApplicationClose{{9}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f1_send_refinement_after_observation_is_rejected() {
+        // FR-013 freeze-on-observation (send side): once poll_ready has OBSERVED
+        // the connection winner (freezing the shared slot at the provisional
+        // LocalClose), a later refinement is rejected and poll_finish keeps
+        // reporting the observed LocalClose.
+        let slot = new_conn_terminal_slot();
+        let exec = Box::new(CountingExec::new(
+            CountingHandle::default(),
+            VecDeque::new(),
+        ));
+        let (sctx, mut ctx) = test_send_ctx_with_conn(slot.clone());
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        provisional_local_close(&mut ctx);
+        // Observe FIRST at poll_ready — freezes the shared slot at LocalClose.
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::Undefined(e),
+            })) => assert!(
+                e.downcast_ref::<crate::LocalConnectionClose>().is_some(),
+                "expected LocalConnectionClose, got {e:?}"
+            ),
+            other => panic!("expected LocalConnectionClose (Undefined), got {other:?}"),
+        }
+        // A refinement AFTER observation is rejected; poll_finish still reports the
+        // observed LocalClose.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(9));
+        match SendStream::<Bytes>::poll_finish(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::Undefined(e),
+            })) => assert!(
+                e.downcast_ref::<crate::LocalConnectionClose>().is_some(),
+                "post-observation refinement must be rejected, got {e:?}"
+            ),
+            other => panic!("expected frozen LocalConnectionClose, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn f1_reset_does_not_freeze_connection_winner_before_observation() {
+        // FR-013 freeze-on-observation is exclusive to genuine CALLER observation
+        // points (poll_data / poll_ready / poll_finish). `reset()` returns no
+        // observable terminal to the caller, so it must NOT freeze the shared
+        // connection slot: a provisional connection LocalClose, then reset(), then
+        // a later peer refinement must still surface the REFINED specific cause at
+        // the next caller observation (poll_ready) — not the stale LocalClose that
+        // a premature freeze in reset() would have retained.
+        let slot = new_conn_terminal_slot();
+        let exec = Box::new(CountingExec::new(
+            CountingHandle::default(),
+            VecDeque::new(),
+        ));
+        let (sctx, mut ctx) = test_send_ctx_with_conn(slot.clone());
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        // Provisional connection LocalClose recorded on the shared slot and
+        // published as the send winner.
+        provisional_local_close(&mut ctx);
+        // reset() consults the winner for bookkeeping (loses to the published
+        // connection terminal, no native op) but must read WITHOUT freezing.
+        SendStream::<Bytes>::reset(&mut s, 5);
+        // The connection refines to a specific peer cause AFTER reset(); this must
+        // still be honoured because reset() did not freeze the slot.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(9));
+
+        // The next genuine caller observation surfaces the REFINED cause.
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9, "reset() must not freeze the refined cause"),
+            other => panic!("expected refined ApplicationClose{{9}}, got {other:?}"),
+        }
+        // poll_ready has now frozen the slot at the refined cause: a later
+        // refinement is rejected and poll_finish reports the same stable value.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(11));
+        match SendStream::<Bytes>::poll_finish(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 9, "stable refined cause after observation"),
+            other => panic!("expected stable ApplicationClose{{9}}, got {other:?}"),
+        }
     }
 
     #[test]
@@ -3175,6 +3587,44 @@ mod send_seam {
             "callback must reconstruct+drop the Box<SendBuffer> exactly once"
         );
         assert_eq!(h.reclaims.load(Relaxed), 0);
+    }
+
+    #[test]
+    fn send_complete_null_client_context_surfaces_internal_error() {
+        // F2 (docs:717-723): a null `SendComplete.client_context` breaks the
+        // ownership invariant (every successful send attaches one
+        // `Box<SendBuffer>`). The callback must NOT emit a normal `Complete`; it
+        // publishes an internal send terminal and wakes the send half, so
+        // `poll_ready` surfaces the internal error rather than a false readiness —
+        // and it never panics or dereferences null.
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+
+        // Panic-free: a null-context SendComplete returns Ok across the FFI boundary.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: false,
+                client_context: std::ptr::null(),
+            },
+        )
+        .expect("null-context SendComplete must be panic-free");
+
+        // No normal `Complete` was enqueued; only a terminal wake, and the shared
+        // send-terminal slot now holds the internal reason. `poll_ready` surfaces
+        // the internal error, NOT `Ready(Ok(()))`.
+        let mut cx = noop_cx();
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(msg),
+            })) => assert!(
+                msg.contains("SendComplete missing client context"),
+                "unexpected internal message: {msg}"
+            ),
+            other => panic!("expected InternalError from null client_context, got {other:?}"),
+        }
     }
 
     #[test]
@@ -4205,7 +4655,7 @@ mod downcall_clamp {
             if let Some(reason) = self.record.clone() {
                 record_conn_terminal(conn.terminal(), reason);
             }
-            let (ctx, recv) = stream_ctx_channel_pre_id();
+            let (ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone());
             let flag = if uni {
                 StreamOpenFlags::UNIDIRECTIONAL
             } else {
@@ -4219,6 +4669,7 @@ mod downcall_clamp {
                 start,
                 send,
                 send_terminal,
+                conn_terminal,
                 receive,
             } = recv;
             Ok(OpeningStream {
@@ -4227,6 +4678,7 @@ mod downcall_clamp {
                 tail: PreIdTail {
                     send,
                     send_terminal,
+                    conn_terminal,
                     receive,
                 },
             })

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -21,6 +21,9 @@ use msquic::{
 
 mod buffer;
 pub use buffer::*;
+mod error;
+use error::clamp_application_code;
+pub use error::{LocalConnectionClose, LocalStreamReset, MsQuicTransportError, OversizedSend};
 mod listener;
 pub use listener::Listener;
 mod registration;
@@ -352,8 +355,10 @@ impl<B: Buf> OpenStreams<B> for StreamOpener {
         tracing::instrument(skip_all, level = "trace", ret)
     )]
     fn close(&mut self, code: h3::error::Code, _reason: &[u8]) {
-        self.conn
-            .shutdown(ConnectionShutdownFlags::NONE, code.value());
+        self.conn.shutdown(
+            ConnectionShutdownFlags::NONE,
+            clamp_application_code(code.value()),
+        );
     }
 }
 
@@ -738,9 +743,10 @@ impl RecvStream for H3RecvStream {
     )]
     fn stop_sending(&mut self, error_code: u64) {
         // Close the send path.
-        let _ = self
-            .stream
-            .shutdown(StreamShutdownFlags::ABORT_RECEIVE, error_code);
+        let _ = self.stream.shutdown(
+            StreamShutdownFlags::ABORT_RECEIVE,
+            clamp_application_code(error_code),
+        );
     }
 
     fn recv_id(&self) -> h3::quic::StreamId {

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -22,7 +22,7 @@ use msquic::{
 mod buffer;
 pub use buffer::*;
 mod error;
-use error::clamp_application_code;
+use error::{ConnectionTerminal, clamp_application_code, convert_conn};
 pub use error::{LocalConnectionClose, LocalStreamReset, MsQuicTransportError, OversizedSend};
 mod listener;
 pub use listener::Listener;
@@ -46,6 +46,87 @@ pub(crate) fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
     m.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
+/// Shared, thread-safe slot recording *why* a connection terminated.
+///
+/// Shared between the connection FFI callback (the writer) and the accept
+/// frontends / stream opener (readers). All access goes through
+/// [`lock_recover`] so an FFI callback never panics on a poisoned lock.
+pub(crate) type ConnTerminalSlot = Arc<Mutex<ConnTerminalState>>;
+
+/// Create a fresh, empty connection terminal-reason slot.
+pub(crate) fn new_conn_terminal_slot() -> ConnTerminalSlot {
+    Arc::new(Mutex::new(ConnTerminalState::default()))
+}
+
+/// First-writer-wins record of the connection terminal reason, with
+/// provisional-to-specific refinement until the value is externally observed.
+///
+/// A provisional cause (`LocalClose`) recorded first may be refined by a later,
+/// more-specific peer/transport cause — but only until an external observer
+/// (an accept frontend delivering the terminal to h3) has frozen the value.
+/// After the freeze point the winner is immutable. This is the connection-scope
+/// SF-7 / T4 rule; it is deliberately independent of the send-scope cancellation
+/// state (MF-2), which lives in the send reducer and is never written here.
+#[derive(Debug, Default)]
+pub(crate) struct ConnTerminalState {
+    terminal: Option<ConnectionTerminal>,
+    observed: bool,
+}
+
+impl ConnTerminalState {
+    /// Record a candidate terminal reason under the first-writer / refinement
+    /// rule. A no-op once the value has been frozen by [`Self::observe`].
+    fn record(&mut self, candidate: ConnectionTerminal) {
+        if self.observed {
+            return;
+        }
+        match &self.terminal {
+            None => self.terminal = Some(candidate),
+            Some(existing) => {
+                // Only a provisional cause may be refined, and only to a
+                // specific one. Specific causes never regress to provisional.
+                if existing.is_provisional() && !candidate.is_provisional() {
+                    self.terminal = Some(candidate);
+                }
+            }
+        }
+    }
+
+    /// Freeze the slot and return a clone of the recorded reason (if any).
+    ///
+    /// After this call the value is immutable: later [`Self::record`] calls are
+    /// ignored. This is the external-observation point of the refinement rule.
+    fn observe(&mut self) -> Option<ConnectionTerminal> {
+        self.observed = true;
+        self.terminal.clone()
+    }
+
+    /// Whether an internal (fail-fast) terminal has been published. Read before
+    /// draining queued streams so an internal failure is reported immediately
+    /// rather than behind already-queued items.
+    fn has_internal(&self) -> bool {
+        matches!(self.terminal, Some(ConnectionTerminal::Internal(_)))
+    }
+}
+
+/// Record a connection terminal reason into the shared slot.
+fn record_conn_terminal(slot: &ConnTerminalSlot, candidate: ConnectionTerminal) {
+    lock_recover(slot).record(candidate);
+}
+
+/// Classify a transport shutdown status into a connection terminal reason.
+///
+/// Idle and connection timeouts map to [`ConnectionTerminal::Timeout`]; every
+/// other transport status is retained verbatim (status + wire error code) as a
+/// [`ConnectionTerminal::Transport`] for `Undefined` mapping at the boundary.
+fn classify_transport(status: Status, error_code: u64) -> ConnectionTerminal {
+    match status.try_as_status_code() {
+        Ok(StatusCode::QUIC_STATUS_CONNECTION_TIMEOUT)
+        | Ok(StatusCode::QUIC_STATUS_CONNECTION_IDLE) => ConnectionTerminal::Timeout,
+        _ => ConnectionTerminal::Transport { status, error_code },
+    }
+}
+
 /// Owns the raw msquic connection handle together with its [`RundownGuard`].
 ///
 /// Field order is load-bearing: `inner` is declared before `_guard`, so on drop
@@ -56,15 +137,29 @@ pub(crate) fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
 #[derive(Debug)]
 pub(crate) struct ConnHandle {
     inner: msquic::Connection,
+    /// Shared connection terminal-reason slot. Cloned from the connection
+    /// context so the stream opener (`OpenStreams::close`) can record a local
+    /// close through the borrowed handle.
+    terminal: ConnTerminalSlot,
     _guard: RundownGuard,
 }
 
 impl ConnHandle {
-    pub(crate) fn new(inner: msquic::Connection, guard: RundownGuard) -> Self {
+    pub(crate) fn new(
+        inner: msquic::Connection,
+        guard: RundownGuard,
+        terminal: ConnTerminalSlot,
+    ) -> Self {
         Self {
             inner,
+            terminal,
             _guard: guard,
         }
+    }
+
+    /// The shared connection terminal-reason slot.
+    pub(crate) fn terminal(&self) -> &ConnTerminalSlot {
+        &self.terminal
     }
 }
 
@@ -85,19 +180,23 @@ pub struct Connection {
 /// from callback send to fount end.
 #[derive(Debug)]
 struct ConnCtxSender {
-    connected: Option<oneshot::Sender<()>>,
+    connected: Option<oneshot::Sender<Result<(), Status>>>,
     shutdown: Option<oneshot::Sender<()>>,
     bidi: Option<mpsc::UnboundedSender<Option<crate::H3Stream>>>,
     uni: Option<mpsc::UnboundedSender<Option<crate::H3Stream>>>,
+    /// Shared connection terminal-reason slot (writer side).
+    terminal: ConnTerminalSlot,
 }
 
 /// front end receive.
 #[derive(Debug)]
 struct ConnCtxReceiver {
-    connected: Option<oneshot::Receiver<()>>,
+    connected: Option<oneshot::Receiver<Result<(), Status>>>,
     shutdown: Option<oneshot::Receiver<()>>,
     bidi: mpsc::UnboundedReceiver<Option<crate::H3Stream>>,
     uni: mpsc::UnboundedReceiver<Option<crate::H3Stream>>,
+    /// Shared connection terminal-reason slot (reader side).
+    terminal: ConnTerminalSlot,
 }
 
 fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
@@ -105,18 +204,21 @@ fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (bidi_tx, bidi_rx) = mpsc::unbounded();
     let (uni_tx, uni_rx) = mpsc::unbounded();
+    let terminal: ConnTerminalSlot = Arc::new(Mutex::new(ConnTerminalState::default()));
     (
         ConnCtxSender {
             connected: Some(conn_tx),
             shutdown: Some(shutdown_tx),
             bidi: Some(bidi_tx),
             uni: Some(uni_tx),
+            terminal: terminal.clone(),
         },
         ConnCtxReceiver {
             connected: Some(conn_rx),
             shutdown: Some(shutdown_rx),
             bidi: bidi_rx,
             uni: uni_rx,
+            terminal,
         },
     )
 }
@@ -131,7 +233,25 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
             // A duplicate `Connected` (slot already taken) or a dropped receiver
             // (send `Err`) is a safe no-op; never panic across the FFI boundary.
             if let Some(tx) = ctx.connected.take() {
-                let _ = tx.send(());
+                let _ = tx.send(Ok(()));
+            }
+        }
+        ConnectionEvent::ShutdownInitiatedByPeer { error_code } => {
+            // Peer application close: record the exact HTTP/3 code. A peer close
+            // has no lossless `Status`, so a pending connect waiter resolves as
+            // `QUIC_STATUS_ABORTED` (the exact code stays in the terminal slot).
+            record_conn_terminal(&ctx.terminal, ConnectionTerminal::PeerApplication(error_code));
+            if let Some(tx) = ctx.connected.take() {
+                let _ = tx.send(Err(Status::new(StatusCode::QUIC_STATUS_ABORTED)));
+            }
+        }
+        ConnectionEvent::ShutdownInitiatedByTransport { status, error_code } => {
+            // Transport shutdown: timeout statuses become `Timeout`, everything
+            // else retains the status + wire code. Resolve a pending connect
+            // waiter with the real transport `Status` (not a synthetic ABORTED).
+            record_conn_terminal(&ctx.terminal, classify_transport(status.clone(), error_code));
+            if let Some(tx) = ctx.connected.take() {
+                let _ = tx.send(Err(status));
             }
         }
         ConnectionEvent::PeerStreamStarted { stream, flags } => {
@@ -150,8 +270,19 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
             }
         }
         ConnectionEvent::ShutdownComplete { .. } => {
+            // A bare shutdown with no more-specific reason published is a local
+            // close (provisional): `record` keeps any specific cause already
+            // recorded by a peer/transport arm. `ShutdownComplete` itself carries
+            // no error code.
+            record_conn_terminal(&ctx.terminal, ConnectionTerminal::LocalClose);
+            // If the connect waiter is still pending here (neither `Connected`
+            // nor a `ShutdownInitiated*` arm resolved it — e.g. a bare local
+            // close), resolve it as a failure so `connect()` returns `Err`
+            // deterministically rather than mapping a `Canceled` drop.
+            if let Some(tx) = ctx.connected.take() {
+                let _ = tx.send(Err(Status::new(StatusCode::QUIC_STATUS_ABORTED)));
+            }
             // clear all channels.
-            ctx.connected.take();
             ctx.uni.take();
             ctx.bidi.take();
             if let Some(shutdown) = ctx.shutdown.take() {
@@ -188,14 +319,18 @@ impl Connection {
             // path uses ConnHandle's proven ConnectionClose-then-guard drop
             // order rather than the async future's unspecified capture layout.
             let inner = msquic::Connection::open(reg.raw(), handler)?;
-            let conn = Arc::new(ConnHandle::new(inner, guard));
+            let conn = Arc::new(ConnHandle::new(inner, guard, crx.terminal.clone()));
             conn.start(config, server_name, server_port)?;
-            // wait for connection.
+            // wait for connection. The one-shot carries `Result<(), Status>`: a
+            // transport/peer shutdown before `Connected` resolves it with the
+            // real cause, so the caller sees the actual `Status` (handshake
+            // failure, timeout, refusal, ...) instead of a synthetic ABORTED,
+            // and never hangs.
             crx.connected
                 .take()
                 .ok_or_else(|| Status::new(StatusCode::QUIC_STATUS_ABORTED))?
                 .await
-                .map_err(|_| Status::new(StatusCode::QUIC_STATUS_ABORTED))?;
+                .map_err(|_| Status::new(StatusCode::QUIC_STATUS_ABORTED))??;
 
             let opener = StreamOpener::new(conn.clone());
 
@@ -213,7 +348,7 @@ impl Connection {
         let handler =
             move |_: ConnectionRef, ev: ConnectionEvent| connection_callback(&mut ctx, ev);
         inner.set_callback_handler(handler);
-        let conn = Arc::new(ConnHandle::new(inner, guard));
+        let conn = Arc::new(ConnHandle::new(inner, guard, crx.terminal.clone()));
 
         let opener = StreamOpener::new(conn.clone());
 
@@ -237,6 +372,34 @@ impl Connection {
             rx
         });
         ConnectionShutdownWaiter { rx }
+    }
+}
+
+/// Fail-fast terminal check for the accept frontends.
+///
+/// Returns the converted connection error only when an *internal* terminal has
+/// been published, so an adapter-internal failure is reported ahead of any
+/// streams still queued. Observing it also freezes the slot. A non-internal
+/// terminal returns `None`, so the caller drains queued streams first.
+fn fail_fast_terminal(slot: &ConnTerminalSlot) -> Option<ConnectionErrorIncoming> {
+    let mut g = lock_recover(slot);
+    if g.has_internal() {
+        return g.observe().map(convert_conn);
+    }
+    None
+}
+
+/// Freeze the terminal slot and convert the recorded reason for h3.
+///
+/// Called when the incoming-stream channel is drained/closed. A closure with no
+/// recorded reason maps to a defined internal error rather than a synthetic
+/// application close.
+fn observe_terminal(slot: &ConnTerminalSlot) -> ConnectionErrorIncoming {
+    match lock_recover(slot).observe() {
+        Some(t) => convert_conn(t),
+        None => ConnectionErrorIncoming::InternalError(
+            "connection closed without a terminal reason".to_string(),
+        ),
     }
 }
 
@@ -285,12 +448,19 @@ impl<B: Buf> h3::quic::Connection<B> for Connection {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<Self::RecvStream, ConnectionErrorIncoming>> {
-        let s = ready!(self.ctx.uni.poll_next_unpin(cx)).unwrap_or(None);
-        // wrap for h3 type. Drop the send stream part
-        std::task::Poll::Ready(
-            s.map(|s| s.recv)
-                .ok_or(ConnectionErrorIncoming::ApplicationClose { error_code: 0 }),
-        )
+        // Fail-fast: an internal terminal is reported immediately, ahead of any
+        // streams still queued in the channel (the adapter has declared its own
+        // connection state invalid). Normal peer/transport/local shutdown keeps
+        // the drain-then-terminal ordering below.
+        if let Some(err) = fail_fast_terminal(&self.ctx.terminal) {
+            return std::task::Poll::Ready(Err(err));
+        }
+        match ready!(self.ctx.uni.poll_next_unpin(cx)) {
+            // wrap for h3 type. Drop the send stream part.
+            Some(Some(s)) => std::task::Poll::Ready(Ok(s.recv)),
+            // Channel drained/closed: report the recorded terminal reason.
+            Some(None) | None => std::task::Poll::Ready(Err(observe_terminal(&self.ctx.terminal))),
+        }
     }
 
     #[cfg_attr(
@@ -301,9 +471,14 @@ impl<B: Buf> h3::quic::Connection<B> for Connection {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<Self::BidiStream, ConnectionErrorIncoming>> {
-        let s = ready!(self.ctx.bidi.poll_next_unpin(cx)).unwrap_or(None);
-        // wrap for h3 type
-        std::task::Poll::Ready(s.ok_or(ConnectionErrorIncoming::ApplicationClose { error_code: 0 }))
+        if let Some(err) = fail_fast_terminal(&self.ctx.terminal) {
+            return std::task::Poll::Ready(Err(err));
+        }
+        match ready!(self.ctx.bidi.poll_next_unpin(cx)) {
+            // wrap for h3 type
+            Some(Some(s)) => std::task::Poll::Ready(Ok(s)),
+            Some(None) | None => std::task::Poll::Ready(Err(observe_terminal(&self.ctx.terminal))),
+        }
     }
 
     #[cfg_attr(
@@ -355,6 +530,11 @@ impl<B: Buf> OpenStreams<B> for StreamOpener {
         tracing::instrument(skip_all, level = "trace", ret)
     )]
     fn close(&mut self, code: h3::error::Code, _reason: &[u8]) {
+        // An application-initiated shutdown may proceed straight to
+        // `ShutdownComplete`, so record the provisional local-close reason
+        // before the downcall. A concurrent peer/transport cause may still
+        // refine it until an accept frontend observes the terminal.
+        record_conn_terminal(self.conn.terminal(), ConnectionTerminal::LocalClose);
         self.conn.shutdown(
             ConnectionShutdownFlags::NONE,
             clamp_application_code(code.value()),
@@ -1092,5 +1272,293 @@ mod callback_safety {
         // Recover without panicking and observe the value written before poison.
         let g = lock_recover(&m);
         assert_eq!(*g, 42);
+    }
+}
+
+/// Phase 3 (connection terminal slot & incoming-terminal propagation) unit
+/// tests: proves the connection close mapping, the connected one-shot carrying
+/// `Result<(), Status>`, the provisional-to-specific refinement/freeze rule, and
+/// the drain-vs-fail-fast queue policy. Hermetic (no network).
+#[cfg(test)]
+mod connection_terminal {
+    use h3::quic::ConnectionErrorIncoming;
+
+    use crate::error::ConnectionTerminal;
+    use crate::msquic::{ConnectionEvent, Status, StatusCode};
+    use crate::{
+        ConnTerminalState, ConnCtxReceiver, classify_transport, conn_ctx_channel,
+        connection_callback, fail_fast_terminal, new_conn_terminal_slot, observe_terminal,
+        record_conn_terminal,
+    };
+
+    /// Drive one connection event through the callback and return the frozen,
+    /// converted terminal the accept frontend would report.
+    fn map_event(ev: ConnectionEvent) -> ConnectionErrorIncoming {
+        let (mut ctx, crx) = conn_ctx_channel();
+        assert!(connection_callback(&mut ctx, ev).is_ok());
+        observe_terminal(&crx.terminal)
+    }
+
+    #[test]
+    fn peer_application_close_maps_to_application_close_with_code() {
+        let err = map_event(ConnectionEvent::ShutdownInitiatedByPeer { error_code: 42 });
+        assert!(
+            matches!(err, ConnectionErrorIncoming::ApplicationClose { error_code: 42 }),
+            "expected ApplicationClose(42), got {err:?}"
+        );
+    }
+
+    #[test]
+    fn idle_timeout_maps_to_timeout() {
+        let ev = ConnectionEvent::ShutdownInitiatedByTransport {
+            status: Status::new(StatusCode::QUIC_STATUS_CONNECTION_IDLE),
+            error_code: 0,
+        };
+        let err = map_event(ev);
+        assert!(
+            matches!(err, ConnectionErrorIncoming::Timeout),
+            "expected Timeout, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn connection_timeout_maps_to_timeout() {
+        let ev = ConnectionEvent::ShutdownInitiatedByTransport {
+            status: Status::new(StatusCode::QUIC_STATUS_CONNECTION_TIMEOUT),
+            error_code: 0,
+        };
+        assert!(matches!(map_event(ev), ConnectionErrorIncoming::Timeout));
+    }
+
+    #[test]
+    fn other_transport_failure_maps_to_undefined_transport_error() {
+        let ev = ConnectionEvent::ShutdownInitiatedByTransport {
+            status: Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR),
+            error_code: 7,
+        };
+        let err = map_event(ev);
+        match err {
+            ConnectionErrorIncoming::Undefined(e) => {
+                // The adapter-owned transport error retains the wire code.
+                let s = e.to_string();
+                assert!(s.contains("transport error_code 7"), "display was: {s}");
+            }
+            other => panic!("expected Undefined(MsQuicTransportError), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn local_close_maps_to_undefined_local_close() {
+        // A bare ShutdownComplete with no more-specific reason is a local close.
+        let err = map_event(ConnectionEvent::ShutdownComplete {
+            handshake_completed: false,
+            peer_acknowledged_shutdown: false,
+            app_close_in_progress: false,
+        });
+        match err {
+            ConnectionErrorIncoming::Undefined(e) => {
+                assert!(e.to_string().contains("locally"), "display was: {e}");
+            }
+            other => panic!("expected Undefined(LocalConnectionClose), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn channel_closed_without_reason_maps_to_internal_error() {
+        // No callback fired: the slot is empty when the channel drains.
+        let slot = new_conn_terminal_slot();
+        match observe_terminal(&slot) {
+            ConnectionErrorIncoming::InternalError(msg) => {
+                assert!(msg.contains("without a terminal reason"), "msg: {msg}");
+            }
+            other => panic!("expected InternalError, got {other:?}"),
+        }
+    }
+
+    /// Read the resolved value of the connect one-shot without blocking. Panics
+    /// if the waiter is still pending (would hang) or was cancelled.
+    fn connect_result(crx: &mut ConnCtxReceiver) -> Result<(), Status> {
+        crx.connected
+            .take()
+            .expect("connected waiter present")
+            .try_recv()
+            .expect("connect waiter resolved, not cancelled (no hang)")
+            .expect("connect waiter produced a value, not Pending")
+    }
+
+    #[test]
+    fn connected_resolves_ok() {
+        let (mut ctx, mut crx) = conn_ctx_channel();
+        let ev = ConnectionEvent::Connected {
+            session_resumed: false,
+            negotiated_alpn: &[],
+        };
+        assert!(connection_callback(&mut ctx, ev).is_ok());
+        assert!(connect_result(&mut crx).is_ok());
+    }
+
+    #[test]
+    fn connected_waiter_resolves_with_transport_status_on_early_shutdown() {
+        let (mut ctx, mut crx) = conn_ctx_channel();
+        // Transport shutdown before Connected carries the real status.
+        let ev = ConnectionEvent::ShutdownInitiatedByTransport {
+            status: Status::new(StatusCode::QUIC_STATUS_HANDSHAKE_FAILURE),
+            error_code: 0,
+        };
+        assert!(connection_callback(&mut ctx, ev).is_ok());
+        let err = connect_result(&mut crx).expect_err("early shutdown resolves as Err");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_HANDSHAKE_FAILURE),
+            "connect() should surface the real transport cause, not synthetic ABORTED"
+        );
+    }
+
+    #[test]
+    fn connected_waiter_resolves_on_peer_shutdown_before_connected() {
+        let (mut ctx, mut crx) = conn_ctx_channel();
+        assert!(
+            connection_callback(&mut ctx, ConnectionEvent::ShutdownInitiatedByPeer {
+                error_code: 9
+            })
+            .is_ok()
+        );
+        // Peer close has no lossless status; the waiter resolves (no hang) as
+        // ABORTED, while the exact peer code stays in the terminal slot.
+        let err = connect_result(&mut crx).expect_err("peer shutdown resolves as Err");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_ABORTED)
+        );
+        assert!(matches!(
+            observe_terminal(&crx.terminal),
+            ConnectionErrorIncoming::ApplicationClose { error_code: 9 }
+        ));
+    }
+
+    #[test]
+    fn connected_waiter_resolves_on_bare_shutdown_complete() {
+        let (mut ctx, mut crx) = conn_ctx_channel();
+        assert!(
+            connection_callback(&mut ctx, ConnectionEvent::ShutdownComplete {
+                handshake_completed: false,
+                peer_acknowledged_shutdown: false,
+                app_close_in_progress: false,
+            })
+            .is_ok()
+        );
+        let err = connect_result(&mut crx).expect_err("bare shutdown resolves as Err");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_ABORTED)
+        );
+    }
+
+    #[test]
+    fn classify_transport_table() {
+        assert!(matches!(
+            classify_transport(Status::new(StatusCode::QUIC_STATUS_CONNECTION_IDLE), 0),
+            ConnectionTerminal::Timeout
+        ));
+        assert!(matches!(
+            classify_transport(Status::new(StatusCode::QUIC_STATUS_CONNECTION_TIMEOUT), 0),
+            ConnectionTerminal::Timeout
+        ));
+        assert!(matches!(
+            classify_transport(Status::new(StatusCode::QUIC_STATUS_TLS_ERROR), 3),
+            ConnectionTerminal::Transport { error_code: 3, .. }
+        ));
+    }
+
+    #[test]
+    fn provisional_local_close_refines_to_specific_before_observation() {
+        let mut st = ConnTerminalState::default();
+        st.record(ConnectionTerminal::LocalClose);
+        // A more-specific peer cause published before observation wins.
+        st.record(ConnectionTerminal::PeerApplication(7));
+        let t = st.observe().expect("terminal recorded");
+        assert!(matches!(t, ConnectionTerminal::PeerApplication(7)));
+        // Frozen after observation: later records are ignored.
+        st.record(ConnectionTerminal::Timeout);
+        assert!(matches!(
+            st.observe(),
+            Some(ConnectionTerminal::PeerApplication(7))
+        ));
+    }
+
+    #[test]
+    fn specific_cause_does_not_regress_to_provisional() {
+        let mut st = ConnTerminalState::default();
+        st.record(ConnectionTerminal::Timeout);
+        // A later provisional local close must not overwrite the specific cause.
+        st.record(ConnectionTerminal::LocalClose);
+        assert!(matches!(st.observe(), Some(ConnectionTerminal::Timeout)));
+    }
+
+    #[test]
+    fn first_specific_cause_wins_over_later_specific() {
+        let mut st = ConnTerminalState::default();
+        st.record(ConnectionTerminal::PeerApplication(1));
+        st.record(ConnectionTerminal::Timeout);
+        assert!(matches!(
+            st.observe(),
+            Some(ConnectionTerminal::PeerApplication(1))
+        ));
+    }
+
+    #[test]
+    fn refinement_frozen_by_observation_even_for_provisional() {
+        let mut st = ConnTerminalState::default();
+        st.record(ConnectionTerminal::LocalClose);
+        // Observing freezes the provisional value; a later specific cause that
+        // arrives after the frontend already reported cannot change it.
+        assert!(matches!(st.observe(), Some(ConnectionTerminal::LocalClose)));
+        st.record(ConnectionTerminal::PeerApplication(3));
+        assert!(matches!(st.observe(), Some(ConnectionTerminal::LocalClose)));
+    }
+
+    #[test]
+    fn normal_shutdown_drains_before_reporting_terminal() {
+        // A non-internal terminal does not fail fast: the accept frontend keeps
+        // the drain-then-terminal ordering (queued streams first).
+        let slot = new_conn_terminal_slot();
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(5));
+        assert!(
+            fail_fast_terminal(&slot).is_none(),
+            "a normal peer close must not fail fast ahead of queued streams"
+        );
+        // Once the channel drains, the recorded reason is reported.
+        assert!(matches!(
+            observe_terminal(&slot),
+            ConnectionErrorIncoming::ApplicationClose { error_code: 5 }
+        ));
+    }
+
+    #[test]
+    fn internal_terminal_fails_fast_ahead_of_queued_streams() {
+        let slot = new_conn_terminal_slot();
+        record_conn_terminal(&slot, ConnectionTerminal::Internal("boom"));
+        match fail_fast_terminal(&slot) {
+            Some(ConnectionErrorIncoming::InternalError(msg)) => assert_eq!(msg, "boom"),
+            other => panic!("expected fail-fast InternalError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn callback_records_local_close_provisionally_then_refines() {
+        // Simulate OpenStreams::close (records LocalClose) racing a peer cause
+        // that lands before the frontend observes: the specific cause wins.
+        let (mut ctx, crx) = conn_ctx_channel();
+        record_conn_terminal(&ctx.terminal, ConnectionTerminal::LocalClose);
+        assert!(
+            connection_callback(&mut ctx, ConnectionEvent::ShutdownInitiatedByPeer {
+                error_code: 11
+            })
+            .is_ok()
+        );
+        assert!(matches!(
+            observe_terminal(&crx.terminal),
+            ConnectionErrorIncoming::ApplicationClose { error_code: 11 }
+        ));
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -55,7 +55,10 @@ pub(crate) fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
 /// [`lock_recover`] so an FFI callback never panics on a poisoned lock.
 pub(crate) type ConnTerminalSlot = Arc<Mutex<ConnTerminalState>>;
 
-/// Create a fresh, empty connection terminal-reason slot.
+/// Create a fresh, empty connection terminal-reason slot. Test-only helper for
+/// exercising the terminal slot directly (production builds the slot inline in
+/// [`conn_ctx_channel`]).
+#[cfg(test)]
 pub(crate) fn new_conn_terminal_slot() -> ConnTerminalSlot {
     Arc::new(Mutex::new(ConnTerminalState::default()))
 }
@@ -212,6 +215,15 @@ struct ConnCtxSender {
     uni: Option<mpsc::UnboundedSender<Option<crate::H3Stream>>>,
     /// Shared connection terminal-reason slot (writer side).
     terminal: ConnTerminalSlot,
+    /// Connection-scoped test seam that forces an accepted-stream ID resolution
+    /// to fail exactly once. Shares its atomic with
+    /// [`ConnCtxReceiver::accepted_id_failpoint`] (created once in
+    /// [`conn_ctx_channel`]) so a live [`Connection`] can arm it before an
+    /// accept; lives in the shared connection state rather than a
+    /// thread-local/process-global because msquic callbacks run on worker
+    /// threads and a connection can migrate between them.
+    #[cfg(test)]
+    accepted_id_failpoint: Arc<AcceptedIdFailpoint>,
 }
 
 /// front end receive.
@@ -223,6 +235,13 @@ struct ConnCtxReceiver {
     uni: mpsc::UnboundedReceiver<Option<crate::H3Stream>>,
     /// Shared connection terminal-reason slot (reader side).
     terminal: ConnTerminalSlot,
+    /// Reader/frontend handle to the connection-scoped accepted-ID failpoint.
+    /// Shares the same atomic as [`ConnCtxSender::accepted_id_failpoint`], so a
+    /// test holding a live [`Connection`] (which owns this receiver) can arm the
+    /// failpoint *before* a peer stream is accepted; the callback's
+    /// `PeerStreamStarted` path then reads it through the sender-side clone.
+    #[cfg(test)]
+    accepted_id_failpoint: Arc<AcceptedIdFailpoint>,
 }
 
 fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
@@ -231,6 +250,10 @@ fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
     let (bidi_tx, bidi_rx) = mpsc::unbounded();
     let (uni_tx, uni_rx) = mpsc::unbounded();
     let terminal: ConnTerminalSlot = Arc::new(Mutex::new(ConnTerminalState::default()));
+    // The accepted-ID failpoint atomic is shared (cloned) between the callback's
+    // sender and the frontend's receiver so a live `Connection` can arm it.
+    #[cfg(test)]
+    let accepted_id_failpoint: Arc<AcceptedIdFailpoint> = Arc::new(AcceptedIdFailpoint::default());
     (
         ConnCtxSender {
             connected: Some(conn_tx),
@@ -238,6 +261,8 @@ fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
             bidi: Some(bidi_tx),
             uni: Some(uni_tx),
             terminal: terminal.clone(),
+            #[cfg(test)]
+            accepted_id_failpoint: accepted_id_failpoint.clone(),
         },
         ConnCtxReceiver {
             connected: Some(conn_rx),
@@ -245,8 +270,116 @@ fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
             bidi: bidi_rx,
             uni: uni_rx,
             terminal,
+            #[cfg(test)]
+            accepted_id_failpoint,
         },
     )
+}
+
+/// Pure, unit-testable ID validation. MsQuic stream IDs are 62-bit so this
+/// never fails for a live peer, but the [`h3::quic::InvalidStreamId`] branch is
+/// still handled explicitly (a test seam and future callers can drive it).
+fn validate_stream_id(raw: u64) -> Result<h3::quic::StreamId, h3::quic::InvalidStreamId> {
+    h3::quic::StreamId::try_from(raw)
+}
+
+/// Non-freezing read of the connection terminal reason.
+///
+/// Unlike [`ConnTerminalState::observe`], this clones the recorded reason
+/// without marking the slot observed, so the stream-open path can consult the
+/// connection terminal without freezing it for the accept frontends.
+fn peek_conn_terminal(slot: &ConnTerminalSlot) -> Option<ConnectionTerminal> {
+    lock_recover(slot).terminal.clone()
+}
+
+/// Wake both accept frontends by dropping the incoming-stream senders.
+///
+/// Used only on the fail-fast accepted-stream attachment path: once the adapter
+/// has declared its own connection state invalid (an `Internal` terminal), it
+/// must stop handing new streams to h3 and unpark any parked acceptor so it
+/// observes the published terminal.
+fn wake_acceptors(ctx: &mut ConnCtxSender) {
+    ctx.uni.take();
+    ctx.bidi.take();
+}
+
+/// Resolve and validate a peer-accepted stream's h3 [`h3::quic::StreamId`]
+/// *before* native ownership is taken.
+///
+/// `query` produces the raw 62-bit ID from the still-borrowed `StreamRef`. On
+/// any failure this publishes an `Internal` connection terminal, wakes both
+/// acceptors, and returns the `Status` the callback must return so msquic closes
+/// the rejected stream itself — the adapter never takes Rust ownership, so it
+/// never double-closes. On success the caller is cleared to take ownership.
+fn accept_stream_id(
+    ctx: &mut ConnCtxSender,
+    query: impl FnOnce() -> Result<u64, Status>,
+) -> Result<h3::quic::StreamId, Status> {
+    let raw = match query() {
+        Ok(raw) => raw,
+        Err(status) => {
+            record_conn_terminal(
+                &ctx.terminal,
+                ConnectionTerminal::Internal("accepted stream ID query failed"),
+            );
+            wake_acceptors(ctx);
+            return Err(status);
+        }
+    };
+    match validate_stream_id(raw) {
+        Ok(id) => Ok(id),
+        Err(_) => {
+            record_conn_terminal(
+                &ctx.terminal,
+                ConnectionTerminal::Internal("accepted stream ID is invalid"),
+            );
+            wake_acceptors(ctx);
+            Err(Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR))
+        }
+    }
+}
+
+/// Connection-scoped test seam forcing exactly one accepted-stream ID
+/// resolution to fail. An atomic (not a thread-local) because the msquic
+/// callback runs on a worker thread; consuming itself atomically identifies the
+/// single rejected stream and stays correct under the parallel test harness.
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct AcceptedIdFailpoint {
+    mode: std::sync::atomic::AtomicU8,
+}
+
+#[cfg(test)]
+impl AcceptedIdFailpoint {
+    const OFF: u8 = 0;
+    const QUERY_FAIL: u8 = 1;
+    const INVALID_ID: u8 = 2;
+
+    /// Arm the next accepted-stream attachment to fail its native ID query.
+    fn arm_query_fail(&self) {
+        self.mode
+            .store(Self::QUERY_FAIL, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Arm the next accepted-stream attachment to yield an invalid h3 ID.
+    fn arm_invalid_id(&self) {
+        self.mode
+            .store(Self::INVALID_ID, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Consume the armed mode atomically and transform the queried raw ID:
+    /// off → `Ok(raw)`, query-fail → `Err(status)`, invalid → an out-of-range
+    /// ID that fails [`validate_stream_id`].
+    fn maybe_override(&self, raw: u64) -> Result<u64, Status> {
+        match self
+            .mode
+            .swap(Self::OFF, std::sync::atomic::Ordering::Relaxed)
+        {
+            Self::QUERY_FAIL => Err(Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR)),
+            Self::INVALID_ID => Ok(u64::MAX),
+            _ => Ok(raw),
+        }
+    }
 }
 
 #[cfg_attr(
@@ -266,7 +399,10 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
             // Peer application close: record the exact HTTP/3 code. A peer close
             // has no lossless `Status`, so a pending connect waiter resolves as
             // `QUIC_STATUS_ABORTED` (the exact code stays in the terminal slot).
-            record_conn_terminal(&ctx.terminal, ConnectionTerminal::PeerApplication(error_code));
+            record_conn_terminal(
+                &ctx.terminal,
+                ConnectionTerminal::PeerApplication(error_code),
+            );
             if let Some(tx) = ctx.connected.take() {
                 let _ = tx.send(Err(Status::new(StatusCode::QUIC_STATUS_ABORTED)));
             }
@@ -275,25 +411,53 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
             // Transport shutdown: timeout statuses become `Timeout`, everything
             // else retains the status + wire code. Resolve a pending connect
             // waiter with the real transport `Status` (not a synthetic ABORTED).
-            record_conn_terminal(&ctx.terminal, classify_transport(status.clone(), error_code));
+            record_conn_terminal(
+                &ctx.terminal,
+                classify_transport(status.clone(), error_code),
+            );
             if let Some(tx) = ctx.connected.take() {
                 let _ = tx.send(Err(status));
             }
         }
         ConnectionEvent::PeerStreamStarted { stream, flags } => {
-            // TODO: need to set callback
-            let s = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
-            if flags.contains(StreamOpenFlags::UNIDIRECTIONAL) {
-                if let Some(uni) = ctx.uni.as_ref() {
-                    // Ownership was taken by `H3Stream::attach`; if delivery
-                    // fails (frontend gone) the returned `SendError` carries the
-                    // owned `H3Stream`, which drops here and closes the native
-                    // stream exactly once.
-                    let _ = uni.unbounded_send(Some(crate::H3Stream::attach(s)));
-                }
-            } else if let Some(bidi) = ctx.bidi.as_ref() {
-                let _ = bidi.unbounded_send(Some(crate::H3Stream::attach(s)));
+            // Resolve and validate the stream ID against the still-BORROWED
+            // `StreamRef` (auto-deref to `Stream::get_stream_id`). No owning
+            // `Stream` is created until this succeeds, so a validation failure
+            // returns the `Status` for msquic to close the rejected stream —
+            // the adapter never took ownership, avoiding the reject-and-close
+            // double-close hazard in native `stream_set.c`.
+            #[cfg(test)]
+            let failpoint = ctx.accepted_id_failpoint.clone();
+            let query = || {
+                let raw = stream.get_stream_id()?;
+                #[cfg(test)]
+                let raw = failpoint.maybe_override(raw)?;
+                Ok(raw)
+            };
+            let id = match accept_stream_id(ctx, query) {
+                Ok(id) => id,
+                // Pre-ownership failure: `accept_stream_id` already published the
+                // internal terminal and woke the acceptors. Return the status so
+                // msquic closes the rejected stream itself (single close).
+                Err(status) => return Err(status),
+            };
+            // Success: only NOW take native ownership and attach.
+            let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
+            let h3 = crate::H3Stream::attach(owned, id);
+            let target = if flags.contains(StreamOpenFlags::UNIDIRECTIONAL) {
+                ctx.uni.as_ref()
+            } else {
+                ctx.bidi.as_ref()
+            };
+            if let Some(tx) = target {
+                // Post-ownership delivery failure: the returned `SendError`
+                // carries the owned `H3Stream`, which drops here and runs a
+                // single `StreamClose`. Do NOT return `Err` — combined with the
+                // close it would trip native `stream_set.c`'s reject assert.
+                let _ = tx.unbounded_send(Some(h3));
             }
+            // No target sender (fail-fast already dropped them): `h3` drops here
+            // and closes exactly once.
         }
         ConnectionEvent::ShutdownComplete { .. } => {
             // A bare shutdown with no more-specific reason published is a local
@@ -401,6 +565,32 @@ impl Connection {
     }
 }
 
+/// Test-only seam to arm the connection-scoped accepted-stream-ID failpoint from
+/// a *live* `Connection`. Because the atomic is stored in the shared connection
+/// state (cloned into both the callback's sender and this frontend's receiver),
+/// a Phase 8 loopback test holding the accepted `Connection` can arm the
+/// failpoint *before* the peer opens a stream; the real `PeerStreamStarted`
+/// accept path then trips on it, driving the native reject + connection
+/// `H3_INTERNAL_ERROR` close.
+#[cfg(test)]
+impl Connection {
+    /// Arm the next accepted-stream attachment to fail its native ID query.
+    pub(crate) fn arm_accepted_id_query_fail(&self) {
+        self.ctx.accepted_id_failpoint.arm_query_fail();
+    }
+
+    /// Arm the next accepted-stream attachment to yield an invalid h3 ID.
+    pub(crate) fn arm_accepted_id_invalid(&self) {
+        self.ctx.accepted_id_failpoint.arm_invalid_id();
+    }
+
+    /// Test-only view of the shared failpoint atomic — the same one the callback
+    /// consults on the accept path — so a test can prove arming took effect.
+    pub(crate) fn accepted_id_failpoint(&self) -> &Arc<AcceptedIdFailpoint> {
+        &self.ctx.accepted_id_failpoint
+    }
+}
+
 /// Fail-fast terminal check for the accept frontends.
 ///
 /// Returns the converted connection error only when an *internal* terminal has
@@ -446,8 +636,8 @@ impl ConnectionShutdownWaiter {
 #[derive(Debug)]
 pub struct StreamOpener {
     conn: Arc<ConnHandle>,
-    bidi_temp: Option<H3Stream>,
-    uni_temp: Option<H3Stream>,
+    bidi_temp: Option<OpeningStream>,
+    uni_temp: Option<OpeningStream>,
 }
 
 impl Clone for StreamOpener {
@@ -577,38 +767,107 @@ impl StreamOpener {
         }
     }
 
-    /// open a stream and poll it in the holder.
+    /// Open a native stream, then drive it to a fully-identified [`H3Stream`].
+    ///
+    /// Never panics: a connection-caused cancellation of the pending start maps
+    /// to a connection error, and a start cancelled with no published reason to
+    /// a nested internal error. The local stream ID is sourced from the
+    /// `StartComplete` outcome and validated before an `H3Stream` is built.
     fn poll_open_inner(
         conn: &Arc<ConnHandle>,
         uni: bool,
-        stream_holder: &mut Option<H3Stream>,
+        holder: &mut Option<OpeningStream>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<H3Stream, StreamErrorIncoming>> {
-        if stream_holder.is_none() {
-            // create new stream
-            let s = match H3Stream::open_and_start(conn, uni) {
-                Ok(s) => s,
-                Err(e) => {
-                    return std::task::Poll::Ready(Err(StreamErrorIncoming::Unknown(e.into())));
-                }
-            };
-            *stream_holder = Some(s);
+        use std::task::Poll;
+        // 1. Fail fast if the connection already published a terminal.
+        if let Some(reason) = peek_conn_terminal(conn.terminal()) {
+            *holder = None; // drop any in-flight OpeningStream
+            return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: convert_conn(reason),
+            }));
         }
-
-        // poll stream start.
-        let res = {
-            let s = stream_holder.as_mut().unwrap();
-            let rx = s.send.sctx.start.as_mut().unwrap();
-            let p = Pin::new(rx);
-            ready!(std::future::Future::poll(p, cx))
+        // 2. Create + start the native stream if none is in flight.
+        if holder.is_none() {
+            match H3Stream::open_and_start(conn, uni) {
+                Ok(opening) => *holder = Some(opening),
+                Err(status) => {
+                    // A shutdown may have raced the open; prefer the terminal.
+                    return Poll::Ready(Err(match peek_conn_terminal(conn.terminal()) {
+                        Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
+                            connection_error: convert_conn(reason),
+                        },
+                        None => StreamErrorIncoming::Unknown(status.into()),
+                    }));
+                }
+            }
+        }
+        // 3. Await StartComplete on the OpeningStream's `start` receiver.
+        let raw = {
+            let Some(opening) = holder.as_mut() else {
+                return Poll::Pending;
+            };
+            match Pin::new(&mut opening.start).poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Ok(raw)) => raw, // Result<u64, Status> from StartComplete
+                Poll::Ready(Err(oneshot::Canceled)) => {
+                    // Sender dropped by ShutdownComplete without a StartComplete:
+                    // a connection-caused cancellation (never a panic).
+                    *holder = None;
+                    return Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                        connection_error: stream_open_conn_error(conn.terminal()),
+                    }));
+                }
+            }
         };
-        // current stream is either ready or error. So ready to be returned or dropped.
-        let s = stream_holder.take().unwrap();
-        let res = res
-            .expect("cannot receive")
-            .map(|_| s)
-            .map_err(|e| StreamErrorIncoming::Unknown(e.into()));
-        std::task::Poll::Ready(res)
+        // 4. StartComplete carried a status; classify it and finalize.
+        let Some(opening) = holder.take() else {
+            return Poll::Pending;
+        };
+        Poll::Ready(match classify_start_outcome(raw, conn.terminal()) {
+            Ok(id) => Ok(opening.finalize(id)),
+            Err(e) => Err(e),
+        })
+    }
+}
+
+/// Connection error for a stream-open whose start channel was cancelled.
+///
+/// A published connection terminal is the true cause; a cancellation with no
+/// recorded reason is a defined internal error, never a synthetic peer code.
+fn stream_open_conn_error(slot: &ConnTerminalSlot) -> ConnectionErrorIncoming {
+    match peek_conn_terminal(slot) {
+        Some(reason) => convert_conn(reason),
+        None => ConnectionErrorIncoming::InternalError(
+            "stream start cancelled without a terminal reason".to_string(),
+        ),
+    }
+}
+
+/// Classify a `StartComplete` outcome into a validated local [`h3::quic::StreamId`]
+/// or a stream error.
+///
+/// A failed start prefers a published connection terminal, else surfaces the raw
+/// `Status` as `Unknown`. A successful start validates the ID; an out-of-range
+/// ID is an adapter-internal fault (never `Unknown`).
+fn classify_start_outcome(
+    raw: Result<u64, Status>,
+    slot: &ConnTerminalSlot,
+) -> Result<h3::quic::StreamId, StreamErrorIncoming> {
+    match raw {
+        Err(status) => Err(match peek_conn_terminal(slot) {
+            Some(reason) => StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: convert_conn(reason),
+            },
+            None => StreamErrorIncoming::Unknown(status.into()),
+        }),
+        Ok(raw_id) => {
+            validate_stream_id(raw_id).map_err(|_| StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(
+                    "local stream ID is invalid".to_string(),
+                ),
+            })
+        }
     }
 }
 
@@ -678,7 +937,7 @@ enum ReceiveEvent {
 }
 
 struct StreamSendCtx {
-    start: Option<oneshot::Sender<Result<(), Status>>>,
+    start: Option<oneshot::Sender<Result<u64, Status>>>,
     // cancelled, client_context
     send: Option<mpsc::UnboundedSender<(bool, BufPtr)>>,
     shutdown: Option<oneshot::Sender<()>>,
@@ -693,6 +952,11 @@ struct StreamSendCtx {
 /// ctx for receiving data on frontend.
 #[derive(Debug)]
 struct RecvStreamReceiveCtx {
+    /// Cached, validated stream identity. Resolved before an `H3RecvStream` is
+    /// exposed (from `StartComplete` for local streams, from the borrowed
+    /// `get_stream_id` query for accepted streams), so `recv_id` never queries a
+    /// native parameter and cannot panic after shutdown.
+    id: h3::quic::StreamId,
     receive: mpsc::UnboundedReceiver<ReceiveEvent>,
     /// Sticky receive terminal. Once a terminal event has been drained it is
     /// stored here and every later `poll_data` returns the same class without
@@ -707,15 +971,95 @@ struct RecvStreamReceiveCtx {
 /// ctx for sending data on frontend.
 #[derive(Debug)]
 struct SendStreamReceiveCtx {
-    start: Option<oneshot::Receiver<Result<(), Status>>>,
+    /// Cached, validated stream identity (see [`RecvStreamReceiveCtx::id`]); read
+    /// by `send_id` without a native query.
+    id: h3::quic::StreamId,
     // cancelled, client_context
     send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
     send_inprogress: bool,
     shutdown: oneshot::Receiver<()>,
 }
 
-fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
-    let (start_tx, start_rx) = oneshot::channel::<Result<(), Status>>();
+/// Frontend *receiver* ends held by an [`OpeningStream`] until the stream ID is
+/// known. The matching *sender* halves live in the callback-owned
+/// [`StreamSendCtx`]; holding these keeps every channel open (so callback sends
+/// never fail) and lets `finalize` move them into the [`H3Stream`] halves.
+#[derive(Debug)]
+struct PreIdReceivers {
+    start: oneshot::Receiver<Result<u64, Status>>,
+    send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
+    shutdown: oneshot::Receiver<()>,
+    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
+}
+
+/// A locally opened stream whose native handle is started but whose h3
+/// [`h3::quic::StreamId`] is not yet known. Private to [`StreamOpener`]; the
+/// only stream form allowed to exist without a cached ID. On a successful
+/// `StartComplete` it is consumed into an [`H3Stream`] with concrete ID fields
+/// in both halves.
+#[derive(Debug)]
+struct OpeningStream {
+    stream: Arc<msquic::Stream>,
+    /// Pending-start receiver, polled by `poll_open_inner` until `StartComplete`.
+    start: oneshot::Receiver<Result<u64, Status>>,
+    /// The remaining receiver ends, moved into the `H3Stream` halves by
+    /// `finalize` once the ID is validated.
+    tail: PreIdTail,
+}
+
+/// The non-start receiver ends of an [`OpeningStream`] (kept apart so `start` can
+/// be polled independently while these wait for `finalize`).
+#[derive(Debug)]
+struct PreIdTail {
+    send: mpsc::UnboundedReceiver<(bool, BufPtr)>,
+    shutdown: oneshot::Receiver<()>,
+    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
+}
+
+impl OpeningStream {
+    /// Consume into an [`H3Stream`] once `StartComplete` has yielded a validated
+    /// ID. The `start` receiver has already been driven to completion and is
+    /// dropped here; the remaining three receivers move into the two halves.
+    fn finalize(self, id: h3::quic::StreamId) -> H3Stream {
+        let OpeningStream {
+            stream,
+            start: _,
+            tail,
+        } = self;
+        let PreIdTail {
+            send,
+            shutdown,
+            receive,
+        } = tail;
+        H3Stream {
+            send: H3SendStream {
+                stream: stream.clone(),
+                sctx: SendStreamReceiveCtx {
+                    id,
+                    send,
+                    send_inprogress: false,
+                    shutdown,
+                },
+            },
+            recv: H3RecvStream {
+                stream,
+                rctx: RecvStreamReceiveCtx {
+                    id,
+                    receive,
+                    terminal: None,
+                    receive_closed: false,
+                },
+            },
+        }
+    }
+}
+
+/// Pre-ID variant of the stream channel builder: no [`h3::quic::StreamId`] is
+/// required or produced. Builds the callback-owned [`StreamSendCtx`] (senders)
+/// and returns the matching receiver ends bundled, so an [`OpeningStream`] can
+/// hold them until `StartComplete` yields the ID.
+fn stream_ctx_channel_pre_id() -> (StreamSendCtx, PreIdReceivers) {
+    let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
     let (send_tx, send_rx) = mpsc::unbounded();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (receive_tx, receive_rx) = mpsc::unbounded();
@@ -727,14 +1071,40 @@ fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamRecei
             receive: Some(receive_tx),
             receive_terminal_sent: false,
         },
-        SendStreamReceiveCtx {
-            start: Some(start_rx),
+        PreIdReceivers {
+            start: start_rx,
             send: send_rx,
-            send_inprogress: false,
             shutdown: shutdown_rx,
+            receive: receive_rx,
+        },
+    )
+}
+
+/// ID-bearing stream channel builder used where the identity is already known
+/// (accepted streams and tests). Splits the pre-ID receivers into the two
+/// frontend halves' ctxs directly.
+#[cfg(test)]
+fn stream_ctx_channel(
+    id: h3::quic::StreamId,
+) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
+    let (ctx, recv) = stream_ctx_channel_pre_id();
+    let PreIdReceivers {
+        start: _,
+        send,
+        shutdown,
+        receive,
+    } = recv;
+    (
+        ctx,
+        SendStreamReceiveCtx {
+            id,
+            send,
+            send_inprogress: false,
+            shutdown,
         },
         RecvStreamReceiveCtx {
-            receive: receive_rx,
+            id,
+            receive,
             terminal: None,
             receive_closed: false,
         },
@@ -747,11 +1117,12 @@ fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamRecei
 )]
 fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Status> {
     match ev {
-        StreamEvent::StartComplete { status, .. } => {
+        StreamEvent::StartComplete { status, id, .. } => {
             // Duplicate `StartComplete` (slot already taken) or a dropped
-            // `OpeningStream` receiver is a safe no-op.
+            // `OpeningStream` receiver is a safe no-op. The `id: u62` outcome is
+            // the local stream's identity source (validated by poll_open_inner).
             if let Some(tx) = ctx.start.take() {
-                let result = if status.is_ok() { Ok(()) } else { Err(status) };
+                let result = if status.is_ok() { Ok(id) } else { Err(status) };
                 let _ = tx.send(result);
             }
         }
@@ -860,31 +1231,36 @@ fn publish_recv_terminal(ctx: &mut StreamSendCtx, ev: ReceiveEvent) {
 }
 
 impl H3Stream {
-    /// attach to accepted stream
-    pub(crate) fn attach(stream: msquic::Stream) -> Self {
-        let (mut ctx, rtx, rrtx) = stream_ctx_channel();
+    /// Attach to a peer-accepted stream whose identity was already validated
+    /// from the borrowed `StreamRef` (see [`accept_stream_id`]). Takes native
+    /// ownership of `stream` (the caller must have confirmed success first).
+    pub(crate) fn attach(stream: msquic::Stream, id: h3::quic::StreamId) -> Self {
+        let (mut ctx, recv) = stream_ctx_channel_pre_id();
         let handler = move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
-
         stream.set_callback_handler(handler);
-        let s = Arc::new(stream);
-        Self {
-            send: H3SendStream {
-                stream: s.clone(),
-                sctx: rtx,
-            },
-            recv: H3RecvStream {
-                stream: s,
-                rctx: rrtx,
+        // The ID is known, so finalize straight away. An accepted stream never
+        // receives `StartComplete`, so its `start` receiver simply drops.
+        OpeningStream {
+            stream: Arc::new(stream),
+            start: recv.start,
+            tail: PreIdTail {
+                send: recv.send,
+                shutdown: recv.shutdown,
+                receive: recv.receive,
             },
         }
+        .finalize(id)
     }
 
+    /// Open + start a native stream, returning the pre-ID [`OpeningStream`]. The
+    /// h3 identity is not known yet; it arrives later via `StartComplete` and is
+    /// resolved by [`StreamOpener::poll_open_inner`].
     #[cfg_attr(
         feature = "tracing",
         tracing::instrument(skip_all, level = "trace", err, ret)
     )]
-    fn open_and_start(conn: &msquic::Connection, uni: bool) -> Result<Self, Status> {
-        let (mut ctx, rtx, rrtx) = stream_ctx_channel();
+    fn open_and_start(conn: &msquic::Connection, uni: bool) -> Result<OpeningStream, Status> {
+        let (mut ctx, recv) = stream_ctx_channel_pre_id();
         let handler = move |_: StreamRef, ev: StreamEvent| stream_callback(&mut ctx, ev);
 
         let flag = match uni {
@@ -893,16 +1269,14 @@ impl H3Stream {
         };
 
         let s = msquic::Stream::open(conn, flag, handler)?;
-        s.start(StreamStartFlags::NONE)?;
-        let s = Arc::new(s);
-        Ok(Self {
-            send: H3SendStream {
-                stream: s.clone(),
-                sctx: rtx,
-            },
-            recv: H3RecvStream {
-                stream: s,
-                rctx: rrtx,
+        s.start(StreamStartFlags::NONE)?; // id arrives later via StartComplete
+        Ok(OpeningStream {
+            stream: Arc::new(s),
+            start: recv.start,
+            tail: PreIdTail {
+                send: recv.send,
+                shutdown: recv.shutdown,
+                receive: recv.receive,
             },
         })
     }
@@ -999,16 +1373,9 @@ impl<B: Buf> SendStream<B> for H3SendStream {
     }
 
     fn send_id(&self) -> h3::quic::StreamId {
-        get_id(&self.stream)
+        // Cached at construction; no native query, so this never panics.
+        self.sctx.id
     }
-}
-
-fn get_id(s: &msquic::Stream) -> h3::quic::StreamId {
-    let raw_id = unsafe {
-        msquic::Api::get_param_auto::<u64>(s.as_raw(), msquic::ffi::QUIC_PARAM_STREAM_ID)
-    }
-    .unwrap();
-    raw_id.try_into().expect("cannot parse id")
 }
 
 impl RecvStreamReceiveCtx {
@@ -1102,7 +1469,8 @@ impl RecvStream for H3RecvStream {
     }
 
     fn recv_id(&self) -> h3::quic::StreamId {
-        get_id(&self.stream)
+        // Cached at construction; no native query, so this never panics.
+        self.rctx.id
     }
 }
 
@@ -1415,7 +1783,7 @@ mod callback_safety {
 
     #[test]
     fn stream_callback_send_complete_with_dropped_receiver_is_noop() {
-        let (mut ctx, srx, rrx) = stream_ctx_channel();
+        let (mut ctx, srx, rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         // Frontend gone: drop the receive side of the send-complete channel.
         drop(srx);
         drop(rrx);
@@ -1458,7 +1826,7 @@ mod connection_terminal {
     use crate::error::ConnectionTerminal;
     use crate::msquic::{ConnectionEvent, Status, StatusCode};
     use crate::{
-        ConnTerminalState, ConnCtxReceiver, classify_transport, conn_ctx_channel,
+        ConnCtxReceiver, ConnTerminalState, classify_transport, conn_ctx_channel,
         connection_callback, fail_fast_terminal, new_conn_terminal_slot, observe_terminal,
         record_conn_terminal,
     };
@@ -1475,7 +1843,10 @@ mod connection_terminal {
     fn peer_application_close_maps_to_application_close_with_code() {
         let err = map_event(ConnectionEvent::ShutdownInitiatedByPeer { error_code: 42 });
         assert!(
-            matches!(err, ConnectionErrorIncoming::ApplicationClose { error_code: 42 }),
+            matches!(
+                err,
+                ConnectionErrorIncoming::ApplicationClose { error_code: 42 }
+            ),
             "expected ApplicationClose(42), got {err:?}"
         );
     }
@@ -1590,9 +1961,10 @@ mod connection_terminal {
     fn connected_waiter_resolves_on_peer_shutdown_before_connected() {
         let (mut ctx, mut crx) = conn_ctx_channel();
         assert!(
-            connection_callback(&mut ctx, ConnectionEvent::ShutdownInitiatedByPeer {
-                error_code: 9
-            })
+            connection_callback(
+                &mut ctx,
+                ConnectionEvent::ShutdownInitiatedByPeer { error_code: 9 }
+            )
             .is_ok()
         );
         // Peer close has no lossless status; the waiter resolves (no hang) as
@@ -1612,11 +1984,14 @@ mod connection_terminal {
     fn connected_waiter_resolves_on_bare_shutdown_complete() {
         let (mut ctx, mut crx) = conn_ctx_channel();
         assert!(
-            connection_callback(&mut ctx, ConnectionEvent::ShutdownComplete {
-                handshake_completed: false,
-                peer_acknowledged_shutdown: false,
-                app_close_in_progress: false,
-            })
+            connection_callback(
+                &mut ctx,
+                ConnectionEvent::ShutdownComplete {
+                    handshake_completed: false,
+                    peer_acknowledged_shutdown: false,
+                    app_close_in_progress: false,
+                }
+            )
             .is_ok()
         );
         let err = connect_result(&mut crx).expect_err("bare shutdown resolves as Err");
@@ -1723,9 +2098,10 @@ mod connection_terminal {
         let (mut ctx, crx) = conn_ctx_channel();
         record_conn_terminal(&ctx.terminal, ConnectionTerminal::LocalClose);
         assert!(
-            connection_callback(&mut ctx, ConnectionEvent::ShutdownInitiatedByPeer {
-                error_code: 11
-            })
+            connection_callback(
+                &mut ctx,
+                ConnectionEvent::ShutdownInitiatedByPeer { error_code: 11 }
+            )
             .is_ok()
         );
         assert!(matches!(
@@ -1777,7 +2153,7 @@ mod receive_events {
 
     #[test]
     fn graceful_fin_yields_data_then_clean_eof() {
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         feed_receive(&mut ctx, &[1, 2, 3], ReceiveFlags::FIN);
         // Data first.
         match poll(&mut rrx) {
@@ -1792,7 +2168,7 @@ mod receive_events {
 
     #[test]
     fn peer_reset_yields_stream_terminated_with_code() {
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         assert!(stream_callback(&mut ctx, StreamEvent::PeerSendAborted { error_code: 42 }).is_ok());
         match poll(&mut rrx) {
             Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
@@ -1806,11 +2182,11 @@ mod receive_events {
     fn graceful_fin_and_peer_reset_are_observably_different() {
         // FIN => Ok(None); RESET_STREAM => Err(StreamTerminated). The two paths
         // must not be conflated (Finding 1).
-        let (mut fin_ctx, _s1, mut fin_rrx) = stream_ctx_channel();
+        let (mut fin_ctx, _s1, mut fin_rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         feed_receive(&mut fin_ctx, &[], ReceiveFlags::FIN);
         let fin = poll(&mut fin_rrx);
 
-        let (mut rst_ctx, _s2, mut rst_rrx) = stream_ctx_channel();
+        let (mut rst_ctx, _s2, mut rst_rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         assert!(
             stream_callback(&mut rst_ctx, StreamEvent::PeerSendAborted { error_code: 7 }).is_ok()
         );
@@ -1825,7 +2201,7 @@ mod receive_events {
 
     #[test]
     fn empty_non_fin_receive_produces_no_event() {
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         // A zero-length, non-FIN notification is not an end-of-stream (Finding 8).
         feed_receive(&mut ctx, &[], ReceiveFlags::NONE);
         // No event was enqueued and the channel is still open: Pending.
@@ -1836,7 +2212,7 @@ mod receive_events {
 
     #[test]
     fn peer_send_shutdown_yields_clean_eof() {
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         assert!(stream_callback(&mut ctx, StreamEvent::PeerSendShutdown).is_ok());
         assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
     }
@@ -1846,7 +2222,7 @@ mod receive_events {
         // The usual `Receive{FIN}` then `PeerSendShutdown` sequence must yield a
         // single clean EOF, not a duplicate. Likewise a reset published first is
         // not overwritten by a later FIN.
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         assert!(stream_callback(&mut ctx, StreamEvent::PeerSendAborted { error_code: 9 }).is_ok());
         // A later graceful FIN must NOT override the earlier reset.
         assert!(stream_callback(&mut ctx, StreamEvent::PeerSendShutdown).is_ok());
@@ -1865,7 +2241,7 @@ mod receive_events {
     fn connection_shutdown_surfaces_connection_error() {
         // A peer application close (by_app && closed_remotely) delivered as a
         // connection-caused stream shutdown surfaces the connection error.
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         let ev = StreamEvent::ShutdownComplete {
             connection_shutdown: true,
             app_close_in_progress: false,
@@ -1888,7 +2264,7 @@ mod receive_events {
         // A stream-local `ShutdownComplete` (connection_shutdown == false) must
         // NOT surface a connection error. The channel closes with no terminal
         // event, which maps to the internal fault class.
-        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         let ev = StreamEvent::ShutdownComplete {
             connection_shutdown: false,
             app_close_in_progress: false,
@@ -1916,12 +2292,289 @@ mod receive_events {
         // stop_sending local-EOF behavior without needing a live FFI stream.
         // `stop_sending` separately submits `ABORT_RECEIVE` with the clamped
         // application code; that FFI effect is exercised by the loopback tests.
-        let (_ctx, _srx, mut rrx) = stream_ctx_channel();
+        let (_ctx, _srx, mut rrx) = stream_ctx_channel(4u64.try_into().unwrap());
         assert!(!rrx.receive_closed);
         rrx.close_receive_locally(); // the exact call RecvStream::stop_sending makes
         assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
         // No terminal was injected: the sticky recv terminal slot stays empty.
         assert!(rrx.terminal.is_none());
         assert!(rrx.receive_closed);
+    }
+}
+
+/// Phase 5 (safe stream open & identity) unit tests: prove the pure stream-ID
+/// validation, the accepted-stream borrow-before-own resolution (with its
+/// connection-scoped failpoint seam), and the non-panicking classification of a
+/// local stream's `StartComplete` outcome (including connection-caused
+/// cancellation). Hermetic (no network): a live peer stream always has a valid
+/// 62-bit ID and a real `StreamRef` cannot be forged, so the resolution logic is
+/// exercised through its factored, testable seams. The real success path is
+/// covered end-to-end by the loopback `basic_server_test`.
+#[cfg(test)]
+mod stream_open_identity {
+    use futures::channel::oneshot;
+    use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
+
+    use crate::error::ConnectionTerminal;
+    use crate::msquic::{Status, StatusCode};
+    use crate::{
+        accept_stream_id, classify_start_outcome, conn_ctx_channel, fail_fast_terminal,
+        new_conn_terminal_slot, record_conn_terminal, stream_ctx_channel_pre_id,
+        stream_open_conn_error, validate_stream_id,
+    };
+
+    /// The largest valid QUIC stream ID (62-bit VarInt max).
+    const MAX_VALID_ID: u64 = (1 << 62) - 1;
+
+    #[test]
+    fn validate_stream_id_boundaries() {
+        // 0 and the 62-bit maximum are valid; anything larger is rejected.
+        assert_eq!(validate_stream_id(0).unwrap().into_inner(), 0);
+        assert_eq!(
+            validate_stream_id(MAX_VALID_ID).unwrap().into_inner(),
+            MAX_VALID_ID
+        );
+        assert!(validate_stream_id(MAX_VALID_ID + 1).is_err());
+        assert!(validate_stream_id(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn accept_stream_id_success_takes_no_terminal() {
+        let (mut ctx, crx) = conn_ctx_channel();
+        let id = accept_stream_id(&mut ctx, || Ok(8)).expect("valid id accepted");
+        assert_eq!(id.into_inner(), 8);
+        // No terminal published; both acceptor senders remain open.
+        assert!(fail_fast_terminal(&crx.terminal).is_none());
+        assert!(ctx.uni.is_some() && ctx.bidi.is_some());
+    }
+
+    #[test]
+    fn accept_stream_id_query_failure_publishes_internal_and_wakes_acceptors() {
+        let (mut ctx, crx) = conn_ctx_channel();
+        let status = Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR);
+        // A native get_stream_id failure returns its Status from the callback...
+        let err = accept_stream_id(&mut ctx, || Err(status.clone())).expect_err("query failed");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            status.try_as_status_code().ok()
+        );
+        // ...publishes a fail-fast internal terminal the acceptors observe...
+        match fail_fast_terminal(&crx.terminal) {
+            Some(ConnectionErrorIncoming::InternalError(_)) => {}
+            other => panic!("expected fail-fast InternalError, got {other:?}"),
+        }
+        // ...and drops both acceptor senders so parked acceptors are woken.
+        assert!(ctx.uni.is_none() && ctx.bidi.is_none());
+    }
+
+    #[test]
+    fn accept_stream_id_invalid_id_publishes_internal_and_returns_internal_status() {
+        let (mut ctx, crx) = conn_ctx_channel();
+        // A (synthetic) out-of-range ID fails h3 validation: internal terminal,
+        // QUIC_STATUS_INTERNAL_ERROR returned so msquic closes the stream.
+        let err = accept_stream_id(&mut ctx, || Ok(u64::MAX)).expect_err("invalid id rejected");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_INTERNAL_ERROR)
+        );
+        assert!(matches!(
+            fail_fast_terminal(&crx.terminal),
+            Some(ConnectionErrorIncoming::InternalError(_))
+        ));
+        assert!(ctx.uni.is_none() && ctx.bidi.is_none());
+    }
+
+    #[test]
+    fn already_published_peer_terminal_wins_over_internal() {
+        // An accepted-stream failure records Internal, but a peer application
+        // close published first is preserved (first-writer-wins).
+        let (mut ctx, crx) = conn_ctx_channel();
+        record_conn_terminal(&ctx.terminal, ConnectionTerminal::PeerApplication(7));
+        let _ = accept_stream_id(&mut ctx, || Ok(u64::MAX)).expect_err("invalid id rejected");
+        // The winning terminal is the earlier peer close, not the internal fault.
+        assert!(matches!(
+            crate::observe_terminal(&crx.terminal),
+            ConnectionErrorIncoming::ApplicationClose { error_code: 7 }
+        ));
+    }
+
+    #[test]
+    fn accepted_id_failpoint_query_fail_seam_rejects_then_consumes() {
+        // Drive the exact seam the callback uses, but arm it through the
+        // RECEIVER-side handle a live `Connection` frontend holds — proving the
+        // failpoint atomic is shared with the callback's sender-side clone.
+        let (mut ctx, crx) = conn_ctx_channel();
+        crx.accepted_id_failpoint.arm_query_fail();
+        // The callback consults its own (shared) sender-side handle.
+        let fp = ctx.accepted_id_failpoint.clone();
+        let err = accept_stream_id(&mut ctx, || fp.maybe_override(4)).expect_err("seam trips once");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_INTERNAL_ERROR)
+        );
+        assert!(matches!(
+            fail_fast_terminal(&crx.terminal),
+            Some(ConnectionErrorIncoming::InternalError(_))
+        ));
+        // The failpoint consumed itself: a fresh query now passes through.
+        let fp2 = crx.accepted_id_failpoint.clone();
+        assert_eq!(fp2.maybe_override(4).unwrap(), 4);
+    }
+
+    #[test]
+    fn accepted_id_failpoint_invalid_seam_rejects() {
+        let (mut ctx, crx) = conn_ctx_channel();
+        // Arm through the receiver-side (frontend) handle; read via the sender.
+        crx.accepted_id_failpoint.arm_invalid_id();
+        let fp = ctx.accepted_id_failpoint.clone();
+        // The seam yields an out-of-range ID, which fails validation downstream.
+        let err = accept_stream_id(&mut ctx, || fp.maybe_override(4)).expect_err("invalid seam");
+        assert_eq!(
+            err.try_as_status_code().ok(),
+            Some(StatusCode::QUIC_STATUS_INTERNAL_ERROR)
+        );
+        assert!(matches!(
+            fail_fast_terminal(&crx.terminal),
+            Some(ConnectionErrorIncoming::InternalError(_))
+        ));
+    }
+
+    #[test]
+    fn classify_start_outcome_valid_id() {
+        let slot = new_conn_terminal_slot();
+        let id = classify_start_outcome(Ok(12), &slot).expect("valid local id");
+        assert_eq!(id.into_inner(), 12);
+    }
+
+    #[test]
+    fn classify_start_outcome_invalid_local_id_is_internal() {
+        let slot = new_conn_terminal_slot();
+        match classify_start_outcome(Ok(u64::MAX), &slot) {
+            Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(msg),
+            }) => assert!(msg.contains("local stream ID is invalid"), "msg: {msg}"),
+            other => panic!("expected nested InternalError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_start_outcome_failed_start_without_terminal_is_unknown() {
+        let slot = new_conn_terminal_slot();
+        let status = Status::new(StatusCode::QUIC_STATUS_ABORTED);
+        match classify_start_outcome(Err(status), &slot) {
+            Err(StreamErrorIncoming::Unknown(_)) => {}
+            other => panic!("expected Unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_start_outcome_failed_start_with_terminal_is_connection_error() {
+        let slot = new_conn_terminal_slot();
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(5));
+        let status = Status::new(StatusCode::QUIC_STATUS_ABORTED);
+        match classify_start_outcome(Err(status), &slot) {
+            Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code: 5 },
+            }) => {}
+            other => panic!("expected connection ApplicationClose(5), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_open_conn_error_without_reason_is_internal() {
+        let slot = new_conn_terminal_slot();
+        match stream_open_conn_error(&slot) {
+            ConnectionErrorIncoming::InternalError(msg) => {
+                assert!(
+                    msg.contains("cancelled without a terminal reason"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected InternalError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_open_conn_error_with_reason_converts_terminal() {
+        let slot = new_conn_terminal_slot();
+        record_conn_terminal(&slot, ConnectionTerminal::Timeout);
+        assert!(matches!(
+            stream_open_conn_error(&slot),
+            ConnectionErrorIncoming::Timeout
+        ));
+    }
+
+    #[test]
+    fn start_cancellation_is_detected_without_panic() {
+        // Simulate ShutdownComplete dropping the start sender (StreamSendCtx)
+        // before StartComplete: the OpeningStream's start receiver resolves as
+        // Canceled, which poll_open_inner maps to a connection error (never a
+        // panic). Here we assert the Canceled detection + the mapping helper.
+        let (ctx, mut recv) = stream_ctx_channel_pre_id();
+        drop(ctx); // drops the start sender -> cancellation
+        match recv.start.try_recv() {
+            Err(oneshot::Canceled) => {}
+            other => panic!("expected Canceled after sender drop, got {other:?}"),
+        }
+        // Cancelled with no published reason -> internal error.
+        let slot = new_conn_terminal_slot();
+        assert!(matches!(
+            stream_open_conn_error(&slot),
+            ConnectionErrorIncoming::InternalError(_)
+        ));
+        // Cancelled by a connection close -> connection error.
+        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(3));
+        assert!(matches!(
+            stream_open_conn_error(&slot),
+            ConnectionErrorIncoming::ApplicationClose { error_code: 3 }
+        ));
+    }
+
+    /// The accepted-ID failpoint must be arm-able from a *live* `Connection`
+    /// (what a Phase 8 loopback test holds) before any peer stream is accepted.
+    /// A real, unstarted connection is opened (no network) and armed through the
+    /// frontend `Connection`; the shared atomic the callback's accept path reads
+    /// then trips exactly once — proving the seam is reachable end-to-end.
+    #[test]
+    fn live_connection_arms_accepted_id_failpoint() {
+        use crate::msquic::{ConnectionEvent, ConnectionRef, RegistrationConfig};
+        use crate::registration::RundownGuard;
+
+        let reg = crate::Registration::new(&RegistrationConfig::default()).unwrap();
+        // Open a real (unstarted) native connection, then attach the frontend —
+        // exactly the ownership the listener's accept path produces.
+        let inner =
+            crate::msquic::Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| {
+                Ok(())
+            })
+            .unwrap();
+        let guard = RundownGuard::new(reg.state().clone());
+        let conn = crate::Connection::attach(inner, guard);
+
+        // Arm query-fail through the live `Connection`; the shared atomic the
+        // accept path consults trips once then consumes itself.
+        conn.arm_accepted_id_query_fail();
+        assert!(
+            conn.accepted_id_failpoint().maybe_override(4).is_err(),
+            "armed query-fail must trip on the next accepted stream"
+        );
+        assert_eq!(
+            conn.accepted_id_failpoint().maybe_override(4).unwrap(),
+            4,
+            "failpoint consumes itself after one trip"
+        );
+
+        // Arm invalid-id through the live `Connection`; the seam yields an
+        // out-of-range ID that fails downstream validation.
+        conn.arm_accepted_id_invalid();
+        assert_eq!(
+            conn.accepted_id_failpoint().maybe_override(4).unwrap(),
+            u64::MAX,
+            "armed invalid-id must yield an out-of-range ID"
+        );
+
+        // Close the connection (single native ConnectionClose) before the
+        // registration is dropped.
+        drop(conn);
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -2724,15 +2724,13 @@ mod receive_events {
 /// covered end-to-end by the loopback `basic_server_test`.
 #[cfg(test)]
 mod stream_open_identity {
-    use futures::channel::oneshot;
     use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
 
     use crate::error::ConnectionTerminal;
     use crate::msquic::{Status, StatusCode};
     use crate::{
         accept_stream_id, classify_start_outcome, conn_ctx_channel, fail_fast_terminal,
-        new_conn_terminal_slot, record_conn_terminal, stream_ctx_channel_pre_id,
-        stream_open_conn_error, validate_stream_id,
+        new_conn_terminal_slot, record_conn_terminal, stream_open_conn_error, validate_stream_id,
     };
 
     /// The largest valid QUIC stream ID (62-bit VarInt max).
@@ -2916,31 +2914,12 @@ mod stream_open_identity {
         ));
     }
 
-    #[test]
-    fn start_cancellation_is_detected_without_panic() {
-        // Simulate ShutdownComplete dropping the start sender (StreamSendCtx)
-        // before StartComplete: the OpeningStream's start receiver resolves as
-        // Canceled, which poll_open_inner maps to a connection error (never a
-        // panic). Here we assert the Canceled detection + the mapping helper.
-        let (ctx, mut recv) = stream_ctx_channel_pre_id();
-        drop(ctx); // drops the start sender -> cancellation
-        match recv.start.try_recv() {
-            Err(oneshot::Canceled) => {}
-            other => panic!("expected Canceled after sender drop, got {other:?}"),
-        }
-        // Cancelled with no published reason -> internal error.
-        let slot = new_conn_terminal_slot();
-        assert!(matches!(
-            stream_open_conn_error(&slot),
-            ConnectionErrorIncoming::InternalError(_)
-        ));
-        // Cancelled by a connection close -> connection error.
-        record_conn_terminal(&slot, ConnectionTerminal::PeerApplication(3));
-        assert!(matches!(
-            stream_open_conn_error(&slot),
-            ConnectionErrorIncoming::ApplicationClose { error_code: 3 }
-        ));
-    }
+    // The REAL poll_open_inner cancellation branch (a dropped start sender mapping
+    // to a connection error / nested internal error) is driven end-to-end through
+    // the public poll_open_bidi / poll_open_send in
+    // `downcall_clamp::poll_open_inner_start_cancellation_maps_through_real_function`.
+    // The two helper unit tests above (`stream_open_conn_error_*`) independently
+    // pin both arms of the mapping the branch relies on.
 
     /// The accepted-ID failpoint must be arm-able from a *live* `Connection`
     /// (what a Phase 8 loopback test holds) before any peer stream is accepted.
@@ -3415,6 +3394,97 @@ mod send_seam {
     }
 
     #[test]
+    fn peer_stop_sending_observed_with_send_outstanding() {
+        // Item 1 (Phase 8): the DETERMINISTIC proof of "peer STOP_SENDING with a
+        // send genuinely outstanding". Over pure loopback msquic copies a buffered
+        // send and completes it synchronously, so a send cannot be *held*
+        // observably outstanding across the public API (see the conformance
+        // module's idle-only note); that condition is proven here at the seam
+        // instead. The `CountingExec` retains the "native"-owned `Box<SendBuffer>`
+        // exactly as `StreamExecutor` does, so the send is provably still
+        // outstanding (not yet reclaimed, `send_inprogress` set) at the moment
+        // STOP_SENDING is observed — then surfaced at `poll_ready` as the sticky
+        // `StreamTerminated{code}`, and the outstanding box reclaimed exactly once
+        // through the production `stream_callback`.
+        const STOP_CODE: u64 = 0x6364;
+        let h = CountingHandle::default();
+        let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new())); // all-Ok
+        let (sctx, mut ctx) = test_send_ctx();
+        let mut s = H3SendStream::with_exec(exec, sctx);
+        let mut cx = noop_cx();
+
+        // 1. Issue a data send: the seam accepts ownership and RETAINS the box, so
+        //    the send is now genuinely outstanding (nothing reclaimed yet).
+        SendStream::<Bytes>::send_data(&mut s, Frame::Data(Bytes::from_static(b"more-data")))
+            .unwrap();
+        assert_eq!(h.sends.load(Relaxed), 1);
+        assert_eq!(
+            h.client_ctx.lock().unwrap().len(),
+            1,
+            "the send is outstanding: native holds the retained buffer"
+        );
+        assert_eq!(h.reclaims.load(Relaxed), 0, "nothing reclaimed yet");
+        assert!(
+            s.sctx.reducer.send_inprogress,
+            "the reducer marks the send in progress"
+        );
+
+        // 2. Peer STOP_SENDING arrives WHILE that send is still outstanding: the
+        //    retained box is provably NOT yet reclaimed, so this is the true
+        //    in-flight condition the loopback test could not establish.
+        stream_callback(
+            &mut ctx,
+            StreamEvent::PeerReceiveAborted {
+                error_code: STOP_CODE,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            h.client_ctx.lock().unwrap().len(),
+            1,
+            "STOP_SENDING observed with the send still outstanding (not completed)"
+        );
+        assert!(
+            s.sctx.reducer.send_inprogress,
+            "the send is still in progress when the stop is published"
+        );
+
+        // 3. The following poll_ready surfaces the sticky terminal even though the
+        //    outstanding send has not completed, preserving the exact stop code.
+        match SendStream::<Bytes>::poll_ready(&mut s, &mut cx) {
+            std::task::Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(
+                    error_code, STOP_CODE,
+                    "exact peer stop code preserved (in flight)"
+                );
+            }
+            other => panic!("expected StreamTerminated{{{STOP_CODE:#x}}}, got {other:?}"),
+        }
+
+        // 4. The native (cancelled) SendComplete for that outstanding send still
+        //    arrives; the production callback reclaims the retained box exactly
+        //    once, mirroring real teardown and leaving nothing outstanding.
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: true,
+                client_context: cc as *const c_void,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            h.reclaims.load(Relaxed),
+            0,
+            "reclaim happens in the callback, not the immediate-failure arm"
+        );
+        assert!(
+            h.client_ctx.lock().unwrap().is_empty(),
+            "no send left outstanding after the cancelled completion"
+        );
+    }
+
+    #[test]
     fn reset_loses_to_published_peer_terminal_no_native_op() {
         // Local reset racing peer STOP_SENDING, terminal-first order: the
         // callback-published terminal wins, no native reset is issued.
@@ -3718,6 +3788,264 @@ mod send_seam {
             other => panic!("expected authoritative Unknown(ABORTED) at closure, got {other:?}"),
         }
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Phase 8: the FULL deterministic `CountingExec` send-seam matrix.
+    //
+    // Classification: SEAM tests (NOT loopback). These own the comprehensive
+    // outstanding-send retain/reclaim and immediate-failure reclaim matrix the
+    // design lists (Phase 6 proved the minimal seam; Phase 8 owns the matrix).
+    // Every reclamation is driven through the PRODUCTION `stream_callback` — the
+    // exact `NonNull` check → reconstruct+drop `Box<SendBuffer>` → one
+    // `SendEvent::Complete` path — so the exactly-once ownership contract is
+    // exercised, not mocked. Buffers carry a drop counter (`new_counted`) so the
+    // reclamation COUNT is asserted concretely (this is the count that a real
+    // loopback send cannot expose; see `docs/error-propagation.md`,
+    // "Native-test mechanisms").
+    //
+    // These are self-checking and deterministic: if the outstanding allocation
+    // cannot be read as expected the test FAILS with a setup-specific message —
+    // it is never skipped or `#[ignore]`d (Rust has no "inconclusive" outcome).
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// SEAM. The canonical `accepted_send_reclaims_via_callback_exactly_once`:
+    /// proves, in order, (1) the deterministic blocking condition was established
+    /// (buffer retained without a `SendComplete`); (2) exactly one adapter
+    /// allocation is outstanding after submit returns; (3) feeding the completion
+    /// through `stream_callback` causes exactly one callback reclamation and one
+    /// `Complete`; (4) the count is back to zero (exactly once).
+    #[test]
+    fn accepted_send_reclaims_via_callback_exactly_once() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let buf = SendBuffer::new_counted(Bytes::from_static(b"outstanding"), counter.clone());
+        let h = CountingHandle::default();
+        let mut exec = CountingExec::new(h.clone(), VecDeque::new()); // all-Ok script
+
+        exec.submit_send(buf).unwrap();
+
+        // (1)+(2): blocking condition established — one alloc, one outstanding
+        // pointer retained by "native", zero in-exec reclaims, buffer NOT dropped.
+        assert_eq!(h.allocs.load(Relaxed), 1, "setup: exactly one allocation");
+        assert_eq!(
+            h.client_ctx.lock().unwrap().len(),
+            1,
+            "setup: exactly one outstanding pointer retained (no SendComplete yet)"
+        );
+        assert_eq!(h.reclaims.load(Relaxed), 0, "setup: no in-exec reclaim");
+        assert_eq!(
+            counter.load(Relaxed),
+            0,
+            "setup: outstanding buffer must not be dropped yet"
+        );
+
+        // (3): feed the retained client_context through the PRODUCTION callback.
+        let (mut sctx, mut ctx) = test_send_ctx();
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: false,
+                client_context: cc as *const c_void,
+            },
+        )
+        .unwrap();
+
+        // (4): reclaimed exactly once; exactly one Complete; a second read empty.
+        assert_eq!(
+            counter.load(Relaxed),
+            1,
+            "callback must reconstruct+drop the Box<SendBuffer> exactly once"
+        );
+        assert_eq!(
+            sctx.send.try_recv().unwrap(),
+            crate::error::SendEvent::Complete { cancelled: false },
+            "exactly one completion, reporting cancelled == false"
+        );
+        assert!(
+            sctx.send.try_recv().is_err(),
+            "no second completion (reclaimed exactly once)"
+        );
+    }
+
+    /// SEAM. Multiple concurrently-outstanding accepted sends: N drop-counted
+    /// buffers are submitted (all Ok) and each is retained by "native"; feeding
+    /// each retained `client_context` back through `stream_callback` reclaims that
+    /// buffer exactly once and enqueues exactly one `Complete` — N reclamations,
+    /// N completions, no double-free, no leak.
+    #[test]
+    fn multiple_outstanding_sends_each_reclaimed_exactly_once() {
+        const N: usize = 5;
+        let h = CountingHandle::default();
+        let mut exec = CountingExec::new(h.clone(), VecDeque::new());
+        let counters: Vec<_> = (0..N).map(|_| Arc::new(AtomicUsize::new(0))).collect();
+
+        for c in &counters {
+            let buf = SendBuffer::new_counted(Bytes::from_static(b"payload"), c.clone());
+            exec.submit_send(buf).unwrap();
+        }
+
+        // All N outstanding: N allocations, N retained pointers, zero reclaimed.
+        assert_eq!(h.allocs.load(Relaxed), N);
+        assert_eq!(h.client_ctx.lock().unwrap().len(), N);
+        assert_eq!(h.reclaims.load(Relaxed), 0);
+        for c in &counters {
+            assert_eq!(
+                c.load(Relaxed),
+                0,
+                "no buffer reclaimed before its callback"
+            );
+        }
+
+        // Feed each retained pointer through the production callback path.
+        let (mut sctx, mut ctx) = test_send_ctx();
+        let pending: Vec<usize> = h.client_ctx.lock().unwrap().drain(..).collect();
+        for cc in pending {
+            stream_callback(
+                &mut ctx,
+                StreamEvent::SendComplete {
+                    cancelled: false,
+                    client_context: cc as *const c_void,
+                },
+            )
+            .unwrap();
+        }
+
+        // Each buffer reclaimed exactly once; exactly N completions delivered.
+        for c in &counters {
+            assert_eq!(c.load(Relaxed), 1, "each buffer reclaimed exactly once");
+        }
+        let mut completes = 0;
+        while sctx.send.try_recv().is_ok() {
+            completes += 1;
+        }
+        assert_eq!(completes, N, "exactly one Complete per outstanding send");
+    }
+
+    /// SEAM. Immediate-failure reclaim asserted with a drop counter: on a scripted
+    /// `Err`, `submit_send` reclaims the box in place (mirroring `StreamExecutor`),
+    /// so `allocs == 1`, `reclaims == 1`, the counter reads exactly 1, nothing is
+    /// retained, and ZERO `SendComplete` callbacks fire (native took no ownership).
+    #[test]
+    fn immediate_failure_reclaims_in_place_counted() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let buf = SendBuffer::new_counted(Bytes::from_static(b"doomed"), counter.clone());
+        let h = CountingHandle::default();
+        let mut script = VecDeque::new();
+        script.push_back(Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER)));
+        let mut exec = CountingExec::new(h.clone(), script);
+
+        exec.submit_send(buf)
+            .expect_err("scripted immediate failure");
+
+        assert_eq!(h.allocs.load(Relaxed), 1, "one allocation before failing");
+        assert_eq!(
+            h.reclaims.load(Relaxed),
+            1,
+            "reclaimed in place, exactly once"
+        );
+        assert_eq!(counter.load(Relaxed), 1, "the box was dropped exactly once");
+        assert!(
+            h.client_ctx.lock().unwrap().is_empty(),
+            "nothing retained on immediate failure"
+        );
+    }
+
+    /// SEAM. Mixed Ok/Err script: only accepted (Ok) sends are retained
+    /// outstanding; the rejected (Err) send is reclaimed in place. Then draining
+    /// the retained pointers through the callback reclaims each accepted buffer
+    /// exactly once — proving the retain-vs-reclaim bookkeeping does not conflate
+    /// the two ownership handoffs.
+    #[test]
+    fn mixed_ok_err_script_retains_only_accepted_sends() {
+        let h = CountingHandle::default();
+        let mut script = VecDeque::new();
+        script.push_back(Ok(()));
+        script.push_back(Err(Status::from(StatusCode::QUIC_STATUS_INVALID_PARAMETER)));
+        script.push_back(Ok(()));
+        let mut exec = CountingExec::new(h.clone(), script);
+
+        let c_ok1 = Arc::new(AtomicUsize::new(0));
+        let c_err = Arc::new(AtomicUsize::new(0));
+        let c_ok2 = Arc::new(AtomicUsize::new(0));
+        exec.submit_send(SendBuffer::new_counted(
+            Bytes::from_static(b"a"),
+            c_ok1.clone(),
+        ))
+        .unwrap();
+        exec.submit_send(SendBuffer::new_counted(
+            Bytes::from_static(b"b"),
+            c_err.clone(),
+        ))
+        .expect_err("scripted Err");
+        exec.submit_send(SendBuffer::new_counted(
+            Bytes::from_static(b"c"),
+            c_ok2.clone(),
+        ))
+        .unwrap();
+
+        // Three allocations; the Err was reclaimed in place; two retained.
+        assert_eq!(h.allocs.load(Relaxed), 3);
+        assert_eq!(h.reclaims.load(Relaxed), 1);
+        assert_eq!(h.client_ctx.lock().unwrap().len(), 2);
+        assert_eq!(c_err.load(Relaxed), 1, "rejected buffer reclaimed in place");
+        assert_eq!(c_ok1.load(Relaxed), 0, "accepted buffer still outstanding");
+        assert_eq!(c_ok2.load(Relaxed), 0, "accepted buffer still outstanding");
+
+        // Drain the two retained pointers through the production callback.
+        let (_sctx, mut ctx) = test_send_ctx();
+        let pending: Vec<usize> = h.client_ctx.lock().unwrap().drain(..).collect();
+        for cc in pending {
+            stream_callback(
+                &mut ctx,
+                StreamEvent::SendComplete {
+                    cancelled: false,
+                    client_context: cc as *const c_void,
+                },
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            c_ok1.load(Relaxed),
+            1,
+            "first accepted reclaimed exactly once"
+        );
+        assert_eq!(
+            c_ok2.load(Relaxed),
+            1,
+            "second accepted reclaimed exactly once"
+        );
+    }
+
+    /// SEAM. A cancelled `SendComplete` (native cancel flag set) still reclaims
+    /// the outstanding buffer exactly once through the production callback, and
+    /// enqueues a `Complete { cancelled: true }` — the reclamation is independent
+    /// of the cancel flag (ownership is returned either way).
+    #[test]
+    fn cancelled_send_complete_reclaims_buffer_exactly_once() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let buf = SendBuffer::new_counted(Bytes::from_static(b"cancelled"), counter.clone());
+        let h = CountingHandle::default();
+        let mut exec = CountingExec::new(h.clone(), VecDeque::new());
+        exec.submit_send(buf).unwrap();
+        assert_eq!(counter.load(Relaxed), 0);
+
+        let (_sctx, mut ctx) = test_send_ctx();
+        let cc = h.client_ctx.lock().unwrap().pop_front().unwrap();
+        stream_callback(
+            &mut ctx,
+            StreamEvent::SendComplete {
+                cancelled: true,
+                client_context: cc as *const c_void,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            counter.load(Relaxed),
+            1,
+            "a cancelled completion still reclaims the box exactly once"
+        );
+    }
 }
 
 /// Phase 7 downcall clamp tests: the recv-side `stop_sending` and the
@@ -3732,14 +4060,18 @@ mod downcall_clamp {
 
     use bytes::Bytes;
     use h3::error::Code;
-    use h3::quic::{OpenStreams, RecvStream};
+    use h3::quic::{ConnectionErrorIncoming, OpenStreams, RecvStream, StreamErrorIncoming};
 
-    use crate::error::clamp_application_code;
-    use crate::msquic::{Connection, ConnectionEvent, ConnectionRef, RegistrationConfig, Status};
+    use crate::error::{ConnectionTerminal, clamp_application_code};
+    use crate::msquic::{
+        Connection, ConnectionEvent, ConnectionRef, RegistrationConfig, Status, Stream,
+        StreamEvent, StreamOpenFlags, StreamRef,
+    };
     use crate::registration::RundownGuard;
     use crate::{
-        ConnHandle, H3RecvStream, OpenExec, OpeningStream, RecvExec, Registration, StreamOpener,
-        new_conn_terminal_slot, stream_ctx_channel,
+        ConnHandle, H3RecvStream, OpenExec, OpeningStream, PreIdReceivers, PreIdTail, RecvExec,
+        Registration, StreamOpener, new_conn_terminal_slot, record_conn_terminal,
+        stream_ctx_channel, stream_ctx_channel_pre_id,
     };
 
     /// Recording recv-side seam: captures every clamped `stop_sending` code.
@@ -3827,5 +4159,672 @@ mod downcall_clamp {
             // native ConnectionClose runs while the registration is still alive.
             drop(opener);
         }
+    }
+
+    /// A leaked no-op waker gives a `'static` context reusable across polls.
+    fn noop_cx() -> std::task::Context<'static> {
+        let waker = Box::leak(Box::new(futures::task::noop_waker()));
+        std::task::Context::from_waker(waker)
+    }
+
+    /// Open-side seam that models the `ShutdownComplete`-drops-the-start-sender
+    /// race (MF / SF): `submit_open_start` opens a real (unstarted) native stream
+    /// but immediately DROPS the pre-ID start sender, so the [`OpeningStream`]'s
+    /// `start` receiver resolves as `oneshot::Canceled` — exactly the condition
+    /// `poll_open_inner`'s cancellation branch handles. When `record` is set, it
+    /// also publishes that connection terminal into the shared slot *during*
+    /// `submit_open_start` — i.e. AFTER `poll_open_inner`'s step-1 fail-fast has
+    /// already seen an empty slot and BEFORE it polls the pending start — modelling
+    /// a connection close that raced the open, so the cancellation resolves through
+    /// [`crate::stream_open_conn_error`] to a connection error rather than the
+    /// fail-fast path.
+    #[derive(Debug)]
+    struct CancellingOpenExec {
+        record: Option<ConnectionTerminal>,
+    }
+
+    impl OpenExec for CancellingOpenExec {
+        fn submit_open_start(&self, conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
+            // Publish the racing terminal (if any) now: after step-1 fail-fast, so
+            // it is only observed at the cancellation branch's terminal read.
+            if let Some(reason) = self.record.clone() {
+                record_conn_terminal(conn.terminal(), reason);
+            }
+            let (ctx, recv) = stream_ctx_channel_pre_id();
+            let flag = if uni {
+                StreamOpenFlags::UNIDIRECTIONAL
+            } else {
+                StreamOpenFlags::NONE
+            };
+            // Trivial handler (never fires on an unstarted stream); it does NOT
+            // capture `ctx`, so dropping `ctx` drops the start sender.
+            let s = Stream::open(conn, flag, |_: StreamRef, _: StreamEvent| Ok(()))?;
+            drop(ctx); // drop the start sender -> pending start resolves Canceled
+            let PreIdReceivers {
+                start,
+                send,
+                send_terminal,
+                receive,
+            } = recv;
+            Ok(OpeningStream {
+                stream: Arc::new(s),
+                start,
+                tail: PreIdTail {
+                    send,
+                    send_terminal,
+                    receive,
+                },
+            })
+        }
+        fn submit_conn_shutdown(&self, _conn: &ConnHandle, _code: u64) {
+            unimplemented!("cancellation drive never closes the connection")
+        }
+    }
+
+    /// Item 2 (Phase 8): drive the REAL `poll_open_inner` (via the public
+    /// `poll_open_bidi` / `poll_open_send`) through its `ShutdownComplete`
+    /// cancellation branch and assert the mapped `StreamErrorIncoming` comes OUT of
+    /// the real function — not merely a detached `Canceled` detection plus a helper
+    /// call. Both sub-outcomes of the branch are covered: cancelled-with-no-reason
+    /// (nested `InternalError`) and cancelled-by-a-connection-close (a real
+    /// connection error carrying the peer code).
+    #[test]
+    fn poll_open_inner_start_cancellation_maps_through_real_function() {
+        let reg = Registration::new(&RegistrationConfig::default()).unwrap();
+
+        // (a) Cancelled with NO published reason -> nested InternalError, straight
+        //     out of the real poll_open_bidi.
+        {
+            let inner =
+                Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
+            let guard = RundownGuard::new(reg.state().clone());
+            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let mut opener =
+                StreamOpener::with_open_exec(conn, Box::new(CancellingOpenExec { record: None }));
+            let mut cx = noop_cx();
+
+            match OpenStreams::<Bytes>::poll_open_bidi(&mut opener, &mut cx) {
+                std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                    connection_error: ConnectionErrorIncoming::InternalError(msg),
+                })) => assert!(
+                    msg.contains("cancelled without a terminal reason"),
+                    "unexpected InternalError message: {msg}"
+                ),
+                other => panic!("expected InternalError from real poll_open_bidi, got {other:?}"),
+            }
+            drop(opener);
+        }
+
+        // (b) Cancelled by a CONNECTION close -> the real cancellation branch reads
+        //     the raced terminal via stream_open_conn_error and surfaces the peer
+        //     application code, straight out of the real poll_open_send.
+        {
+            let inner =
+                Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
+            let guard = RundownGuard::new(reg.state().clone());
+            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let mut opener = StreamOpener::with_open_exec(
+                conn,
+                Box::new(CancellingOpenExec {
+                    record: Some(ConnectionTerminal::PeerApplication(3)),
+                }),
+            );
+            let mut cx = noop_cx();
+
+            match OpenStreams::<Bytes>::poll_open_send(&mut opener, &mut cx) {
+                std::task::Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                    connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+                })) => assert_eq!(error_code, 3, "peer application code preserved"),
+                other => {
+                    panic!("expected ApplicationClose{{3}} from real poll_open_send, got {other:?}")
+                }
+            }
+            drop(opener);
+        }
+    }
+}
+
+/// Phase 8 (Conformance) — end-to-end loopback tests over a real 127.0.0.1
+/// msquic connection, mirroring `listener::basic_server_test` but driving the
+/// raw `h3::quic` trait surface (open/accept bidi streams, `send_data`,
+/// `reset`, `stop_sending`, connection `close`) directly so each error-
+/// propagation path can be triggered deterministically without the full h3
+/// protocol layer.
+///
+/// Determinism strategy (no arbitrary sleeps racing real timers):
+/// - each test owns an isolated [`Registration`] and an **ephemeral** loopback
+///   port (`127.0.0.1:0`, queried back via `get_local_addr`), so parallel tests
+///   never collide;
+/// - peer `RESET_STREAM` / `STOP_SENDING` / application-close are produced by
+///   *calling the peer endpoint's own* `reset` / `stop_sending` / `close`, not by
+///   hoping a timer fires;
+/// - the idle-timeout case sets a short `IdleTimeoutMs` via msquic settings and
+///   then simply awaits the (bounded) shutdown — a fixed setting, not a race
+///   against another timer;
+/// - the accepted-stream-ID failpoint is armed on the **live** server
+///   `Connection` (Phase 5 seam) *before* the peer opens its stream, with an
+///   explicit client→server handshake barrier so the arming strictly precedes
+///   the peer `PeerStreamStarted`.
+///
+/// SOURCE-REVIEW-ONLY GUARANTEE (SC-007, labelled UNTESTED): the close-time
+/// inline `SendComplete` drain performed by native `QuicStreamClose` has **no**
+/// executable drop-triggered teardown test here — the public API cannot hold a
+/// real send observably outstanding across the close (buffered sends complete
+/// synchronously; see `docs/error-propagation.md`, "Native-test mechanisms").
+/// That guarantee rests on native source review plus the binding's uniform
+/// `close_inner` contract, and is asserted only by
+/// [`conformance::close_time_inline_drain_is_source_review_only`] as a labelled,
+/// auditable NON-executable marker — never by a passing teardown test. The
+/// adapter's own exactly-once reclamation bookkeeping is proven by the
+/// `send_seam` `CountingExec` suite, which replays the real `stream_callback`
+/// reclaim path.
+#[cfg(test)]
+mod conformance {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use h3::error::Code;
+    use h3::proto::frame::Frame;
+    use h3::quic::{
+        ConnectionErrorIncoming, OpenStreams, RecvStream, SendStream, StreamErrorIncoming,
+    };
+    use msquic::{
+        BufferRef, CredentialConfig, CredentialFlags, RegistrationConfig, ServerResumptionLevel,
+        Settings,
+    };
+
+    use crate::test::util::{get_test_cred, try_setup_tracing};
+    use crate::{Connection, H3Stream, Listener, Registration};
+
+    const H3_INTERNAL_ERROR: u64 = 0x0102;
+
+    // ── poll_fn adapters over the &mut self trait methods (buffer type = Bytes) ──
+
+    async fn open_bidi(conn: &mut Connection) -> Result<H3Stream, StreamErrorIncoming> {
+        std::future::poll_fn(|cx| OpenStreams::<Bytes>::poll_open_bidi(conn, cx)).await
+    }
+
+    async fn accept_bidi(conn: &mut Connection) -> Result<H3Stream, ConnectionErrorIncoming> {
+        std::future::poll_fn(|cx| {
+            <Connection as h3::quic::Connection<Bytes>>::poll_accept_bidi(conn, cx)
+        })
+        .await
+    }
+
+    async fn send_ready<S: SendStream<Bytes>>(s: &mut S) -> Result<(), StreamErrorIncoming> {
+        std::future::poll_fn(|cx| s.poll_ready(cx)).await
+    }
+
+    async fn send_finish<S: SendStream<Bytes>>(s: &mut S) -> Result<(), StreamErrorIncoming> {
+        std::future::poll_fn(|cx| s.poll_finish(cx)).await
+    }
+
+    /// Await a peer-caused send-side termination (`STOP_SENDING`).
+    ///
+    /// An idle `poll_ready` returns `Ok` immediately (no send in flight, no
+    /// terminal yet), so a single poll can observe `Ok` before the peer's
+    /// `STOP_SENDING` frame has been delivered and turned into the sticky send
+    /// terminal. This re-polls on a short fixed interval until the terminal is
+    /// observed. It is NOT a race against a timer: the peer stop is guaranteed to
+    /// arrive over loopback, so the loop always exits via the terminal; the outer
+    /// bound only guards against a hang if the propagation invariant regressed.
+    async fn await_peer_send_terminated<S: SendStream<Bytes>>(s: &mut S) -> u64 {
+        let poll_terminal = async {
+            loop {
+                match send_ready(s).await {
+                    Err(StreamErrorIncoming::StreamTerminated { error_code }) => {
+                        return error_code;
+                    }
+                    Err(other) => panic!("expected StreamTerminated, got {other:?}"),
+                    // Terminal not yet delivered; yield and re-poll.
+                    Ok(()) => tokio::time::sleep(std::time::Duration::from_millis(1)).await,
+                }
+            }
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(5), poll_terminal)
+            .await
+            .expect("peer STOP_SENDING must be observed on the send side")
+    }
+
+    async fn recv_next<R: RecvStream>(
+        r: &mut R,
+    ) -> Result<Option<<R as RecvStream>::Buf>, StreamErrorIncoming> {
+        std::future::poll_fn(|cx| r.poll_data(cx)).await
+    }
+
+    /// A live loopback pair plus the machinery that must outlive them.
+    fn run_loopback<F, Fut>(idle_ms: u64, body: F)
+    where
+        F: FnOnce(Connection, Connection) -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        try_setup_tracing();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            let reg = Registration::new(&RegistrationConfig::default()).unwrap();
+            let alpn = [BufferRef::from("h3")];
+
+            // Server: self-signed cert, generous peer stream credit, configurable
+            // idle timeout.
+            let cred = get_test_cred();
+            let server_settings = Settings::new()
+                .set_ServerResumptionLevel(ServerResumptionLevel::ResumeAndZerortt)
+                .set_PeerBidiStreamCount(100)
+                .set_PeerUnidiStreamCount(100)
+                .set_IdleTimeoutMs(idle_ms);
+            let server_config = reg
+                .open_configuration(&alpn, Some(&server_settings))
+                .unwrap();
+            let cred_config = CredentialConfig::new()
+                .set_credential_flags(CredentialFlags::NO_CERTIFICATE_VALIDATION)
+                .set_credential(cred);
+            server_config.load_credential(&cred_config).unwrap();
+            let server_config = Arc::new(server_config);
+
+            let mut listener = Listener::new(
+                &reg,
+                server_config.clone(),
+                &alpn,
+                Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)),
+            )
+            .unwrap();
+            // Ephemeral port assigned by ListenerStart; read it back so the client
+            // dials the exact bound port (no fixed-port collisions across tests).
+            let port = listener.get_ref().get_local_addr().unwrap().port();
+
+            let client_settings = Settings::new()
+                .set_PeerBidiStreamCount(100)
+                .set_PeerUnidiStreamCount(100)
+                .set_IdleTimeoutMs(idle_ms);
+            let client_config = reg
+                .open_configuration(&alpn, Some(&client_settings))
+                .unwrap();
+            let client_cred = CredentialConfig::new_client()
+                .set_credential_flags(CredentialFlags::NO_CERTIFICATE_VALIDATION);
+            client_config.load_credential(&client_cred).unwrap();
+
+            // Drive server accept and client connect concurrently on the same
+            // single-threaded runtime; msquic worker threads fire the callbacks.
+            let (accepted, connected) = tokio::join!(
+                listener.accept(),
+                Connection::connect(&reg, &client_config, "127.0.0.1", port),
+            );
+            let server = accepted.expect("server accept ok").expect("a connection");
+            let client = connected.expect("client connect ok");
+
+            // Run the scenario; `body` owns and drops both connections.
+            body(server, client).await;
+
+            // Deterministic teardown order: connections were dropped by `body`;
+            // drop the listener, then drain the rundown, then the configurations.
+            drop(listener);
+            reg.shutdown();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(10), reg.wait_idle()).await;
+            drop(server_config);
+            drop(client_config);
+        });
+    }
+
+    /// Send one h3 `DATA` frame carrying `payload` on a send half.
+    fn send_data_frame<S: SendStream<Bytes>>(
+        s: &mut S,
+        payload: &'static [u8],
+    ) -> Result<(), StreamErrorIncoming> {
+        s.send_data(Frame::Data(Bytes::from_static(payload)))
+    }
+
+    /// Client opens a bidi stream and sends `first` so the server's
+    /// `PeerStreamStarted` fires; returns `(client_stream, server_stream)`, both
+    /// fully identified. The client flush (`poll_ready` to completion) guarantees
+    /// the opening `STREAM` frame has reached the peer before the server accepts,
+    /// so the handoff is ordered, not raced.
+    async fn establish_bidi(
+        client: &mut Connection,
+        server: &mut Connection,
+        first: &'static [u8],
+    ) -> (H3Stream, H3Stream) {
+        let mut cs = open_bidi(client).await.expect("client open bidi");
+        send_data_frame(&mut cs, first).expect("client send first frame");
+        send_ready(&mut cs).await.expect("client flush first frame");
+        let ss = accept_bidi(server).await.expect("server accept bidi");
+        (cs, ss)
+    }
+
+    /// (a) Peer `RESET_STREAM` → `StreamTerminated { code }` on the receiving
+    /// side, carrying the exact HTTP/3 code. The server resets its send half of a
+    /// client-opened bidi stream; the client observes the reset at `poll_data`.
+    #[test]
+    fn peer_reset_stream_maps_to_stream_terminated() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const RESET_CODE: u64 = 0x4142;
+            let (mut cs, mut ss) = establish_bidi(&mut client, &mut server, b"ping").await;
+
+            // Server RESET_STREAMs its send direction with a specific code.
+            SendStream::<Bytes>::reset(&mut ss, RESET_CODE);
+
+            // Client's receive half observes the peer reset (after draining any
+            // bytes the server may have sent first — none are expected here).
+            loop {
+                match recv_next(&mut cs).await {
+                    Ok(Some(_)) => continue,
+                    Ok(None) => panic!("expected RESET_STREAM, got a clean FIN"),
+                    Err(StreamErrorIncoming::StreamTerminated { error_code }) => {
+                        assert_eq!(error_code, RESET_CODE, "exact peer reset code preserved");
+                        break;
+                    }
+                    Err(other) => panic!("expected StreamTerminated, got {other:?}"),
+                }
+            }
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (b, idle) Peer `STOP_SENDING` observed from the *send* side with no send
+    /// outstanding: the server stop_sends the receive half of a client-opened
+    /// bidi stream; the client's idle `poll_ready` surfaces
+    /// `StreamTerminated { code }`.
+    #[test]
+    fn peer_stop_sending_observed_from_send_side_idle() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const STOP_CODE: u64 = 0x5253;
+            let (mut cs, mut ss) = establish_bidi(&mut client, &mut server, b"hi").await;
+
+            // Server STOP_SENDINGs its receive half (= client's send half).
+            RecvStream::stop_sending(&mut ss, STOP_CODE);
+
+            // Client's send half — idle, no data buffered — observes the stop.
+            let code = await_peer_send_terminated(&mut cs).await;
+            assert_eq!(code, STOP_CODE, "exact peer stop code preserved (idle)");
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    // (b, in flight) DEFERRED-TO-SEAM. A peer `STOP_SENDING` observed with a send
+    // *genuinely outstanding* is intentionally NOT covered by a loopback test:
+    // over pure 127.0.0.1 msquic copies a buffered `send_data` and completes it
+    // synchronously (often before `send_data` even returns), so a send cannot be
+    // *held* observably outstanding through the public API — a loopback test could
+    // claim "in flight" but never prove it (documented in "Native-test
+    // mechanisms", `docs/error-propagation.md`). The true outstanding-send
+    // condition is instead proven deterministically at the send seam by
+    // [`send_seam::peer_stop_sending_observed_with_send_outstanding`], where the
+    // `CountingExec` retains the native-owned buffer so the send is provably still
+    // outstanding at the exact moment STOP_SENDING is observed and surfaced at
+    // `poll_ready` as `StreamTerminated { code }`. The idle observation over real
+    // loopback remains covered by
+    // [`peer_stop_sending_observed_from_send_side_idle`] above.
+
+    /// (d) Idle timeout → `ConnectionErrorIncoming::Timeout`. A short, fixed
+    /// `IdleTimeoutMs` makes the transport idle-close deterministic (a setting,
+    /// not a race against another timer); the client's `poll_accept_bidi` awaits
+    /// the resulting terminal with no manual sleep.
+    #[test]
+    fn idle_timeout_maps_to_timeout() {
+        run_loopback(300, |server, mut client| async move {
+            // No traffic after connect: the negotiated 300 ms idle timeout fires
+            // and both endpoints transport-close as idle.
+            let err = accept_bidi(&mut client)
+                .await
+                .expect_err("client must observe the idle timeout");
+            assert!(
+                matches!(err, ConnectionErrorIncoming::Timeout),
+                "expected Timeout, got {err:?}"
+            );
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (e, local reset) Local cancellation via `reset(code)` → the client's own
+    /// send half reports the local-reset outcome (`Unknown(LocalStreamReset)`),
+    /// issues at most one native `ABORT_SEND`, and never panics.
+    #[test]
+    fn local_reset_yields_local_stream_reset_outcome() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const LOCAL_CODE: u64 = 0x0707;
+            let (mut cs, ss) = establish_bidi(&mut client, &mut server, b"payload").await;
+
+            // Client locally resets its own send half (infallible).
+            SendStream::<Bytes>::reset(&mut cs, LOCAL_CODE);
+
+            // The local outcome is surfaced at poll_finish as a local reset, not a
+            // peer termination or connection error.
+            match send_finish(&mut cs).await {
+                Err(StreamErrorIncoming::Unknown(e)) => {
+                    assert!(
+                        e.downcast_ref::<crate::LocalStreamReset>().is_some(),
+                        "expected LocalStreamReset, got {e:?}"
+                    );
+                }
+                other => panic!("expected Unknown(LocalStreamReset), got {other:?}"),
+            }
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (e, local stop_sending) Local cancellation via `stop_sending(code)` → the
+    /// client's own receive half ends cleanly (`Ok(None)`, SF-6 local EOF)
+    /// without panicking, regardless of the peer.
+    #[test]
+    fn local_stop_sending_yields_clean_local_eof() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const LOCAL_CODE: u64 = 0x0809;
+            let (mut cs, ss) = establish_bidi(&mut client, &mut server, b"payload").await;
+
+            // Client locally stop_sends its own receive half (infallible).
+            RecvStream::stop_sending(&mut cs, LOCAL_CODE);
+
+            // SF-6: our own stop_sending is a clean local end-of-stream.
+            match recv_next(&mut cs).await {
+                Ok(None) => {}
+                other => panic!("expected clean Ok(None) local EOF, got {other:?}"),
+            }
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (f) Attachment failure — a stream open attempted after the connection has
+    /// closed → a connection error, no panic. The peer application-closes the
+    /// connection; once the client has observed that terminal, a fresh
+    /// `poll_open_bidi` fails fast with a `ConnectionErrorIncoming` rather than
+    /// panicking.
+    ///
+    /// The tighter *in-flight* variant — a pending `OpeningStream` whose
+    /// `StartComplete` receiver is cancelled by `ShutdownComplete` — cannot be
+    /// suspended at exactly that instant through the public loopback surface, so
+    /// it is proven deterministically by the hermetic seam test
+    /// `downcall_clamp::poll_open_inner_start_cancellation_maps_through_real_function`.
+    #[test]
+    fn open_after_connection_close_is_connection_error_no_panic() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const APP_CODE: u64 = 0x0abc;
+            OpenStreams::<Bytes>::close(&mut server, Code::from(APP_CODE), b"bye");
+
+            // Confirm the client has observed the connection terminal first.
+            let conn_err = accept_bidi(&mut client)
+                .await
+                .expect_err("client observes the peer close");
+            assert!(
+                matches!(conn_err, ConnectionErrorIncoming::ApplicationClose { error_code } if error_code == APP_CODE),
+                "expected ApplicationClose({APP_CODE:#x}), got {conn_err:?}"
+            );
+
+            // Now an open must fail fast with a connection error — never a panic.
+            match open_bidi(&mut client).await {
+                Err(StreamErrorIncoming::ConnectionErrorIncoming { .. }) => {}
+                other => panic!("expected ConnectionErrorIncoming, got {other:?}"),
+            }
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (g) Accepted-send reclamation *ordering* over a real loopback connection:
+    /// a server-accepted send drives to completion (proving the native
+    /// `SendComplete` was delivered and consumed), the client receives the data
+    /// end to end, and dropping every frontend owner afterwards causes no
+    /// callback panic.
+    ///
+    /// NOTE ON RECLAIM-ONCE: the exactly-once `Box<SendBuffer>` reclamation
+    /// *count* is proven by the `send_seam` `CountingExec` tests
+    /// (`send_buffer_reclaimed_exactly_once_via_callback`,
+    /// `immediate_send_failure_reclaims_without_completion`, and the outstanding-
+    /// retain matrix), which replay the production `stream_callback` reclaim path
+    /// with a drop-counted buffer. The public `send_data` path builds its
+    /// `SendBuffer` internally with no injectable counter, so a real loopback send
+    /// cannot be *counted* here — only its ordering and no-panic teardown are
+    /// observable (see `docs/error-propagation.md`, "Native-test mechanisms").
+    #[test]
+    fn accepted_send_completes_and_teardown_is_panic_free() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            let (mut cs, mut ss) = establish_bidi(&mut client, &mut server, b"req").await;
+
+            // The accepted (server) side sends a response and drives it to
+            // completion: poll_ready resolves ready only after the single native
+            // SendComplete for this send is delivered and consumed.
+            const RESP: &[u8] = b"accepted-response-body";
+            send_data_frame(&mut ss, RESP).expect("server send response");
+            send_ready(&mut ss)
+                .await
+                .expect("server send completes once");
+
+            // The client receives the response bytes end to end (the h3 DATA frame
+            // header precedes the payload, which appears as the frame's suffix).
+            let mut got = Vec::new();
+            loop {
+                match recv_next(&mut cs).await {
+                    Ok(Some(chunk)) => {
+                        use bytes::Buf as _;
+                        got.extend_from_slice(chunk.chunk());
+                        if got.ends_with(RESP) {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => panic!("client recv error: {e:?}"),
+                }
+            }
+            assert!(
+                got.ends_with(RESP),
+                "client must receive the accepted-send payload; got {got:?}"
+            );
+
+            // Drop every frontend owner after the completion: no callback panic.
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// (h) Accepted-stream ID failpoint (Phase 5 connection-scoped seam), armed
+    /// on the *live* server `Connection` BEFORE the peer opens its stream. The
+    /// rejected stream is closed natively (never enqueued), the server's accept
+    /// path fails fast with `InternalError`, and — mirroring what h3 does on that
+    /// internal error — the connection is closed with `H3_INTERNAL_ERROR`, which
+    /// the peer observes as an application close carrying that code. No panic.
+    #[test]
+    fn accepted_stream_id_failpoint_rejects_and_closes_h3_internal_error() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            // Arm BEFORE the peer opens a stream. Arming is synchronous on the
+            // live Connection's shared atomic, and the client only opens its
+            // stream afterwards, so the PeerStreamStarted callback is guaranteed
+            // to see the armed failpoint.
+            server.arm_accepted_id_query_fail();
+
+            // Peer opens a bidi stream and sends, driving the server's
+            // PeerStreamStarted (which trips the failpoint and rejects natively).
+            let mut cs = open_bidi(&mut client).await.expect("client open bidi");
+            send_data_frame(&mut cs, b"trigger").expect("client send trigger");
+
+            // The server accept path fails fast with an internal error, and the
+            // rejected stream is never delivered.
+            let acc_err = accept_bidi(&mut server)
+                .await
+                .expect_err("rejected accept must be an internal error");
+            assert!(
+                matches!(acc_err, ConnectionErrorIncoming::InternalError(_)),
+                "expected InternalError, got {acc_err:?}"
+            );
+
+            // h3 responds to an InternalError from the trait by closing the
+            // connection with H3_INTERNAL_ERROR; emulate that here.
+            OpenStreams::<Bytes>::close(&mut server, Code::H3_INTERNAL_ERROR, b"internal");
+
+            // The peer observes the H3_INTERNAL_ERROR application close.
+            let peer_err = accept_bidi(&mut client)
+                .await
+                .expect_err("client observes the H3_INTERNAL_ERROR close");
+            match peer_err {
+                ConnectionErrorIncoming::ApplicationClose { error_code } => {
+                    assert_eq!(
+                        error_code, H3_INTERNAL_ERROR,
+                        "connection closed with H3_INTERNAL_ERROR"
+                    );
+                }
+                other => panic!("expected ApplicationClose(H3_INTERNAL_ERROR), got {other:?}"),
+            }
+            drop(cs);
+            drop(server);
+            drop(client);
+        });
+    }
+
+    /// SC-007 labelled marker (NON-executable): the close-time inline
+    /// `SendComplete` drain performed by native `QuicStreamClose` has **no**
+    /// drop-triggered teardown test — the public API cannot hold a real send
+    /// observably outstanding across the close, so that path is exercised by
+    /// **native source review + the uniform `close_inner` contract**, NOT by any
+    /// executable test here. This test exists solely as an auditable label; it
+    /// deliberately asserts nothing about runtime behavior (there is nothing
+    /// test-observable to assert), only that this guarantee is documented as
+    /// source-review-only. See the module doc and `docs/error-propagation.md`
+    /// ("Native stream teardown on drop" / "Native-test mechanisms").
+    #[test]
+    fn close_time_inline_drain_is_source_review_only() {
+        // Intentionally empty: the inline-drain guarantee is established by
+        // source review, not by a drop-triggered teardown assertion. The adapter
+        // exactly-once reclamation bookkeeping it relies on is covered by the
+        // `send_seam` CountingExec tests.
+    }
+
+    /// (c) Peer application close → `ApplicationClose { code }` with the exact
+    /// HTTP/3 code, observed on the other endpoint's connection accept path.
+    #[test]
+    fn peer_application_close_propagates_code() {
+        run_loopback(5_000, |mut server, mut client| async move {
+            const APP_CODE: u64 = 0x1234;
+            // Server closes the connection with a specific application code.
+            OpenStreams::<Bytes>::close(&mut server, Code::from(APP_CODE), b"bye");
+
+            // Client observes the peer application close carrying that code.
+            let err = accept_bidi(&mut client)
+                .await
+                .expect_err("client must observe the peer close");
+            match err {
+                ConnectionErrorIncoming::ApplicationClose { error_code } => {
+                    assert_eq!(error_code, APP_CODE, "exact HTTP/3 code preserved");
+                }
+                other => panic!("expected ApplicationClose({APP_CODE:#x}), got {other:?}"),
+            }
+            drop(server);
+            drop(client);
+        });
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -1,4 +1,8 @@
-use std::{ffi::c_void, pin::Pin, sync::Arc};
+use std::{
+    ffi::c_void,
+    pin::Pin,
+    sync::{Arc, Mutex, MutexGuard, PoisonError},
+};
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use futures::{
@@ -26,6 +30,17 @@ pub use registration::{Registration, WaitIdle};
 /// re-export msquic type
 pub mod msquic {
     pub use ::msquic::*;
+}
+
+/// Acquire a mutex, recovering the guard if a panic on another thread poisoned
+/// the lock.
+///
+/// FFI callbacks and rundown/waiter paths must never unwind across the msquic
+/// boundary, so a poisoned lock is recovered via [`PoisonError::into_inner`]
+/// rather than propagated as a panic. Every lock these paths touch guards only
+/// plain data with no torn invariant, so the inner value is always safe to use.
+pub(crate) fn lock_recover<T>(m: &Mutex<T>) -> MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 /// Owns the raw msquic connection handle together with its [`RundownGuard`].
@@ -110,19 +125,25 @@ fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
 fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> Result<(), Status> {
     match ev {
         ConnectionEvent::Connected { .. } => {
-            ctx.connected.take().unwrap().send(()).unwrap();
+            // A duplicate `Connected` (slot already taken) or a dropped receiver
+            // (send `Err`) is a safe no-op; never panic across the FFI boundary.
+            if let Some(tx) = ctx.connected.take() {
+                let _ = tx.send(());
+            }
         }
         ConnectionEvent::PeerStreamStarted { stream, flags } => {
             // TODO: need to set callback
             let s = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
             if flags.contains(StreamOpenFlags::UNIDIRECTIONAL) {
                 if let Some(uni) = ctx.uni.as_ref() {
-                    uni.unbounded_send(Some(crate::H3Stream::attach(s)))
-                        .expect("cannot send");
+                    // Ownership was taken by `H3Stream::attach`; if delivery
+                    // fails (frontend gone) the returned `SendError` carries the
+                    // owned `H3Stream`, which drops here and closes the native
+                    // stream exactly once.
+                    let _ = uni.unbounded_send(Some(crate::H3Stream::attach(s)));
                 }
             } else if let Some(bidi) = ctx.bidi.as_ref() {
-                bidi.unbounded_send(Some(crate::H3Stream::attach(s)))
-                    .expect("cannot send");
+                let _ = bidi.unbounded_send(Some(crate::H3Stream::attach(s)));
             }
         }
         ConnectionEvent::ShutdownComplete { .. } => {
@@ -169,7 +190,7 @@ impl Connection {
             // wait for connection.
             crx.connected
                 .take()
-                .unwrap()
+                .ok_or_else(|| Status::new(StatusCode::QUIC_STATUS_ABORTED))?
                 .await
                 .map_err(|_| Status::new(StatusCode::QUIC_STATUS_ABORTED))?;
 
@@ -200,11 +221,19 @@ impl Connection {
         }
     }
 
-    /// Can only be called once after construction.
+    /// Returns the connection shutdown waiter.
+    ///
+    /// The first call waits for shutdown completion. Later calls return a
+    /// waiter that resolves immediately.
     pub fn get_shutdown_waiter(&mut self) -> ConnectionShutdownWaiter {
-        ConnectionShutdownWaiter {
-            rx: self.ctx.shutdown.take().unwrap(),
-        }
+        // If the waiter was already taken, hand back an immediately-resolving
+        // one (its sender is dropped) rather than panicking. `wait` treats a
+        // dropped sender as a benign completion.
+        let rx = self.ctx.shutdown.take().unwrap_or_else(|| {
+            let (_tx, rx) = oneshot::channel();
+            rx
+        });
+        ConnectionShutdownWaiter { rx }
     }
 }
 
@@ -215,9 +244,9 @@ pub struct ConnectionShutdownWaiter {
 impl ConnectionShutdownWaiter {
     /// wait for connection to be fully shutdown.
     pub async fn wait(self) {
-        self.rx
-            .await
-            .expect("failed to wait for connection shutdown");
+        // A dropped sender (connection torn down without a clean
+        // `ShutdownComplete`) resolves the wait rather than panicking.
+        let _ = self.rx.await;
     }
 }
 
@@ -473,11 +502,11 @@ fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamRecei
 fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Status> {
     match ev {
         StreamEvent::StartComplete { status, .. } => {
-            let tx = ctx.start.take().unwrap();
-            if status.is_ok() {
-                tx.send(Ok(())).expect("cannot send");
-            } else {
-                tx.send(Err(status)).expect("cannot send")
+            // Duplicate `StartComplete` (slot already taken) or a dropped
+            // `OpeningStream` receiver is a safe no-op.
+            if let Some(tx) = ctx.start.take() {
+                let result = if status.is_ok() { Ok(()) } else { Err(status) };
+                let _ = tx.send(result);
             }
         }
         StreamEvent::SendComplete {
@@ -485,10 +514,10 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             client_context,
         } => {
             if let Some(send) = ctx.send.as_ref() {
-                send.unbounded_send((cancelled, BufPtr(client_context)))
-                    .expect("cannot send");
-            } else {
-                debug_assert!(false, "mem leak");
+                // NOTE: on delivery failure (frontend gone) the buffer behind
+                // `client_context` is not reclaimed here; that structural
+                // reclamation lands in Phase 6. Phase 1 only removes the panic.
+                let _ = send.unbounded_send((cancelled, BufPtr(client_context)));
             }
         }
         StreamEvent::Receive { buffers, flags, .. } => {
@@ -502,7 +531,11 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
                 }
                 let b = b.freeze();
                 if !b.is_empty() {
-                    receive.unbounded_send(b).expect("cannot send");
+                    // Failed delivery (frontend `H3RecvStream` dropped) drops the
+                    // sender so no further receive events are attempted.
+                    if receive.unbounded_send(b).is_err() {
+                        ctx.receive.take();
+                    }
                 } else {
                     // zero buff can happen. so drop the receiver.
                     ctx.receive.take();
@@ -516,7 +549,7 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
         StreamEvent::SendShutdownComplete { graceful: _ } => {
             // Peer acknowledged shutdown.
             if let Some(shutdown) = ctx.shutdown.take() {
-                shutdown.send(()).expect("cannot send");
+                let _ = shutdown.send(());
             }
         }
         StreamEvent::ShutdownComplete { .. } => {
@@ -991,5 +1024,67 @@ mod test {
             .build()
             .unwrap()
             .block_on(send_get_request(uri));
+    }
+}
+
+/// Phase 1 (callback safety) unit tests: proves the FFI callback surfaces are
+/// panic-free when a receiver has been dropped, and that the poison-recovering
+/// lock helper never panics on a poisoned mutex. Hermetic (no network).
+#[cfg(test)]
+mod callback_safety {
+    use std::sync::{Arc, Mutex};
+
+    use crate::msquic::{ConnectionEvent, StreamEvent};
+    use crate::{
+        conn_ctx_channel, connection_callback, lock_recover, stream_callback, stream_ctx_channel,
+    };
+
+    #[test]
+    fn connection_callback_connected_with_dropped_receiver_is_noop() {
+        let (mut ctx, rx) = conn_ctx_channel();
+        // Frontend gone: the `Connected` one-shot receiver is dropped.
+        drop(rx);
+        let ev = ConnectionEvent::Connected {
+            session_resumed: false,
+            negotiated_alpn: &[],
+        };
+        // The fallible send returns Err internally; the callback must not panic
+        // and must return Ok across the FFI boundary.
+        assert!(connection_callback(&mut ctx, ev).is_ok());
+        // The one-shot slot was consumed exactly once.
+        assert!(ctx.connected.is_none());
+    }
+
+    #[test]
+    fn stream_callback_send_complete_with_dropped_receiver_is_noop() {
+        let (mut ctx, srx, rrx) = stream_ctx_channel();
+        // Frontend gone: drop the receive side of the send-complete channel.
+        drop(srx);
+        drop(rrx);
+        let ev = StreamEvent::SendComplete {
+            cancelled: false,
+            client_context: std::ptr::null(),
+        };
+        // Fallible unbounded_send returns Err; no panic, callback returns Ok.
+        assert!(stream_callback(&mut ctx, ev).is_ok());
+    }
+
+    #[test]
+    fn lock_recover_recovers_poisoned_mutex() {
+        let m = Arc::new(Mutex::new(41u32));
+        let m2 = m.clone();
+        // Poison the mutex by panicking while its guard is held.
+        let joined = std::thread::spawn(move || {
+            let mut g = m2.lock().unwrap();
+            *g = 42;
+            panic!("poison the callback-path lock");
+        })
+        .join();
+        assert!(joined.is_err(), "helper thread should have panicked");
+        assert!(m.is_poisoned(), "mutex should be poisoned");
+
+        // Recover without panicking and observe the value written before poison.
+        let g = lock_recover(&m);
+        assert_eq!(*g, 42);
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -22,7 +22,9 @@ use msquic::{
 mod buffer;
 pub use buffer::*;
 mod error;
-use error::{ConnectionTerminal, clamp_application_code, convert_conn};
+use error::{
+    ConnectionTerminal, ReceiveTerminal, clamp_application_code, convert_conn, convert_recv,
+};
 pub use error::{LocalConnectionClose, LocalStreamReset, MsQuicTransportError, OversizedSend};
 mod listener;
 pub use listener::Listener;
@@ -124,6 +126,30 @@ fn classify_transport(status: Status, error_code: u64) -> ConnectionTerminal {
         Ok(StatusCode::QUIC_STATUS_CONNECTION_TIMEOUT)
         | Ok(StatusCode::QUIC_STATUS_CONNECTION_IDLE) => ConnectionTerminal::Timeout,
         _ => ConnectionTerminal::Transport { status, error_code },
+    }
+}
+
+/// Classify a connection-caused stream `ShutdownComplete` into a connection
+/// terminal reason.
+///
+/// This is the deterministic fallback a *stream* callback uses when it observes
+/// `ShutdownComplete { connection_shutdown: true, .. }`. It follows MsQuic's
+/// `ConnectionShutdownByApp` / `ConnectionClosedRemotely` semantics (see
+/// `docs/error-propagation.md`, "Receive-side transitions"):
+/// - `by_app && closed_remotely` is a peer HTTP/3 application close;
+/// - `by_app && !closed_remotely` is a local application close (no peer code);
+/// - anything else is a transport close, delegated to [`classify_transport`]
+///   (which distinguishes idle/handshake timeouts from generic transport).
+fn classify_conn_shutdown(
+    by_app: bool,
+    closed_remotely: bool,
+    error_code: u64,
+    status: Status,
+) -> ConnectionTerminal {
+    match (by_app, closed_remotely) {
+        (true, true) => ConnectionTerminal::PeerApplication(error_code),
+        (true, false) => ConnectionTerminal::LocalClose,
+        (false, _) => classify_transport(status, error_code),
     }
 }
 
@@ -632,18 +658,50 @@ struct BufPtr(*const c_void);
 unsafe impl Send for BufPtr {}
 unsafe impl Sync for BufPtr {}
 
+/// Explicit receive-side event delivered from the stream callback to the
+/// frontend receive half.
+///
+/// Splitting the receive path into explicit events makes a graceful FIN, a peer
+/// reset, an empty non-FIN notification, and a connection failure observably
+/// distinct at `poll_data` (they were previously all collapsed into a bare
+/// channel close). Data from a single notification is always enqueued before any
+/// terminal marker from that same notification.
+enum ReceiveEvent {
+    /// Normal received bytes.
+    Data(Bytes),
+    /// Peer finished sending gracefully (FIN / `PeerSendShutdown`): clean EOF.
+    Fin,
+    /// Peer reset the receive side (`PeerSendAborted`) with this code.
+    Reset(u64),
+    /// The whole connection terminated with this reason.
+    Connection(ConnectionTerminal),
+}
+
 struct StreamSendCtx {
     start: Option<oneshot::Sender<Result<(), Status>>>,
     // cancelled, client_context
     send: Option<mpsc::UnboundedSender<(bool, BufPtr)>>,
     shutdown: Option<oneshot::Sender<()>>,
-    receive: Option<mpsc::UnboundedSender<Bytes>>,
+    receive: Option<mpsc::UnboundedSender<ReceiveEvent>>,
+    /// First-writer-wins guard for the receive scope: once a `Fin`, `Reset`, or
+    /// `Connection` terminal has been published, later receive events are
+    /// suppressed (e.g. the usual `Receive { FIN }` then `PeerSendShutdown`
+    /// sequence must not enqueue a duplicate FIN).
+    receive_terminal_sent: bool,
 }
 
 /// ctx for receiving data on frontend.
 #[derive(Debug)]
 struct RecvStreamReceiveCtx {
-    receive: mpsc::UnboundedReceiver<Bytes>,
+    receive: mpsc::UnboundedReceiver<ReceiveEvent>,
+    /// Sticky receive terminal. Once a terminal event has been drained it is
+    /// stored here and every later `poll_data` returns the same class without
+    /// re-polling the channel.
+    terminal: Option<ReceiveTerminal>,
+    /// SF-6: local, sticky end-of-stream flag set by OUR OWN `stop_sending`.
+    /// Distinct from `terminal` (a peer/connection-caused reason); when set,
+    /// `poll_data` returns a clean `Ok(None)` and `terminal` is left untouched.
+    receive_closed: bool,
 }
 
 /// ctx for sending data on frontend.
@@ -667,6 +725,7 @@ fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamRecei
             send: Some(send_tx),
             shutdown: Some(shutdown_tx),
             receive: Some(receive_tx),
+            receive_terminal_sent: false,
         },
         SendStreamReceiveCtx {
             start: Some(start_rx),
@@ -676,6 +735,8 @@ fn stream_ctx_channel() -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamRecei
         },
         RecvStreamReceiveCtx {
             receive: receive_rx,
+            terminal: None,
+            receive_closed: false,
         },
     )
 }
@@ -706,7 +767,12 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
             }
         }
         StreamEvent::Receive { buffers, flags, .. } => {
-            if let Some(receive) = ctx.receive.as_ref() {
+            // Enqueue received bytes (if any) BEFORE any terminal marker from
+            // this same notification, so `poll_data` observes data then FIN.
+            // Once a receive terminal has been published, suppress further data.
+            if !ctx.receive_terminal_sent
+                && let Some(receive) = ctx.receive.as_ref()
+            {
                 let mut b = BytesMut::new();
                 for br in buffers {
                     // skip empty buffs.
@@ -716,20 +782,28 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
                 }
                 let b = b.freeze();
                 if !b.is_empty() {
-                    // Failed delivery (frontend `H3RecvStream` dropped) drops the
-                    // sender so no further receive events are attempted.
-                    if receive.unbounded_send(b).is_err() {
+                    // Failed delivery (frontend `H3RecvStream` dropped) drops
+                    // the sender so no further receive events are attempted.
+                    if receive.unbounded_send(ReceiveEvent::Data(b)).is_err() {
                         ctx.receive.take();
                     }
-                } else {
-                    // zero buff can happen. so drop the receiver.
-                    ctx.receive.take();
                 }
+                // An empty, non-FIN notification produces NO event (Finding
+                // 8): a zero-length receive is not by itself an end-of-stream.
             }
+            // A FIN flag is a clean end-of-stream marker (peer finished sending).
             if flags.contains(ReceiveFlags::FIN) {
-                // close
-                ctx.receive.take();
+                publish_recv_terminal(ctx, ReceiveEvent::Fin);
             }
+        }
+        StreamEvent::PeerSendShutdown => {
+            // Peer gracefully finished sending: clean end-of-stream.
+            publish_recv_terminal(ctx, ReceiveEvent::Fin);
+        }
+        StreamEvent::PeerSendAborted { error_code } => {
+            // Peer RESET_STREAM on its send half: surfaces at `poll_data` as
+            // `StreamTerminated { error_code }`, distinct from a graceful FIN.
+            publish_recv_terminal(ctx, ReceiveEvent::Reset(error_code));
         }
         StreamEvent::SendShutdownComplete { graceful: _ } => {
             // Peer acknowledged shutdown.
@@ -737,7 +811,26 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
                 let _ = shutdown.send(());
             }
         }
-        StreamEvent::ShutdownComplete { .. } => {
+        StreamEvent::ShutdownComplete {
+            connection_shutdown,
+            connection_shutdown_by_app,
+            connection_closed_remotely,
+            connection_error_code,
+            connection_close_status,
+            ..
+        } => {
+            // A connection-caused stream shutdown surfaces the connection error
+            // on the receive half (reusing the Phase-3 connection terminal +
+            // convert helpers). A stream-local shutdown publishes no terminal.
+            if connection_shutdown {
+                let reason = classify_conn_shutdown(
+                    connection_shutdown_by_app,
+                    connection_closed_remotely,
+                    connection_error_code,
+                    connection_close_status,
+                );
+                publish_recv_terminal(ctx, ReceiveEvent::Connection(reason));
+            }
             // close all channels
             ctx.receive.take();
             ctx.send.take();
@@ -747,6 +840,23 @@ fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Result<(), Statu
         _ => {}
     }
     Ok(())
+}
+
+/// Publish a receive-side terminal event under first-writer-wins.
+///
+/// The first `Fin`/`Reset`/`Connection` wins and suppresses later receive
+/// events. After publishing, the receive sender is dropped so no further events
+/// are delivered; bytes already enqueued are preserved by the channel and are
+/// still observed before the terminal.
+fn publish_recv_terminal(ctx: &mut StreamSendCtx, ev: ReceiveEvent) {
+    if ctx.receive_terminal_sent {
+        return;
+    }
+    if let Some(receive) = ctx.receive.as_ref() {
+        let _ = receive.unbounded_send(ev);
+    }
+    ctx.receive_terminal_sent = true;
+    ctx.receive.take();
 }
 
 impl H3Stream {
@@ -901,6 +1011,63 @@ fn get_id(s: &msquic::Stream) -> h3::quic::StreamId {
     raw_id.try_into().expect("cannot parse id")
 }
 
+impl RecvStreamReceiveCtx {
+    /// SF-6: mark the receive half as locally ended by OUR OWN `stop_sending`.
+    ///
+    /// Idempotent and deliberately independent of any FFI outcome: the h3
+    /// `stop_sending` trait method is infallible, so this sticky local
+    /// end-of-stream must be set regardless of whether the `ABORT_RECEIVE`
+    /// submit succeeds. Once set, `poll_event` returns a clean `Ok(None)` and
+    /// leaves the sticky `terminal` slot untouched.
+    fn close_receive_locally(&mut self) {
+        self.receive_closed = true;
+    }
+
+    /// Drain one explicit receive event and map it to the h3 `poll_data` result.
+    ///
+    /// Sticky: once a terminal is stored, every later poll returns the same
+    /// class without touching the channel. SF-6: a local `stop_sending` sets
+    /// `receive_closed`, which yields a clean `Ok(None)` end-of-stream and leaves
+    /// the terminal slot untouched.
+    fn poll_event(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<Option<Bytes>, StreamErrorIncoming>> {
+        use std::task::Poll;
+        // SF-6: our own `stop_sending` ended the receive half locally. This is a
+        // clean end-of-stream, NOT a terminal: `terminal` stays untouched.
+        if self.receive_closed {
+            return Poll::Ready(Ok(None));
+        }
+        // Replay the stored sticky terminal without re-polling the channel.
+        if let Some(terminal) = &self.terminal {
+            return Poll::Ready(convert_recv(terminal.clone()));
+        }
+        match ready!(self.receive.poll_next_unpin(cx)) {
+            Some(ReceiveEvent::Data(b)) => Poll::Ready(Ok(Some(b))),
+            Some(ReceiveEvent::Fin) => self.store_and_convert(ReceiveTerminal::Fin),
+            Some(ReceiveEvent::Reset(code)) => self.store_and_convert(ReceiveTerminal::Reset(code)),
+            Some(ReceiveEvent::Connection(reason)) => {
+                self.store_and_convert(ReceiveTerminal::Connection(reason))
+            }
+            // A closed channel without an explicit terminal event is an internal
+            // fault, not a clean end-of-stream.
+            None => self.store_and_convert(ReceiveTerminal::Internal(
+                "receive channel closed without a terminal reason",
+            )),
+        }
+    }
+
+    /// Store `terminal` as the sticky receive reason and convert it for h3.
+    fn store_and_convert(
+        &mut self,
+        terminal: ReceiveTerminal,
+    ) -> std::task::Poll<Result<Option<Bytes>, StreamErrorIncoming>> {
+        self.terminal = Some(terminal.clone());
+        std::task::Poll::Ready(convert_recv(terminal))
+    }
+}
+
 impl RecvStream for H3RecvStream {
     type Buf = Bytes;
 
@@ -912,8 +1079,7 @@ impl RecvStream for H3RecvStream {
         &mut self,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<Option<Self::Buf>, StreamErrorIncoming>> {
-        let res = ready!(self.rctx.receive.poll_next_unpin(cx));
-        std::task::Poll::Ready(Ok(res))
+        self.rctx.poll_event(cx)
     }
 
     /// Stop accepting data. Discard unread data, notify peer to not send.
@@ -922,11 +1088,17 @@ impl RecvStream for H3RecvStream {
         tracing::instrument(skip_all, level = "trace", ret)
     )]
     fn stop_sending(&mut self, error_code: u64) {
-        // Close the send path.
+        // Close the send path (code already clamped, Phase 2).
         let _ = self.stream.shutdown(
             StreamShutdownFlags::ABORT_RECEIVE,
             clamp_application_code(error_code),
         );
+        // SF-6: sticky local end-of-stream. Subsequent `poll_data` returns a
+        // clean `Ok(None)` and injects NO receive terminal (`terminal`
+        // untouched). Set unconditionally via the local-state seam: the FFI
+        // submit above is best-effort and its outcome must not gate the
+        // infallible h3 `stop_sending` contract.
+        self.rctx.close_receive_locally();
     }
 
     fn recv_id(&self) -> h3::quic::StreamId {
@@ -1560,5 +1732,196 @@ mod connection_terminal {
             observe_terminal(&crx.terminal),
             ConnectionErrorIncoming::ApplicationClose { error_code: 11 }
         ));
+    }
+}
+
+/// Phase 4 (explicit receive events) unit tests: prove that a graceful FIN, a
+/// peer reset, an empty non-FIN notification, a peer send-shutdown, a
+/// connection failure, and a local `stop_sending` are all observably distinct at
+/// the `poll_data` boundary. Hermetic (no network): events are driven straight
+/// through `stream_callback` and drained via `RecvStreamReceiveCtx::poll_event`,
+/// so no native `msquic::Stream` is required.
+#[cfg(test)]
+mod receive_events {
+    use std::task::{Context, Poll};
+
+    use bytes::Bytes;
+    use h3::quic::{ConnectionErrorIncoming, StreamErrorIncoming};
+
+    use crate::msquic::{BufferRef, ReceiveFlags, Status, StatusCode, StreamEvent};
+    use crate::{RecvStreamReceiveCtx, stream_callback, stream_ctx_channel};
+
+    fn noop_context() -> Context<'static> {
+        // A leaked no-op waker gives a `'static` context usable across polls.
+        let waker = Box::leak(Box::new(futures::task::noop_waker()));
+        Context::from_waker(waker)
+    }
+
+    /// Drive one `StreamEvent::Receive` carrying `data` and `flags`.
+    fn feed_receive(ctx: &mut crate::StreamSendCtx, data: &[u8], flags: ReceiveFlags) {
+        let bufs = [BufferRef::from(data)];
+        let mut total = data.len() as u64;
+        let ev = StreamEvent::Receive {
+            absolute_offset: 0,
+            total_buffer_length: &mut total,
+            buffers: &bufs,
+            flags,
+        };
+        assert!(stream_callback(ctx, ev).is_ok());
+    }
+
+    fn poll(rrx: &mut RecvStreamReceiveCtx) -> Poll<Result<Option<Bytes>, StreamErrorIncoming>> {
+        let mut cx = noop_context();
+        rrx.poll_event(&mut cx)
+    }
+
+    #[test]
+    fn graceful_fin_yields_data_then_clean_eof() {
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        feed_receive(&mut ctx, &[1, 2, 3], ReceiveFlags::FIN);
+        // Data first.
+        match poll(&mut rrx) {
+            Poll::Ready(Ok(Some(b))) => assert_eq!(&b[..], &[1, 2, 3]),
+            other => panic!("expected data, got {other:?}"),
+        }
+        // Then a clean end-of-stream.
+        assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
+        // Sticky: a later poll keeps returning clean EOF.
+        assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
+    }
+
+    #[test]
+    fn peer_reset_yields_stream_terminated_with_code() {
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        assert!(stream_callback(&mut ctx, StreamEvent::PeerSendAborted { error_code: 42 }).is_ok());
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                assert_eq!(error_code, 42)
+            }
+            other => panic!("expected StreamTerminated{{42}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn graceful_fin_and_peer_reset_are_observably_different() {
+        // FIN => Ok(None); RESET_STREAM => Err(StreamTerminated). The two paths
+        // must not be conflated (Finding 1).
+        let (mut fin_ctx, _s1, mut fin_rrx) = stream_ctx_channel();
+        feed_receive(&mut fin_ctx, &[], ReceiveFlags::FIN);
+        let fin = poll(&mut fin_rrx);
+
+        let (mut rst_ctx, _s2, mut rst_rrx) = stream_ctx_channel();
+        assert!(
+            stream_callback(&mut rst_ctx, StreamEvent::PeerSendAborted { error_code: 7 }).is_ok()
+        );
+        let rst = poll(&mut rst_rrx);
+
+        assert!(matches!(fin, Poll::Ready(Ok(None))));
+        assert!(matches!(
+            rst,
+            Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code: 7 }))
+        ));
+    }
+
+    #[test]
+    fn empty_non_fin_receive_produces_no_event() {
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        // A zero-length, non-FIN notification is not an end-of-stream (Finding 8).
+        feed_receive(&mut ctx, &[], ReceiveFlags::NONE);
+        // No event was enqueued and the channel is still open: Pending.
+        assert!(matches!(poll(&mut rrx), Poll::Pending));
+        // The terminal slot must remain empty.
+        assert!(rrx.terminal.is_none());
+    }
+
+    #[test]
+    fn peer_send_shutdown_yields_clean_eof() {
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        assert!(stream_callback(&mut ctx, StreamEvent::PeerSendShutdown).is_ok());
+        assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
+    }
+
+    #[test]
+    fn first_receive_terminal_wins() {
+        // The usual `Receive{FIN}` then `PeerSendShutdown` sequence must yield a
+        // single clean EOF, not a duplicate. Likewise a reset published first is
+        // not overwritten by a later FIN.
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        assert!(stream_callback(&mut ctx, StreamEvent::PeerSendAborted { error_code: 9 }).is_ok());
+        // A later graceful FIN must NOT override the earlier reset.
+        assert!(stream_callback(&mut ctx, StreamEvent::PeerSendShutdown).is_ok());
+        assert!(matches!(
+            poll(&mut rrx),
+            Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code: 9 }))
+        ));
+        // Sticky reset persists.
+        assert!(matches!(
+            poll(&mut rrx),
+            Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code: 9 }))
+        ));
+    }
+
+    #[test]
+    fn connection_shutdown_surfaces_connection_error() {
+        // A peer application close (by_app && closed_remotely) delivered as a
+        // connection-caused stream shutdown surfaces the connection error.
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let ev = StreamEvent::ShutdownComplete {
+            connection_shutdown: true,
+            app_close_in_progress: false,
+            connection_shutdown_by_app: true,
+            connection_closed_remotely: true,
+            connection_error_code: 13,
+            connection_close_status: Status::new(StatusCode::QUIC_STATUS_ABORTED),
+        };
+        assert!(stream_callback(&mut ctx, ev).is_ok());
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::ApplicationClose { error_code },
+            })) => assert_eq!(error_code, 13),
+            other => panic!("expected connection ApplicationClose{{13}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stream_local_shutdown_publishes_no_connection_terminal() {
+        // A stream-local `ShutdownComplete` (connection_shutdown == false) must
+        // NOT surface a connection error. The channel closes with no terminal
+        // event, which maps to the internal fault class.
+        let (mut ctx, _srx, mut rrx) = stream_ctx_channel();
+        let ev = StreamEvent::ShutdownComplete {
+            connection_shutdown: false,
+            app_close_in_progress: false,
+            connection_shutdown_by_app: false,
+            connection_closed_remotely: false,
+            connection_error_code: 0,
+            connection_close_status: Status::new(StatusCode::QUIC_STATUS_SUCCESS),
+        };
+        assert!(stream_callback(&mut ctx, ev).is_ok());
+        match poll(&mut rrx) {
+            Poll::Ready(Err(StreamErrorIncoming::ConnectionErrorIncoming {
+                connection_error: ConnectionErrorIncoming::InternalError(_),
+            })) => {}
+            other => panic!("expected internal-fault on bare channel close, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn poll_data_after_local_stop_sending_is_ok_none() {
+        // SF-6 / FR-017: after a local `stop_sending`, `poll_data` returns a
+        // defined clean end-of-stream (Ok(None)), NOT a peer error, and no
+        // receive terminal is injected. This drives the REAL local-state seam
+        // that `RecvStream::stop_sending` calls (`close_receive_locally`) rather
+        // than poking the field directly, so it genuinely covers the
+        // stop_sending local-EOF behavior without needing a live FFI stream.
+        // `stop_sending` separately submits `ABORT_RECEIVE` with the clamped
+        // application code; that FFI effect is exercised by the loopback tests.
+        let (_ctx, _srx, mut rrx) = stream_ctx_channel();
+        assert!(!rrx.receive_closed);
+        rrx.close_receive_locally(); // the exact call RecvStream::stop_sending makes
+        assert!(matches!(poll(&mut rrx), Poll::Ready(Ok(None))));
+        // No terminal was injected: the sticky recv terminal slot stays empty.
+        assert!(rrx.terminal.is_none());
+        assert!(rrx.receive_closed);
     }
 }

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -20,7 +20,7 @@ use msquic::{
 };
 
 mod buffer;
-use buffer::{SendBuffer, SendLen, classify_send_len};
+use buffer::{SendBuffer, SendLen, classify_send_len, copy_into_send_buffer};
 mod error;
 use error::{
     ConnectionTerminal, ReceiveTerminal, SendCommand, SendEvent, SendInput, SendPayload, SendPoll,
@@ -33,6 +33,22 @@ pub use listener::Listener;
 mod registration;
 use registration::RundownGuard;
 pub use registration::{Registration, WaitIdle};
+
+/// Runtime native-library attestation (MF-3): the `native_version_preflight`
+/// gate lives here. Test-only — it queries the live msquic handle for its
+/// version + git hash and digests the loaded `libmsquic`.
+#[cfg(test)]
+mod attest;
+
+/// Feature-gated public re-export of the ONE send-copy path so the separate
+/// Criterion bench crate (`benches/send_copy.rs`) can reach it (MF-4). Only the
+/// function is re-exported; `SendBuffer`'s name is never exposed. The surface
+/// appears **only** when the committed `bench-internals` feature is enabled, so
+/// no bench-only API leaks into the default library build.
+#[cfg(feature = "bench-internals")]
+pub mod bench_support {
+    pub use crate::buffer::copy_into_send_buffer;
+}
 
 /// re-export msquic type
 pub mod msquic {
@@ -491,13 +507,11 @@ fn connection_callback(ctx: &mut ConnCtxSender, ev: msquic::ConnectionEvent) -> 
                 let raw = failpoint.maybe_override(raw)?;
                 Ok(raw)
             };
-            let id = match accept_stream_id(ctx, query) {
-                Ok(id) => id,
-                // Pre-ownership failure: `accept_stream_id` already published the
-                // internal terminal and woke the acceptors. Return the status so
-                // msquic closes the rejected stream itself (single close).
-                Err(status) => return Err(status),
-            };
+            // Pre-ownership failure path: `accept_stream_id` already published the
+            // internal terminal and woke the acceptors, so `?` returns the status
+            // and msquic closes the rejected stream itself (single close). On
+            // success we take native ownership only NOW.
+            let id = accept_stream_id(ctx, query)?;
             // Success: only NOW take native ownership and attach.
             let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
             let h3 = crate::H3Stream::attach(owned, id);
@@ -1634,9 +1648,10 @@ impl<B: Buf> SendStream<B> for H3SendStream {
                     // The single production copy path: materialize the complete
                     // wire representation into owned `Bytes` while `B` is still on
                     // this thread, then hand it to the seam (which reclaims the box
-                    // itself on an immediate `Err`).
-                    let remaining = wb.remaining();
-                    let buf = SendBuffer::new(wb.copy_to_bytes(remaining));
+                    // itself on an immediate `Err`). `&mut WriteBuf<B>` is a `Buf`,
+                    // so this drives the exact `copy_to_bytes` allocation the
+                    // Criterion bench measures through `bench_support`.
+                    let buf = copy_into_send_buffer(&mut wb);
                     let res = self.exec.submit_send(buf);
                     input = SendInput::SendSubmitted {
                         result: res,

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -42,6 +42,55 @@ fn listener_ctx_channel() -> (ListenerCtxSender, ListenerCtxReceiver) {
     )
 }
 
+/// The single-outcome decision for a listener `NewConnection` event, factored
+/// out of the FFI callback so every branch is unit-testable without a forgeable
+/// `ConnectionRef`.
+///
+/// The listener double-close hazard lives entirely in *which* of these three
+/// outcomes runs; keeping the choice in a pure function lets tests assert it
+/// directly while [`listener_callback`] performs the matching ownership action.
+#[derive(Debug)]
+enum NewConnDecision {
+    /// `set_configuration` failed on the borrowed `ConnectionRef` *before* any
+    /// ownership was taken. The callback returns this `Status` so native
+    /// `listener.c` performs the single close; the reserved rundown guard is
+    /// released (never `from_raw`, never a Rust-side close).
+    ConfigFailedClose(Status),
+    /// Configuration succeeded and the owned connection was handed to the accept
+    /// frontend. The callback returns `Ok`.
+    DeliveredOwned,
+    /// Configuration succeeded and ownership was taken, but frontend delivery
+    /// failed (receiver lost). The owned `Connection` is dropped (a single
+    /// `ConnectionClose`) and the callback returns `Ok` — never close-then-reject
+    /// the same handle (which would trip native `listener.c`'s assert).
+    DeliveryFailedDropOwned,
+}
+
+/// Pure decision logic for the listener `NewConnection` event.
+///
+/// `config` is the result of `set_configuration` run through the *borrowed*
+/// `ConnectionRef`. Only when it succeeds is `deliver` invoked; that closure
+/// takes native ownership (`from_raw`), attaches, and attempts frontend
+/// delivery, returning `true` on delivery and `false` if the receiver was lost
+/// (dropping the now-owned connection). On a config failure `deliver` is never
+/// called, so no ownership is ever taken — and any rundown guard the closure
+/// captured is released when the un-invoked closure is dropped here.
+fn decide_new_connection(
+    config: Result<(), Status>,
+    deliver: impl FnOnce() -> bool,
+) -> NewConnDecision {
+    match config {
+        Err(e) => NewConnDecision::ConfigFailedClose(e),
+        Ok(()) => {
+            if deliver() {
+                NewConnDecision::DeliveredOwned
+            } else {
+                NewConnDecision::DeliveryFailedDropOwned
+            }
+        }
+    }
+}
+
 #[cfg_attr(
     feature = "tracing",
     tracing::instrument(skip(ctx, config, state), level = "trace", ret, err)
@@ -57,30 +106,44 @@ fn listener_callback(
             info: _,
             connection,
         } => {
-            let inner = unsafe { msquic::Connection::from_raw(connection.as_raw()) };
-            // The native handle already holds a registration rundown ref here;
-            // reserve our count immediately.
+            // `connection` is the borrowed `ConnectionRef`; the native handle
+            // already holds a registration rundown ref, so reserve our count now.
             let guard = RundownGuard::new(state.clone());
-            // set the config
-            if let Err(e) = inner.set_configuration(config) {
-                // Close the handle first (releases the rundown ref), then the
-                // guard decrements. This handle is discarded, so it gets a fresh
-                // terminal slot that no reader ever observes.
-                drop(crate::ConnHandle::new(
-                    inner,
-                    guard,
-                    crate::new_conn_terminal_slot(),
-                ));
-                return Err(e);
-            }
-            let conn = crate::Connection::attach(inner, guard);
-            if let Some(tx) = ctx.conn.as_ref() {
-                // Ownership was taken by `Connection::attach`; if delivery fails
-                // the returned `SendError` carries the owned `Connection`, which
-                // drops here and runs a single `ConnectionClose`. Return `Ok`
-                // (never `Err`) so the callback does not also reject an owned
-                // handle and trip native `listener.c`'s close-and-reject assert.
-                let _ = tx.unbounded_send(Some(conn));
+            // Validate/configure through the BORROWED ref, before taking
+            // ownership. `ConnectionRef` derefs to `Connection` and its `Drop`
+            // only nulls the handle — it never closes it.
+            let config = connection.set_configuration(config);
+            // The `deliver` closure runs (taking ownership) only if `config`
+            // succeeded. It captures `guard` by move: on the config-failure path
+            // it is dropped un-invoked, releasing the reserved rundown count with
+            // no `from_raw` and no Rust-side close — native `listener.c` performs
+            // the single close on our returned `Err`.
+            let decision = decide_new_connection(config, move || {
+                // `set_configuration` succeeded: only NOW take ownership.
+                let inner = unsafe { msquic::Connection::from_raw(connection.as_raw()) };
+                let conn = crate::Connection::attach(inner, guard);
+                match ctx.conn.as_ref() {
+                    Some(tx) => match tx.unbounded_send(Some(conn)) {
+                        Ok(()) => true,
+                        // Delivery failed after ownership: the `SendError`
+                        // carries the owned `Connection`, dropped here for a
+                        // single `ConnectionClose`.
+                        Err(send_err) => {
+                            drop(send_err.into_inner());
+                            false
+                        }
+                    },
+                    // No sender (listener frontend gone): drop the owned
+                    // `Connection` for a single close.
+                    None => {
+                        drop(conn);
+                        false
+                    }
+                }
+            });
+            match decision {
+                NewConnDecision::ConfigFailedClose(e) => return Err(e),
+                NewConnDecision::DeliveredOwned | NewConnDecision::DeliveryFailedDropOwned => {}
             }
         }
         ListenerEvent::StopComplete { .. } => {
@@ -373,5 +436,78 @@ mod test {
                 .await
                 .expect("wait_idle should resolve after the listener is dropped");
         });
+    }
+}
+
+/// Phase 5 listener connection failure-path unit tests. The real `NewConnection`
+/// callback is FFI-driven and a `ConnectionRef` cannot be forged hermetically,
+/// so the single-outcome decision is factored into [`decide_new_connection`] and
+/// asserted directly for all three branches: pre-ownership `set_configuration`
+/// failure (single close / `Err`), post-ownership delivery success (owned +
+/// `Ok`), and post-ownership delivery failure (owned dropped + `Ok`). The real
+/// success path is covered end-to-end by `basic_server_test`.
+#[cfg(test)]
+mod new_conn_decision {
+    use std::{cell::Cell, sync::Arc};
+
+    use msquic::{Status, StatusCode};
+
+    use super::{NewConnDecision, decide_new_connection};
+    use crate::registration::{RundownGuard, RundownState};
+
+    /// Pre-ownership `set_configuration` failure: the deliver closure (which is
+    /// the only thing that takes native ownership) never runs, the decision is
+    /// `ConfigFailedClose` carrying the status the callback returns as `Err` (so
+    /// native `listener.c` performs the single close), and the reserved rundown
+    /// guard captured by the un-invoked closure is released.
+    #[test]
+    fn config_failure_closes_once_without_taking_ownership() {
+        let state = Arc::new(RundownState::default());
+        let base = Arc::strong_count(&state);
+        let guard = RundownGuard::new(state.clone());
+        // Reserving a guard clones the shared `RundownState` Arc.
+        assert_eq!(Arc::strong_count(&state), base + 1);
+
+        let delivered = Cell::new(false);
+        let status = Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR);
+        let expected = status.try_as_status_code().ok();
+        let decision = decide_new_connection(Err(status), || {
+            // Would take ownership + deliver in production; must not run here.
+            delivered.set(true);
+            let _consumes_guard = guard;
+            true
+        });
+
+        match decision {
+            NewConnDecision::ConfigFailedClose(e) => {
+                assert_eq!(e.try_as_status_code().ok(), expected);
+            }
+            other => panic!("expected ConfigFailedClose, got {other:?}"),
+        }
+        assert!(
+            !delivered.get(),
+            "no ownership must be taken when set_configuration fails (single native close)"
+        );
+        // The un-invoked closure dropped the guard it captured, releasing the
+        // reserved rundown count back to the pre-reservation baseline.
+        assert_eq!(Arc::strong_count(&state), base);
+    }
+
+    /// Post-ownership delivery success: configuration passed and the owned
+    /// connection reached the frontend → `DeliveredOwned` (callback returns `Ok`).
+    #[test]
+    fn delivery_success_reports_delivered_owned() {
+        let decision = decide_new_connection(Ok(()), || true);
+        assert!(matches!(decision, NewConnDecision::DeliveredOwned));
+    }
+
+    /// Post-ownership delivery failure (receiver lost): configuration passed and
+    /// ownership was taken, but delivery failed → `DeliveryFailedDropOwned`. The
+    /// callback drops the owned connection (single close) and returns `Ok` —
+    /// never close-then-reject.
+    #[test]
+    fn delivery_failure_reports_drop_owned() {
+        let decision = decide_new_connection(Ok(()), || false);
+        assert!(matches!(decision, NewConnDecision::DeliveryFailedDropOwned));
     }
 }

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -64,8 +64,13 @@ fn listener_callback(
             // set the config
             if let Err(e) = inner.set_configuration(config) {
                 // Close the handle first (releases the rundown ref), then the
-                // guard decrements.
-                drop(crate::ConnHandle::new(inner, guard));
+                // guard decrements. This handle is discarded, so it gets a fresh
+                // terminal slot that no reader ever observes.
+                drop(crate::ConnHandle::new(
+                    inner,
+                    guard,
+                    crate::new_conn_terminal_slot(),
+                ));
                 return Err(e);
             }
             let conn = crate::Connection::attach(inner, guard);

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -70,18 +70,22 @@ fn listener_callback(
             }
             let conn = crate::Connection::attach(inner, guard);
             if let Some(tx) = ctx.conn.as_ref() {
-                tx.unbounded_send(Some(conn)).expect("cannot send");
+                // Ownership was taken by `Connection::attach`; if delivery fails
+                // the returned `SendError` carries the owned `Connection`, which
+                // drops here and runs a single `ConnectionClose`. Return `Ok`
+                // (never `Err`) so the callback does not also reject an owned
+                // handle and trip native `listener.c`'s close-and-reject assert.
+                let _ = tx.unbounded_send(Some(conn));
             }
         }
         ListenerEvent::StopComplete { .. } => {
             // none means end of connections
             if let Some(tx) = ctx.conn.as_ref() {
-                tx.unbounded_send(None).expect("cannot send");
+                let _ = tx.unbounded_send(None);
             }
-            let mut lk = ctx.shutdown.lock().unwrap();
-            let tx = lk.take();
+            let tx = crate::lock_recover(&ctx.shutdown).take();
             if let Some(tx) = tx {
-                tx.send(()).expect("cannot send");
+                let _ = tx.send(());
             }
         }
     }
@@ -141,12 +145,15 @@ impl Listener {
     /// shutdown is made immutable to enable it to be called from another thread.
     pub async fn shutdown(&self) {
         let opt_rx = {
-            let mut lk = self.conn.shutdown.lock().unwrap();
+            let mut lk = crate::lock_recover(&self.conn.shutdown);
             lk.take()
         };
         if let Some(rx) = opt_rx {
             self.inner.stop();
-            rx.await.expect("cannot receive");
+            // On cancellation (sender dropped) treat as already shut down and
+            // return rather than panicking. Calling `shutdown` twice is a no-op
+            // because the receiver was taken above.
+            let _ = rx.await;
         }
     }
 }
@@ -307,7 +314,7 @@ mod test {
             .unwrap()
             .block_on(crate::test::send_get_request(uri));
         //std::thread::sleep(Duration::from_secs(1));
-        sht_tx.send(()).unwrap();
+        let _ = sht_tx.send(());
         th.join().unwrap();
     }
 

--- a/msquic-h3/src/registration.rs
+++ b/msquic-h3/src/registration.rs
@@ -59,7 +59,7 @@ impl Drop for RundownGuard {
             // Wake every outstanding waiter. Collect under the lock, wake after
             // releasing it.
             let woken: Vec<Waker> = {
-                let mut w = self.state.waiters.lock().unwrap();
+                let mut w = crate::lock_recover(&self.state.waiters);
                 w.map.drain().map(|(_, waker)| waker).collect()
             };
             for waker in woken {
@@ -139,7 +139,7 @@ pub struct WaitIdle {
 impl WaitIdle {
     fn deregister(&mut self) {
         if let Some(k) = self.key.take() {
-            self.state.waiters.lock().unwrap().map.remove(&k);
+            crate::lock_recover(&self.state.waiters).map.remove(&k);
         }
     }
 }
@@ -156,7 +156,7 @@ impl Future for WaitIdle {
         }
         // Register/refresh this task's waker under the lock.
         {
-            let mut w = this.state.waiters.lock().unwrap();
+            let mut w = crate::lock_recover(&this.state.waiters);
             match this.key {
                 Some(k) => {
                     w.map.insert(k, cx.waker().clone());


### PR DESCRIPTION
# [Error Propagation] Faithful, panic-free MsQuic → h3 error propagation

## Summary

Replaces the `msquic-h3` adapter's lossy "close-a-channel-to-signal-everything"
model with explicit, sticky, scope-precedenced error propagation from msquic
2.5.1-beta into the h3 0.0.8 incoming-error contract, implementing the
review-hardened design in `docs/error-propagation.md`.

Key behavioral changes:
- **Peer stream reset** (`RESET_STREAM`) now surfaces as
  `StreamErrorIncoming::StreamTerminated { error_code }` — distinguishable from a
  graceful FIN — instead of a clean end-of-stream.
- **Connection closes** carry their true cause (peer application-close with code,
  timeout, or transport/undefined) instead of a synthetic `ApplicationClose{0}`.
- **Peer `STOP_SENDING`** is observable from the send side, including when no send
  is in flight.
- **Empty non-FIN receives** no longer produce a spurious EOF; local `stop_sending`
  yields a clean end-of-stream.
- **No FFI callback or lifecycle race can panic across the C boundary** — every
  callback send is fallible and every lock is poison-recovering; the last `panic!`
  (in `reset`) is gone.
- The **send half owns its buffer** (`SendBuffer`, `Bytes`-backed) with exactly-once
  reclamation over `Box::into_raw`/`from_raw`, driven by a **pure send-side reducer**
  (single ordered event source, non-consuming finish guard, provisional-abort
  refinement).
- **Safe accept paths**: accepted streams and listener-accepted connections are
  validated on the borrowed handle and take ownership only on success (no native
  double-close).

## Changes

- `msquic-h3/src/lib.rs` — panic-free callbacks, connection terminal slot + true-cause
  mapping, explicit receive events, safe stream open/identity, owned-buffer send path +
  executor seam, the pure send reducer, and the conformance suite.
- `msquic-h3/src/error.rs` — scoped terminal enums, adapter-owned error types, the
  msquic→h3 conversion table, and `clamp_application_code` (62-bit varint).
- `msquic-h3/src/buffer.rs` — owned `SendBuffer` replacing `pub H3Buff`.
- `msquic-h3/src/listener.rs`, `registration.rs` — borrow-before-own accept + poison-safe locks.
- `msquic-h3/src/attest.rs`, `msquic-h3/benches/send_copy.rs` — native-version attestation
  and the send-copy / aggregate-memory / latency measurement harness.
- `Cargo.toml`, `.github/workflows/build.yaml` — provenance feature matrix
  (`native-find`/`native-src`/`bench-internals`) and the reworked CI gate.
- `docs/error-propagation.md` — appendix scaffold removed (invariants promoted to the
  narrative); `docs/Development.md`, `CHANGELOG.md` — supported matrix, attestation policy,
  measurements, and the 0.0.7 changelog.

## Testing

- **134 tests** pass: `cargo test --no-default-features --features native-find`
- `cargo clippy --all-targets --no-default-features --features native-find -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Conformance suite covers the error-mapping matrix, both-order reducer transitions,
  CountingExec exactly-once seam tests, and loopback tests (peer reset, STOP_SENDING,
  app-close, idle timeout, local cancellation, accepted-ID failpoint).
- Close-time inline-drain is labelled **source-review-only** (no drop-triggered teardown
  test is achievable via the public API).
- Reviewed by a 3-model final agent review (gpt-5.6-sol, gemini-3.1-pro, opus-4.8) — all
  findings resolved.

## Breaking Changes (0.0.6 → 0.0.7)

- **Removed** `pub H3Buff` (replaced by the internal owned `SendBuffer`).
- **New** oversized-send rejection above `MAX_ADAPTER_SEND` (16 MiB, provisional).
- **Changed** terminal/error classifications (peer reset → `StreamTerminated`, real
  connection-close causes, `STOP_SENDING` observable, empty-non-FIN no longer EOF).

Migration and rollback (revert to 0.0.6) notes are in `CHANGELOG.md`.

## Deferred (tracked)

- Ratifying the final send ceiling / switching to chunking (ships provisional at 16 MiB;
  Phase 9 recorded aggregate-memory ≈ 4.29 GB at 256×16 MiB and latency evidence).
- Prerelease validation against a downstream h3 example (non-blocking at 0.0.x).
- Windows native-version attestation (loaded-module digest not yet implemented — Windows is
  compile/test-only, outside the SC-012 attested matrix).

## Artifacts

Workflow artifacts (Spec, CodeResearch, ImplementationPlan, Docs) at
`tree/f93dbd5/.paw/work/error-propagation/`.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
