### PR TITLE
[OOM Budget Fixes] Configurable memory budgets: receive unit-count guard + tunable per-send ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ where every `0.0.z` bump may contain breaking changes.
 
 ## [Unreleased]
 
-Post-`0.0.7` crate-review fixes. No public API break: the adapter surface is
-unchanged and these are behavioral/robustness corrections plus test and
-packaging hardening.
+Post-`0.0.7` crate-review fixes. No breaking public API change: existing
+constructors and the adapter surface keep their signatures and behavior. This
+release does **add** an additive public configuration API (see **Added** —
+`H3Config` plus two `*_with_config` constructors); the additions are opt-in and
+existing call sites are unaffected. The remaining changes are behavioral/
+robustness corrections plus test and packaging hardening.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,21 @@ packaging hardening.
 
 ### Added
 
+- **Configurable memory budgets (`H3Config`).** A new public `H3Config`
+  (with `H3ConfigBuilder` and `ConfigError`) carries validated per-stream
+  budgets — `max_send_bytes` (default 16 MiB), `max_recv_bytes` (default 1 MiB),
+  and a new `max_recv_units` (default 16384) — supplied at construction via the
+  additive `Connection::connect_with_config` / `Listener::with_config`; the
+  existing `Connection::connect` / `Listener::new` apply the defaults unchanged.
+  The receive path now enforces a per-stream **unit-count** budget alongside the
+  byte budget, so the callback returns `QUIC_STATUS_PENDING` when either bound is
+  reached — closing a paced-tiny-frame allocation-amplification OOM (a 1-byte-
+  paced peer is bounded to ≤ 16384 buffered units/stream instead of ~1,048,576).
+  The send side has no aggregate cap (the h3 trait contract calls the synchronous
+  `send_data` before its only async readiness hook, so a send cannot be deferred
+  as backpressure); per-connection send memory scales as
+  `max_send_bytes × concurrent streams`, documented with a recommendation to cap
+  concurrent streams at the application level.
 - **docs.rs metadata + provenance policy.** `[package.metadata.docs.rs]` pins
   the `native-src` provenance and `--cfg docsrs` for a self-contained doc build.
   Selecting neither provenance is a supported type-check-only configuration (no

--- a/README.md
+++ b/README.md
@@ -26,5 +26,29 @@ pwsh 7 packages the msquic.dll. If you install pwsh 7, rust will load it from th
 ## Other
 You can download msquic from github release [here](https://github.com/microsoft/msquic/releases) and put the lib to locations where app can load it.
 
+# Configuring memory budgets
+The adapter bounds per-stream memory with fixed finite defaults (16 MiB per send,
+1 MiB and 16384 buffered units per receive stream). Existing `Connection::connect`
+/ `Listener::new` callers get these defaults automatically. To tune them, build an
+`H3Config` and use the additive `*_with_config` constructors:
+
+```rust,ignore
+use msquic_h3::{Connection, H3Config};
+
+let cfg = H3Config::builder()
+    .with_max_send_bytes(4 * 1024 * 1024) // 4 MiB per send (default 16 MiB)
+    .with_max_recv_bytes(512 * 1024)      // 512 KiB per stream (default 1 MiB)
+    .with_max_recv_units(4096)            // buffered units per stream (default 16384)
+    .build()?;
+
+let conn = Connection::connect_with_config(&reg, &config, "example.com", 443, cfg).await?;
+// server side: Listener::with_config(&reg, config, &alpn, Some(addr), cfg)?;
+```
+
+The receive caps are enforced as backpressure. The send side has no aggregate
+cap: per-connection send memory scales as `max_send_bytes × concurrent streams`,
+so bound it by choosing `max_send_bytes` and limiting concurrent streams at the
+application level. See [`docs/receive-and-send.md`](./docs/receive-and-send.md).
+
 # License
 This project is licensed under the MIT license.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,6 +53,7 @@ lives in the sibling modules below.
 | `stream` (`../msquic-h3/src/stream.rs`) | The stream types (`H3Stream`/`H3SendStream`/`H3RecvStream`), the send/receive exec seams, the owned-send buffer transfer, receive backpressure, the stream FFI callback, and the stream h3 trait impls. |
 | `error` (`../msquic-h3/src/error.rs`) | Adapter error vocabulary, the scoped terminal enums, the h3-conversion helpers, and the pure send reducer `transition()`. |
 | `buffer` (`../msquic-h3/src/buffer.rs`) | The owned send payload (`SendBuffer`), send-length classification, and the single production copy path. |
+| `config` (`../msquic-h3/src/config.rs`) | The public, validated memory-budget configuration `H3Config` (with `H3ConfigBuilder` and `ConfigError`): the per-send-size ceiling and the per-stream receive byte/unit caps, threaded from construction into every connection and stream. |
 | `listener` (`../msquic-h3/src/listener.rs`) | The server-side `Listener` plus the listener FFI callback and its ownership-aware recovery. |
 | `registration` (`../msquic-h3/src/registration.rs`) | `Registration`, rundown tracking (`RundownState`/`RundownGuard`), and the `WaitIdle` future. |
 | `attest` (`../msquic-h3/src/attest.rs`, test-only) | Runtime native-library version / git-hash / digest attestation gate. |
@@ -74,6 +75,16 @@ The public surface is intentionally small. Types come from the modules noted:
   *not* an h3 trait impl; it produces `Connection`s that are.
 - **Registration**: `Registration` and `WaitIdle`
   (`../msquic-h3/src/registration.rs`).
+- **Configuration**: `H3Config`, `H3ConfigBuilder`, and `ConfigError`
+  (`../msquic-h3/src/config.rs`) — the validated memory budgets (per-send-size
+  ceiling, per-stream receive byte and unit caps). Supplied at construction via
+  the additive `Connection::connect_with_config` / `Listener::with_config`; the
+  existing `Connection::connect` / `Listener::new` apply `H3Config::default()`.
+  The config rides the **dual per-connection carrier** — it is stored on both
+  `ConnHandle` (read by locally-opened streams via `StreamOpener`) and the
+  callback-side `ConnCtxSender` (read in the `PeerStreamStarted` arm), so it
+  reaches both locally-opened and peer-accepted streams, mirroring the terminal
+  slot.
 - **Error types**: the adapter-owned `MsQuicTransportError`, `LocalConnectionClose`,
   `LocalStreamReset`, and `OversizedSend` (`../msquic-h3/src/error.rs`), described
   in the [error model](./error-model.md).

--- a/docs/receive-and-send.md
+++ b/docs/receive-and-send.md
@@ -37,10 +37,14 @@ than per-connection. The resulting connection memory bound is approximately
 `(MAX_RECV_BUFFER + one in-flight indication) × max concurrent streams`, with the
 unit count similarly bounded by `max_recv_units × max concurrent streams`.
 
-Frames of at least `F = 128` bytes bind on the **byte** budget first — the byte
-total reaches `max_recv_bytes` before the unit count reaches `max_recv_units`, so
-the unit cap never becomes the binding limit for realistic frame sizes and there
-is no behavior change for frames ≥ F.
+With the **default** `1 MiB` / `16384`-unit pair, frames of at least `F = 128`
+bytes bind on the **byte** budget first — the byte total reaches
+`max_recv_bytes` before the unit count reaches `max_recv_units`, so the unit cap
+never becomes the binding limit for realistic frame sizes and there is no
+behavior change for frames ≥ F. This "byte-budget-binds-first" property is a
+consequence of the default pair (`16384 × 128 > 1 MiB`), **not** an unconditional
+guarantee: a custom configuration such as `max_recv_units = 1` with a large
+`max_recv_bytes` would deliberately bind on the unit cap instead.
 
 ### The budget state machine
 

--- a/docs/receive-and-send.md
+++ b/docs/receive-and-send.md
@@ -14,26 +14,55 @@ between h3 polls. The adapter enforces a per-stream budget so a stalled reader
 pauses only its own stream, and the connection's total receive memory is bounded
 by the number of concurrent streams.
 
-`MAX_RECV_BUFFER` is `1 MiB` per stream (`../msquic-h3/src/stream.rs`). Returning
-`QUIC_STATUS_PENDING` from a receive callback pauses delivery for *that stream
-only*, which is why the budget is per-stream rather than per-connection. The
-resulting connection memory bound is approximately
-`(MAX_RECV_BUFFER + one in-flight indication) × max concurrent streams`.
+The receive path enforces **two** per-stream caps together — a **byte** budget
+and a **unit-count** budget — and pauses the stream when *either* is reached:
+
+- `MAX_RECV_BUFFER` is `1 MiB` per stream (`../msquic-h3/src/stream.rs`), the
+  default `max_recv_bytes`. It bounds the undrained received **bytes**.
+- `DEFAULT_MAX_RECV_UNITS` is `16384` per stream, the default `max_recv_units`.
+  It bounds the number of undrained buffered **units** (one heap allocation /
+  queue node per admitted non-empty indication). The byte budget alone does not
+  bound this: because msquic's coalescing of small frames is a defeatable
+  arrival-timing optimization (not a contract), a peer that paces tiny (e.g.
+  1-byte) frames would otherwise force roughly one allocation per byte — on the
+  order of a million buffered units for 1 MiB of accounted payload. The
+  unit-count cap closes that allocation-amplification vector; a paced-1-byte peer
+  is bounded to ≤ `max_recv_units` buffered units per stream.
+
+Both caps are configurable through [`H3Config`](../msquic-h3/src/config.rs) (see
+the [architecture](./architecture.md) module map); the defaults equal the
+constants above. Returning `QUIC_STATUS_PENDING` from a receive callback pauses
+delivery for *that stream only*, which is why the budget is per-stream rather
+than per-connection. The resulting connection memory bound is approximately
+`(MAX_RECV_BUFFER + one in-flight indication) × max concurrent streams`, with the
+unit count similarly bounded by `max_recv_units × max concurrent streams`.
+
+Frames of at least `F = 128` bytes bind on the **byte** budget first — the byte
+total reaches `max_recv_bytes` before the unit count reaches `max_recv_units`, so
+the unit cap never becomes the binding limit for realistic frame sizes and there
+is no behavior change for frames ≥ F.
 
 ### The budget state machine
 
-Per-stream accounting lives in `RecvState` (`buffered`, `pend_outstanding`,
-`pending_indication_len` — the full saved length of a paused indication — and a
-`peak` high-water mark) behind a single mutex, driven by `RecvBudget`:
+Per-stream accounting lives in `RecvState` (`buffered` bytes, `units`,
+`pend_outstanding`, `pending_indication_len` — the full saved length of a paused
+indication — and `peak` / `peak_units` high-water marks) behind a single mutex,
+driven by `RecvBudget` (which holds `max_bytes` and `max_units`):
 
 - **`admit`** runs on the callback side as one locked transition: increment the
-  buffered count, decide whether this indication must be paused, then publish the
-  data last. If publishing to the drain-visible queue fails, the increment is
-  rolled back. The decision is expressed by the `Admit` enum: `Accepted`, `Pend`
-  (over budget — pause this stream), or `PublishFailed` (rollback).
+  buffered byte count, charge one **unit** (only for a non-empty indication that
+  will enqueue a `Data` event — an empty indication charges none), decide whether
+  this indication must be paused (`buffered >= max_bytes || units >= max_units`),
+  then publish the data last. If publishing to the drain-visible queue fails, the
+  whole transition — bytes, unit charge, both peak watermarks, and the pend
+  fields — is rolled back, so a failed publish never leaks a unit charge. The
+  decision is expressed by the `Admit` enum: `Accepted`, `Pend` (over budget —
+  pause this stream), or `PublishFailed` (rollback).
 - **`on_drained`** runs on the drain side when h3 consumes data: decrement the
-  buffered count and, if a pause is outstanding and the budget has recovered,
-  clear the pause and return the full saved length so the stream can be re-armed.
+  buffered byte count and release exactly one unit (each delivered `Data` event
+  consumed exactly one queued unit) and, if a pause is outstanding and **both**
+  budgets have recovered (`buffered < max_bytes && units < max_units`), clear the
+  pause and return the full saved length so the stream can be re-armed.
 
 Accounting happens *before* the data is made drain-visible, so the budget can
 never be undercounted by a publish that races the drain.
@@ -81,13 +110,15 @@ self-referential native `BufferRef` that points into it. It carries an
 completes the send on an arbitrary thread.
 
 A payload is classified before any allocation. `classify_send_len` maps the
-`remaining()` length to `SendLen::{Empty, NonEmpty, Oversized}` against
-`MAX_ADAPTER_SEND`, the provisional `16 MiB` per-`send_data` ceiling
-(`../msquic-h3/src/error.rs`). The split is against this ceiling — not the raw
-`u32` protocol maximum — so the adapter never materializes a near-`u32::MAX` owned
-copy just to have msquic reject the aggregate; an oversized request is rejected up
-front with `OversizedSend`. Because the ceiling is below `u32::MAX`, every accepted
-length fits the native `BufferRef`'s `u32`.
+`remaining()` length to `SendLen::{Empty, NonEmpty, Oversized}` against the
+configured `max_send_bytes` ceiling — `MAX_ADAPTER_SEND` (`16 MiB`,
+`../msquic-h3/src/error.rs`) by default, or the value supplied via
+[`H3Config`](../msquic-h3/src/config.rs). The split is against this ceiling — not
+the raw `u32` protocol maximum — so the adapter never materializes a
+near-`u32::MAX` owned copy just to have msquic reject the aggregate; an oversized
+request is rejected up front with `OversizedSend`. Because the ceiling is
+constrained below `u32::MAX` (config validation rejects `max_send_bytes >=
+u32::MAX`), every accepted length fits the native `BufferRef`'s `u32`.
 
 There is exactly **one** production copy path: `copy_into_send_buffer`, a single
 `copy_to_bytes(remaining)`. It is called from `send_data` (with h3's `WriteBuf`)
@@ -117,10 +148,26 @@ a finish has started resolves from state without consuming the shared send chann
 
 ### A note on aggregate memory
 
-The `16 MiB` ceiling bounds a *single* `send_data` call, not the sum of
-concurrently outstanding sends. The unbounded-aggregate concern (many large sends
-in flight at once) is documented in the send-copy benchmark header and is not
-enforced by the adapter today; the ceiling is marked provisional for this reason.
+The `max_send_bytes` ceiling (default `16 MiB`) bounds a *single* `send_data`
+call, not the sum of concurrently outstanding sends. The adapter holds at most
+one outstanding owned send copy per stream, so per-connection resident send
+memory scales as approximately `concurrent-in-flight-streams × max_send_bytes`.
+
+The adapter does **not** enforce an aggregate send budget, and this is a
+constraint of the h3 trait contract rather than an omission. h3 (0.0.8) calls the
+synchronous `send_data` — which copies and takes ownership of the payload and
+returns a `Result`, not a `Poll` — *before* awaiting the only asynchronous
+readiness hook, `poll_ready`. Since the copy has already happened by the time any
+async hook runs, the adapter cannot refuse or defer a send as backpressure, so an
+aggregate send budget is infeasible at the adapter layer.
+
+The mitigation is the configurable per-send ceiling plus this documented scaling:
+to bound per-connection send memory, choose a `max_send_bytes` appropriate to the
+workload (via [`H3Config`](../msquic-h3/src/config.rs)) and cap the number of
+concurrent streams at the **application** level — the adapter cannot cap stream
+concurrency itself. The receive side, by contrast, *is* under the adapter's
+control (the receive callback can return PENDING), which is why its byte and
+unit-count budgets are enforced as real backpressure.
 
 ## Related
 

--- a/msquic-h3/src/buffer.rs
+++ b/msquic-h3/src/buffer.rs
@@ -1,30 +1,32 @@
 use bytes::{Buf, Bytes};
 use msquic::BufferRef;
 
-use crate::error::MAX_ADAPTER_SEND;
-
 /// Classification of a `send_data` payload's `remaining()` length against the
-/// adapter's owned-copy ceiling ([`MAX_ADAPTER_SEND`]).
+/// adapter's owned-copy ceiling (a configured `max_send_bytes`, default
+/// [`MAX_ADAPTER_SEND`](crate::error::MAX_ADAPTER_SEND)).
 ///
-/// The split is against the ceiling, **not** the raw `u32` protocol maximum, so
-/// the adapter never materializes a near-`u32::MAX` owned buffer just to have
-/// MsQuic reject the aggregate. The classification is performed up front, before
-/// any allocation, so an oversized request is rejected without a copy.
+/// The split is against the configured ceiling, **not** the raw `u32` protocol
+/// maximum, so the adapter never materializes a near-`u32::MAX` owned buffer
+/// just to have MsQuic reject the aggregate. The classification is performed up
+/// front, before any allocation, so an oversized request is rejected without a
+/// copy.
 pub(crate) enum SendLen {
     /// Zero-length payload: a successful no-op — no allocation, no native send.
     Empty,
-    /// `0 < len <= MAX_ADAPTER_SEND`. The ceiling is below `u32::MAX`, so the
+    /// `0 < len <= ceiling`. The ceiling is below `u32::MAX`, so the
     /// materialized length always fits the `u32` a [`BufferRef`] carries.
     NonEmpty,
-    /// `len > MAX_ADAPTER_SEND`: reject with `OversizedSend` before any allocation.
+    /// `len > ceiling`: reject with `OversizedSend` before any allocation.
     Oversized,
 }
 
-/// Classify a payload length against [`MAX_ADAPTER_SEND`] before any allocation.
-pub(crate) fn classify_send_len(remaining: usize) -> SendLen {
+/// Classify a payload length against the configured `ceiling` (in bytes) before
+/// any allocation. The caller sources `ceiling` from the connection's
+/// `H3Config` (default [`MAX_ADAPTER_SEND`](crate::error::MAX_ADAPTER_SEND)).
+pub(crate) fn classify_send_len(remaining: usize, ceiling: u64) -> SendLen {
     if remaining == 0 {
         SendLen::Empty
-    } else if remaining as u64 > MAX_ADAPTER_SEND {
+    } else if remaining as u64 > ceiling {
         SendLen::Oversized
     } else {
         SendLen::NonEmpty
@@ -85,14 +87,16 @@ const _: fn() = || {
 impl SendBuffer {
     /// Materialize a validated, non-empty payload into an owned `SendBuffer`.
     ///
-    /// `bytes` must be non-empty and no longer than [`MAX_ADAPTER_SEND`] (both
-    /// already guaranteed by [`classify_send_len`] at the call site), so the
-    /// `usize as u32` length cast inside `BufferRef::from` never truncates.
+    /// `bytes` must be non-empty and no longer than the caller's configured send
+    /// ceiling (already guaranteed by [`classify_send_len`] at the call site).
+    /// Because every valid `H3Config` ceiling is `< u32::MAX`, the payload here
+    /// is always `< u32::MAX`, so the `usize as u32` length cast inside
+    /// `BufferRef::from` never truncates.
     pub(crate) fn new(bytes: Bytes) -> Self {
         debug_assert!(!bytes.is_empty(), "SendBuffer requires a non-empty payload");
         debug_assert!(
-            bytes.len() as u64 <= MAX_ADAPTER_SEND,
-            "SendBuffer length must be within MAX_ADAPTER_SEND"
+            (bytes.len() as u64) < u32::MAX as u64,
+            "SendBuffer length must fit a u32 BufferRef"
         );
         // Build the `BufferRef` from the heap slice *before* moving `bytes` into
         // the struct. The pointer targets the heap allocation, which does not move
@@ -120,7 +124,7 @@ impl SendBuffer {
 /// bench calls it with `&[u8]`; both implement [`Buf`], so both drive the
 /// identical `src.copy_to_bytes(remaining)` allocation — the benchmark measures
 /// the exact production copy, not a second implementation. The caller must have
-/// already classified the payload as non-empty and within [`MAX_ADAPTER_SEND`]
+/// already classified the payload as non-empty and within [`MAX_ADAPTER_SEND`](crate::error::MAX_ADAPTER_SEND)
 /// (via [`classify_send_len`]), matching [`SendBuffer::new`]'s contract.
 ///
 /// The helper is `pub` (inside the crate-private `mod buffer`) so a gated
@@ -162,14 +166,41 @@ mod test {
 
     #[test]
     fn classify_send_len_boundaries() {
-        assert!(matches!(classify_send_len(0), SendLen::Empty));
-        assert!(matches!(classify_send_len(1), SendLen::NonEmpty));
         assert!(matches!(
-            classify_send_len(MAX_ADAPTER_SEND as usize),
+            classify_send_len(0, MAX_ADAPTER_SEND),
+            SendLen::Empty
+        ));
+        assert!(matches!(
+            classify_send_len(1, MAX_ADAPTER_SEND),
             SendLen::NonEmpty
         ));
         assert!(matches!(
-            classify_send_len(MAX_ADAPTER_SEND as usize + 1),
+            classify_send_len(MAX_ADAPTER_SEND as usize, MAX_ADAPTER_SEND),
+            SendLen::NonEmpty
+        ));
+        assert!(matches!(
+            classify_send_len(MAX_ADAPTER_SEND as usize + 1, MAX_ADAPTER_SEND),
+            SendLen::Oversized
+        ));
+    }
+
+    #[test]
+    fn classify_send_len_honors_a_custom_ceiling() {
+        // A reduced ceiling C rejects payloads > C up front and accepts <= C,
+        // proving the send-size classification is config-driven (SC-001/SC-004).
+        let ceiling: u64 = 4096;
+        assert!(matches!(classify_send_len(0, ceiling), SendLen::Empty));
+        assert!(matches!(
+            classify_send_len(ceiling as usize, ceiling),
+            SendLen::NonEmpty
+        ));
+        assert!(matches!(
+            classify_send_len(ceiling as usize + 1, ceiling),
+            SendLen::Oversized
+        ));
+        // A payload the DEFAULT ceiling would accept is oversized under C.
+        assert!(matches!(
+            classify_send_len(MAX_ADAPTER_SEND as usize, ceiling),
             SendLen::Oversized
         ));
     }

--- a/msquic-h3/src/callback.rs
+++ b/msquic-h3/src/callback.rs
@@ -142,7 +142,7 @@ mod callback_safety {
 
     #[test]
     fn connection_callback_connected_with_dropped_receiver_is_noop() {
-        let (mut ctx, rx) = conn_ctx_channel();
+        let (mut ctx, rx) = conn_ctx_channel(crate::H3Config::default());
         // Frontend gone: the `Connected` one-shot receiver is dropped.
         drop(rx);
         let ev = ConnectionEvent::Connected {
@@ -323,7 +323,7 @@ mod callback_safety {
 
     #[test]
     fn connection_callback_panic_is_contained() {
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         let seam = RecordingSeam::default();
         // A panicking body is contained: process survives (test completes), the
         // connection is force-closed via the seam, and Err(INTERNAL_ERROR) returns.
@@ -362,7 +362,7 @@ mod callback_safety {
     fn connection_poison_short_circuit_is_event_aware() {
         // After a contained panic poisons the ctx, a teardown event short-circuits
         // to Ok (no-op) and a non-teardown (ownership-bearing) event to Err.
-        let (mut ctx, _crx) = conn_ctx_channel();
+        let (mut ctx, _crx) = conn_ctx_channel(crate::H3Config::default());
         let _ = guard_callback(
             &mut ctx,
             &RecordingSeam::default(),
@@ -416,7 +416,7 @@ mod callback_safety {
         // the ctx — so a task parked on the connect one-shot cannot hang. A
         // subsequent teardown then short-circuits to Ok WITHOUT re-running the
         // body, so Phase 2 terminal state is never double-completed.
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         let seam = RecordingSeam::default();
         let teardown = ConnectionEvent::ShutdownComplete {
             handshake_completed: false,
@@ -486,7 +486,7 @@ mod callback_safety {
         // native stream ownership, so no owned stand-in exists (close == 0) and
         // `connection_recover` returns Err — msquic performs the single stream
         // reject. The connection is still force-closed and its waiters woken.
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         let seam = RecordingSeam::default();
         // Per-invocation peer-stream ownership token, never shared with the ctx.
         let stream_owned = Cell::new(false);
@@ -538,7 +538,7 @@ mod callback_safety {
         // stream's Drop performs the single `StreamClose` (close == 1). msquic must
         // NOT re-close it, so `connection_recover` returns Ok (no double-close),
         // while still force-closing the CONNECTION and waking its waiters.
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         let seam = RecordingSeam::default();
         let stream_owned = Cell::new(false);
         let closes = Arc::new(AtomicUsize::new(0));
@@ -588,7 +588,8 @@ mod callback_safety {
 
     #[test]
     fn stream_callback_panic_is_contained() {
-        let (mut ctx, mut recv) = stream_ctx_channel_pre_id(new_conn_terminal_slot());
+        let (mut ctx, mut recv) =
+            stream_ctx_channel_pre_id(new_conn_terminal_slot(), crate::H3Config::default());
         let seam = RecordingSeam::default();
         let got = guard_callback(
             &mut ctx,
@@ -632,7 +633,8 @@ mod callback_safety {
 
     #[test]
     fn stream_poison_short_circuit_is_event_aware() {
-        let (mut ctx, _recv) = stream_ctx_channel_pre_id(new_conn_terminal_slot());
+        let (mut ctx, _recv) =
+            stream_ctx_channel_pre_id(new_conn_terminal_slot(), crate::H3Config::default());
         let _ = guard_callback(
             &mut ctx,
             &RecordingSeam::default(),
@@ -674,7 +676,8 @@ mod callback_safety {
         // waiter, and poisons the ctx — so no waiter hangs. A subsequent teardown
         // then short-circuits to Ok without re-running the body (no double
         // completion of Phase 2 send/receive terminal state).
-        let (mut ctx, mut recv) = stream_ctx_channel_pre_id(new_conn_terminal_slot());
+        let (mut ctx, mut recv) =
+            stream_ctx_channel_pre_id(new_conn_terminal_slot(), crate::H3Config::default());
         let seam = RecordingSeam::default();
         let teardown = StreamEvent::ShutdownComplete {
             connection_shutdown: false,

--- a/msquic-h3/src/config.rs
+++ b/msquic-h3/src/config.rs
@@ -33,6 +33,16 @@ pub(crate) const DEFAULT_MAX_RECV_UNITS: usize = 16384;
 /// Fields are private; construct via [`H3Config::default`] or
 /// [`H3Config::builder`]. All accessors are read-only, so a value cannot be
 /// mutated after construction.
+///
+/// The receive side is enforced per stream as real backpressure (both a byte
+/// budget and a unit-count budget). The **send** side is only bounded by
+/// `max_send_bytes` per outstanding send; there is no aggregate send cap, so
+/// per-connection send memory scales as `max_send_bytes × concurrent
+/// in-flight streams`. The adapter cannot enforce an aggregate send budget as
+/// backpressure because the h3 trait contract calls the synchronous
+/// `send_data` (which copies and takes ownership) before its only async
+/// readiness hook — applications that need to bound send memory should choose
+/// `max_send_bytes` and cap their concurrent stream count.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct H3Config {
     /// Maximum single `send_data` payload accepted before rejecting with

--- a/msquic-h3/src/config.rs
+++ b/msquic-h3/src/config.rs
@@ -1,0 +1,300 @@
+//! Public, validated memory-budget configuration for the adapter.
+//!
+//! [`H3Config`] carries the per-stream send-size ceiling, the per-stream
+//! receive-byte budget, and the per-stream receive-unit (allocation/message)
+//! cap. Its fields are **private** and can only be produced via [`Default`] or
+//! the validated [`H3ConfigBuilder`], so no invalid configuration is ever
+//! constructible by a literal or a field mutation. The defaults equal the
+//! adapter's historical hard-coded ceilings ([`MAX_ADAPTER_SEND`] for sends and
+//! [`MAX_RECV_BUFFER`] for receive bytes), so a default-configured adapter
+//! behaves exactly as before.
+//!
+//! The send side is bounded by `max_send_bytes × concurrent streams` (there is
+//! no aggregate/per-connection send budget — the h3 trait contract calls the
+//! synchronous `send_data` before the only async readiness hook, so a send
+//! cannot be deferred as backpressure); applications that need to bound send
+//! memory should also cap their concurrent stream count.
+
+use std::fmt;
+
+use crate::error::MAX_ADAPTER_SEND;
+use crate::stream::MAX_RECV_BUFFER;
+
+/// Default per-stream receive-unit (buffered allocation/message) cap.
+///
+/// Bounds the number of queued receive indications per stream, independently of
+/// their byte total, so a flood of tiny frames cannot amplify into unbounded
+/// per-stream allocations. The byte budget alone does not bound this.
+pub(crate) const DEFAULT_MAX_RECV_UNITS: usize = 16384;
+
+/// Validated, `Copy` memory-budget configuration threaded from connection /
+/// listener construction into every per-connection and per-stream state.
+///
+/// Fields are private; construct via [`H3Config::default`] or
+/// [`H3Config::builder`]. All accessors are read-only, so a value cannot be
+/// mutated after construction.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct H3Config {
+    /// Maximum single `send_data` payload accepted before rejecting with
+    /// `OversizedSend`. Must be non-zero and below `u32::MAX`.
+    max_send_bytes: u64,
+    /// Maximum undrained, adapter-buffered received bytes per stream before the
+    /// receive callback pends. Must be non-zero.
+    max_recv_bytes: usize,
+    /// Maximum buffered receive units (allocations/messages) per stream. Must be
+    /// non-zero.
+    max_recv_units: usize,
+}
+
+impl Default for H3Config {
+    fn default() -> Self {
+        Self {
+            max_send_bytes: MAX_ADAPTER_SEND,
+            max_recv_bytes: MAX_RECV_BUFFER,
+            max_recv_units: DEFAULT_MAX_RECV_UNITS,
+        }
+    }
+}
+
+impl H3Config {
+    /// Start building a validated [`H3Config`].
+    pub fn builder() -> H3ConfigBuilder {
+        H3ConfigBuilder::default()
+    }
+
+    /// Construct a validated [`H3Config`] directly from its three caps.
+    ///
+    /// Returns a [`ConfigError`] if any value is out of range (see
+    /// [`H3ConfigBuilder::build`]).
+    pub fn try_new(
+        max_send_bytes: u64,
+        max_recv_bytes: usize,
+        max_recv_units: usize,
+    ) -> Result<Self, ConfigError> {
+        validate(max_send_bytes, max_recv_bytes, max_recv_units)
+    }
+
+    /// Maximum single `send_data` payload accepted before rejecting with
+    /// `OversizedSend`.
+    pub fn max_send_bytes(&self) -> u64 {
+        self.max_send_bytes
+    }
+
+    /// Maximum undrained, adapter-buffered received bytes per stream before the
+    /// receive callback pends.
+    pub fn max_recv_bytes(&self) -> usize {
+        self.max_recv_bytes
+    }
+
+    /// Maximum buffered receive units (allocations/messages) per stream.
+    pub fn max_recv_units(&self) -> usize {
+        self.max_recv_units
+    }
+}
+
+/// Chainable builder for a validated [`H3Config`].
+///
+/// Each `with_*` setter overrides one cap; unset caps keep their default. The
+/// terminal [`build`](H3ConfigBuilder::build) validates all three and yields a
+/// [`ConfigError`] on the first out-of-range value.
+#[derive(Copy, Clone, Debug)]
+pub struct H3ConfigBuilder {
+    max_send_bytes: u64,
+    max_recv_bytes: usize,
+    max_recv_units: usize,
+}
+
+impl Default for H3ConfigBuilder {
+    fn default() -> Self {
+        let d = H3Config::default();
+        Self {
+            max_send_bytes: d.max_send_bytes,
+            max_recv_bytes: d.max_recv_bytes,
+            max_recv_units: d.max_recv_units,
+        }
+    }
+}
+
+impl H3ConfigBuilder {
+    /// Override the per-send-size ceiling.
+    pub fn with_max_send_bytes(mut self, max_send_bytes: u64) -> Self {
+        self.max_send_bytes = max_send_bytes;
+        self
+    }
+
+    /// Override the per-stream receive-byte budget.
+    pub fn with_max_recv_bytes(mut self, max_recv_bytes: usize) -> Self {
+        self.max_recv_bytes = max_recv_bytes;
+        self
+    }
+
+    /// Override the per-stream receive-unit cap.
+    pub fn with_max_recv_units(mut self, max_recv_units: usize) -> Self {
+        self.max_recv_units = max_recv_units;
+        self
+    }
+
+    /// Validate the accumulated caps and produce an [`H3Config`].
+    ///
+    /// Rejects `max_send_bytes == 0` or `>= u32::MAX`
+    /// ([`ConfigError::SendSize`]), `max_recv_bytes == 0`
+    /// ([`ConfigError::RecvBytes`]), and `max_recv_units == 0`
+    /// ([`ConfigError::RecvUnits`]).
+    pub fn build(self) -> Result<H3Config, ConfigError> {
+        validate(
+            self.max_send_bytes,
+            self.max_recv_bytes,
+            self.max_recv_units,
+        )
+    }
+}
+
+/// Shared validation for [`H3ConfigBuilder::build`] and [`H3Config::try_new`].
+fn validate(
+    max_send_bytes: u64,
+    max_recv_bytes: usize,
+    max_recv_units: usize,
+) -> Result<H3Config, ConfigError> {
+    if max_send_bytes == 0 || max_send_bytes >= u32::MAX as u64 {
+        return Err(ConfigError::SendSize);
+    }
+    if max_recv_bytes == 0 {
+        return Err(ConfigError::RecvBytes);
+    }
+    if max_recv_units == 0 {
+        return Err(ConfigError::RecvUnits);
+    }
+    Ok(H3Config {
+        max_send_bytes,
+        max_recv_bytes,
+        max_recv_units,
+    })
+}
+
+/// A rejected [`H3Config`] cap value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ConfigError {
+    /// `max_send_bytes` was zero or `>= u32::MAX` (the native send-length
+    /// ceiling, above which a `BufferRef` length would truncate).
+    SendSize,
+    /// `max_recv_bytes` was zero (a stream could never buffer any receive data).
+    RecvBytes,
+    /// `max_recv_units` was zero (a stream could never buffer any receive unit).
+    RecvUnits,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::SendSize => write!(
+                f,
+                "max_send_bytes must be non-zero and less than u32::MAX ({})",
+                u32::MAX
+            ),
+            ConfigError::RecvBytes => write!(f, "max_recv_bytes must be non-zero"),
+            ConfigError::RecvUnits => write!(f, "max_recv_units must be non-zero"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{ConfigError, DEFAULT_MAX_RECV_UNITS, H3Config};
+    use crate::error::MAX_ADAPTER_SEND;
+    use crate::stream::MAX_RECV_BUFFER;
+
+    #[test]
+    fn defaults_equal_the_historical_constants() {
+        let c = H3Config::default();
+        assert_eq!(c.max_send_bytes(), MAX_ADAPTER_SEND);
+        assert_eq!(c.max_recv_bytes(), MAX_RECV_BUFFER);
+        assert_eq!(c.max_recv_units(), DEFAULT_MAX_RECV_UNITS);
+        assert_eq!(c.max_recv_units(), 16384);
+    }
+
+    #[test]
+    fn builder_defaults_match_default() {
+        let built = H3Config::builder().build().unwrap();
+        let def = H3Config::default();
+        assert_eq!(built.max_send_bytes(), def.max_send_bytes());
+        assert_eq!(built.max_recv_bytes(), def.max_recv_bytes());
+        assert_eq!(built.max_recv_units(), def.max_recv_units());
+    }
+
+    #[test]
+    fn valid_builder_round_trips_accessors() {
+        let c = H3Config::builder()
+            .with_max_send_bytes(4096)
+            .with_max_recv_bytes(8192)
+            .with_max_recv_units(7)
+            .build()
+            .unwrap();
+        assert_eq!(c.max_send_bytes(), 4096);
+        assert_eq!(c.max_recv_bytes(), 8192);
+        assert_eq!(c.max_recv_units(), 7);
+    }
+
+    #[test]
+    fn try_new_round_trips() {
+        let c = H3Config::try_new(4096, 8192, 7).unwrap();
+        assert_eq!(c.max_send_bytes(), 4096);
+        assert_eq!(c.max_recv_bytes(), 8192);
+        assert_eq!(c.max_recv_units(), 7);
+    }
+
+    #[test]
+    fn zero_send_size_is_rejected() {
+        assert_eq!(
+            H3Config::builder().with_max_send_bytes(0).build(),
+            Err(ConfigError::SendSize)
+        );
+    }
+
+    #[test]
+    fn send_size_at_or_above_u32_max_is_rejected() {
+        assert_eq!(
+            H3Config::builder()
+                .with_max_send_bytes(u32::MAX as u64)
+                .build(),
+            Err(ConfigError::SendSize)
+        );
+        assert_eq!(
+            H3Config::builder()
+                .with_max_send_bytes(u32::MAX as u64 + 1)
+                .build(),
+            Err(ConfigError::SendSize)
+        );
+        // One below u32::MAX is the largest accepted ceiling.
+        assert!(
+            H3Config::builder()
+                .with_max_send_bytes(u32::MAX as u64 - 1)
+                .build()
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn zero_recv_bytes_is_rejected() {
+        assert_eq!(
+            H3Config::builder().with_max_recv_bytes(0).build(),
+            Err(ConfigError::RecvBytes)
+        );
+    }
+
+    #[test]
+    fn zero_recv_units_is_rejected() {
+        assert_eq!(
+            H3Config::builder().with_max_recv_units(0).build(),
+            Err(ConfigError::RecvUnits)
+        );
+    }
+
+    #[test]
+    fn config_error_displays_a_message_per_variant() {
+        assert!(!ConfigError::SendSize.to_string().is_empty());
+        assert!(!ConfigError::RecvBytes.to_string().is_empty());
+        assert!(!ConfigError::RecvUnits.to_string().is_empty());
+    }
+}

--- a/msquic-h3/src/config.rs
+++ b/msquic-h3/src/config.rs
@@ -4,10 +4,13 @@
 //! receive-byte budget, and the per-stream receive-unit (allocation/message)
 //! cap. Its fields are **private** and can only be produced via [`Default`] or
 //! the validated [`H3ConfigBuilder`], so no invalid configuration is ever
-//! constructible by a literal or a field mutation. The defaults equal the
-//! adapter's historical hard-coded ceilings ([`MAX_ADAPTER_SEND`] for sends and
-//! [`MAX_RECV_BUFFER`] for receive bytes), so a default-configured adapter
-//! behaves exactly as before.
+//! constructible by a literal or a field mutation. The defaults preserve the
+//! adapter's historical send ceiling ([`MAX_ADAPTER_SEND`]) and receive-**byte**
+//! budget ([`MAX_RECV_BUFFER`]) while **adding** a protective receive-unit cap
+//! ([`DEFAULT_MAX_RECV_UNITS`], 16384). A default-configured adapter therefore
+//! keeps the prior send and receive-byte behavior, but the new unit cap does
+//! bound highly fragmented tiny-frame input that was previously unbounded — that
+//! is the point of the cap.
 //!
 //! The send side is bounded by `max_send_bytes × concurrent streams` (there is
 //! no aggregate/per-connection send budget — the h3 trait contract calls the

--- a/msquic-h3/src/conformance.rs
+++ b/msquic-h3/src/conformance.rs
@@ -11,7 +11,7 @@ use msquic::{
 };
 
 use crate::test::util::{get_test_cred, try_setup_tracing};
-use crate::{Connection, H3_INTERNAL_ERROR, H3Stream, Listener, Registration};
+use crate::{Connection, H3_INTERNAL_ERROR, H3Config, H3Stream, Listener, Registration};
 
 // ── poll_fn adapters over the &mut self trait methods (buffer type = Bytes) ──
 
@@ -73,6 +73,23 @@ where
     F: FnOnce(Connection, Connection) -> Fut,
     Fut: std::future::Future<Output = ()>,
 {
+    run_loopback_with_configs(idle_ms, H3Config::default(), H3Config::default(), body)
+}
+
+/// Like [`run_loopback`] but threads an explicit server-side ([`Listener`]) and
+/// client-side ([`Connection`]) [`H3Config`] through the REAL public
+/// constructors (`Listener::with_config` / `Connection::connect_with_config`),
+/// so a test can assert the configured caps emerge on live peer-accepted and
+/// locally-opened streams after the actual hand-off chain.
+fn run_loopback_with_configs<F, Fut>(
+    idle_ms: u64,
+    server_h3: H3Config,
+    client_h3: H3Config,
+    body: F,
+) where
+    F: FnOnce(Connection, Connection) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
     try_setup_tracing();
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -99,11 +116,12 @@ where
         server_config.load_credential(&cred_config).unwrap();
         let server_config = Arc::new(server_config);
 
-        let mut listener = Listener::new(
+        let mut listener = Listener::with_config(
             &reg,
             server_config.clone(),
             &alpn,
             Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)),
+            server_h3,
         )
         .unwrap();
         // Ephemeral port assigned by ListenerStart; read it back so the client
@@ -125,7 +143,7 @@ where
         // single-threaded runtime; msquic worker threads fire the callbacks.
         let (accepted, connected) = tokio::join!(
             listener.accept(),
-            Connection::connect(&reg, &client_config, "127.0.0.1", port),
+            Connection::connect_with_config(&reg, &client_config, "127.0.0.1", port, client_h3),
         );
         let server = accepted.expect("server accept ok").expect("a connection");
         let client = connected.expect("client connect ok");
@@ -460,7 +478,108 @@ fn accepted_stream_id_failpoint_rejects_and_closes_h3_internal_error() {
     });
 }
 
-/// SC-007 labelled marker (NON-executable): the close-time inline
+/// SC-006 / FR-009 / FR-010 (end-to-end): a custom `H3Config` threaded through
+/// the REAL public constructors (`Listener::with_config` +
+/// `Connection::connect_with_config`) reaches BOTH a peer-accepted stream on the
+/// server and a locally-opened stream on the client — executing the actual
+/// `PeerStreamStarted` → `H3Stream::attach` → `finalize` (accepted) and
+/// `open_and_start` (locally-opened) hand-offs, not just the shared seam helper.
+/// The live stream budgets are read straight off each stream's `RecvBudget` /
+/// send ceiling via the crate-private test accessors.
+#[test]
+fn custom_config_threads_through_real_loopback() {
+    let custom = H3Config::builder()
+        .with_max_send_bytes(1 << 20) // 1 MiB (!= 16 MiB default)
+        .with_max_recv_bytes(512 * 1024) // 512 KiB (!= 1 MiB default)
+        .with_max_recv_units(4096) // (!= 16384 default)
+        .build()
+        .unwrap();
+
+    run_loopback_with_configs(5_000, custom, custom, |mut server, mut client| async move {
+        let (cs, ss) = establish_bidi(&mut client, &mut server, b"ping").await;
+
+        // Peer-ACCEPTED stream on the server inherits the listener's config.
+        assert_eq!(
+            ss.recv_budget_caps(),
+            (custom.max_recv_bytes(), custom.max_recv_units()),
+            "accepted stream must carry the listener's custom recv caps"
+        );
+        assert_eq!(
+            ss.max_send_bytes(),
+            custom.max_send_bytes(),
+            "accepted stream must carry the listener's custom send ceiling"
+        );
+
+        // Locally-OPENED stream on the client inherits the connection's config.
+        assert_eq!(
+            cs.recv_budget_caps(),
+            (custom.max_recv_bytes(), custom.max_recv_units()),
+            "locally-opened stream must carry the connection's custom recv caps"
+        );
+        assert_eq!(
+            cs.max_send_bytes(),
+            custom.max_send_bytes(),
+            "locally-opened stream must carry the connection's custom send ceiling"
+        );
+
+        drop(cs);
+        drop(ss);
+        drop(server);
+        drop(client);
+    });
+}
+
+/// SC-006 isolation: two connections built with DIFFERENT configs (the server
+/// listener vs. the client) produce streams that carry their OWN respective caps
+/// — no cross-talk. The server's peer-accepted stream reflects the server
+/// config; the client's locally-opened stream reflects the (distinct) client
+/// config.
+#[test]
+fn distinct_connection_configs_do_not_cross_talk() {
+    let server_h3 = H3Config::builder()
+        .with_max_send_bytes(2 << 20)
+        .with_max_recv_bytes(256 * 1024)
+        .with_max_recv_units(1024)
+        .build()
+        .unwrap();
+    let client_h3 = H3Config::builder()
+        .with_max_send_bytes(5 << 20)
+        .with_max_recv_bytes(768 * 1024)
+        .with_max_recv_units(2048)
+        .build()
+        .unwrap();
+    assert_ne!(server_h3, client_h3, "the two configs must differ");
+
+    run_loopback_with_configs(
+        5_000,
+        server_h3,
+        client_h3,
+        |mut server, mut client| async move {
+            let (cs, ss) = establish_bidi(&mut client, &mut server, b"ping").await;
+
+            // Server accepted stream → server config only.
+            assert_eq!(
+                ss.recv_budget_caps(),
+                (server_h3.max_recv_bytes(), server_h3.max_recv_units()),
+                "accepted stream must reflect ONLY the server config"
+            );
+            assert_eq!(ss.max_send_bytes(), server_h3.max_send_bytes());
+
+            // Client local stream → client config only (no cross-talk).
+            assert_eq!(
+                cs.recv_budget_caps(),
+                (client_h3.max_recv_bytes(), client_h3.max_recv_units()),
+                "locally-opened stream must reflect ONLY the client config"
+            );
+            assert_eq!(cs.max_send_bytes(), client_h3.max_send_bytes());
+
+            drop(cs);
+            drop(ss);
+            drop(server);
+            drop(client);
+        },
+    );
+}
 /// `SendComplete` drain performed by native `QuicStreamClose` has **no**
 /// drop-triggered teardown test — the public API cannot hold a real send
 /// observably outstanding across the close, so that path is exercised by

--- a/msquic-h3/src/connection.rs
+++ b/msquic-h3/src/connection.rs
@@ -28,10 +28,10 @@ use msquic::{
 use crate::error::{ConnectionTerminal, convert_conn};
 use crate::registration::{Registration, RundownGuard};
 use crate::{
-    CbClass, ConnTerminalSlot, ConnTerminalState, ForceShutdown, H3_INTERNAL_ERROR, H3RecvStream,
-    H3SendStream, H3Stream, PoisonFlag, ShutdownSeam, StreamOpener, classify_transport,
-    commit_conn, guard_callback, internal_error_status, lock_recover, record_conn_terminal,
-    report_contained_panic,
+    CbClass, ConnTerminalSlot, ConnTerminalState, ForceShutdown, H3_INTERNAL_ERROR, H3Config,
+    H3RecvStream, H3SendStream, H3Stream, PoisonFlag, ShutdownSeam, StreamOpener,
+    classify_transport, commit_conn, guard_callback, internal_error_status, lock_recover,
+    record_conn_terminal, report_contained_panic,
 };
 
 /// Owns the raw msquic connection handle together with its [`RundownGuard`].
@@ -48,6 +48,9 @@ pub(crate) struct ConnHandle {
     /// context so the stream opener (`OpenStreams::close`) can record a local
     /// close through the borrowed handle.
     terminal: ConnTerminalSlot,
+    /// Per-connection memory-budget configuration (Copy). Read by the
+    /// [`StreamOpener`] so locally-opened streams inherit the connection's caps.
+    config: H3Config,
     _guard: RundownGuard,
 }
 
@@ -56,10 +59,12 @@ impl ConnHandle {
         inner: msquic::Connection,
         guard: RundownGuard,
         terminal: ConnTerminalSlot,
+        config: H3Config,
     ) -> Self {
         Self {
             inner,
             terminal,
+            config,
             _guard: guard,
         }
     }
@@ -67,6 +72,11 @@ impl ConnHandle {
     /// The shared connection terminal-reason slot.
     pub(crate) fn terminal(&self) -> &ConnTerminalSlot {
         &self.terminal
+    }
+
+    /// The per-connection memory-budget configuration.
+    pub(crate) fn config(&self) -> H3Config {
+        self.config
     }
 }
 
@@ -93,6 +103,10 @@ pub(crate) struct ConnCtxSender {
     pub(crate) uni: Option<mpsc::UnboundedSender<Option<crate::H3Stream>>>,
     /// Shared connection terminal-reason slot (writer side).
     pub(crate) terminal: ConnTerminalSlot,
+    /// Per-connection memory-budget configuration (Copy). Read in the
+    /// `PeerStreamStarted` arm so peer-accepted streams inherit the connection's
+    /// caps (the dual carrier alongside [`ConnHandle::config`]).
+    pub(crate) config: H3Config,
     /// Set by [`connection_recover`] after a contained callback panic (SF-E), so
     /// [`guard_callback`] short-circuits every subsequent event on this ctx.
     pub(crate) poisoned: bool,
@@ -125,7 +139,7 @@ pub(crate) struct ConnCtxReceiver {
     pub(crate) accepted_id_failpoint: Arc<AcceptedIdFailpoint>,
 }
 
-pub(crate) fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
+pub(crate) fn conn_ctx_channel(config: H3Config) -> (ConnCtxSender, ConnCtxReceiver) {
     let (conn_tx, conn_rx) = oneshot::channel();
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (bidi_tx, bidi_rx) = mpsc::unbounded();
@@ -142,6 +156,7 @@ pub(crate) fn conn_ctx_channel() -> (ConnCtxSender, ConnCtxReceiver) {
             bidi: Some(bidi_tx),
             uni: Some(uni_tx),
             terminal: terminal.clone(),
+            config,
             poisoned: false,
             #[cfg(test)]
             accepted_id_failpoint: accepted_id_failpoint.clone(),
@@ -326,7 +341,7 @@ pub(crate) fn connection_callback(
             // (the `stream_set.c` reject-and-close double-close hazard, F-C).
             let owned = unsafe { msquic::Stream::from_raw(stream.as_raw()) };
             stream_owned.set(true);
-            let h3 = crate::H3Stream::attach(owned, id, ctx.terminal.clone());
+            let h3 = crate::H3Stream::attach(owned, id, ctx.terminal.clone(), ctx.config);
             let target = if flags.contains(StreamOpenFlags::UNIDIRECTIONAL) {
                 ctx.uni.as_ref()
             } else {
@@ -435,6 +450,8 @@ pub(crate) fn connection_recover(
 }
 
 impl Connection {
+    /// Connect to `server_name:server_port` using the default memory budgets
+    /// ([`H3Config::default`]).
     ///
     /// The rundown count is reserved synchronously when this is called (before
     /// the returned future is polled), so even a queued/unpolled connect is
@@ -446,11 +463,26 @@ impl Connection {
         server_name: &'a str,
         server_port: u16,
     ) -> impl std::future::Future<Output = Result<Self, Status>> + 'a {
+        Self::connect_with_config(reg, config, server_name, server_port, H3Config::default())
+    }
+
+    /// Connect to `server_name:server_port` with an explicit [`H3Config`].
+    ///
+    /// Identical to [`connect`](Self::connect) except the supplied memory
+    /// budgets are threaded into the connection and every stream it opens or
+    /// accepts.
+    pub fn connect_with_config<'a>(
+        reg: &'a Registration,
+        config: &'a Configuration,
+        server_name: &'a str,
+        server_port: u16,
+        h3config: H3Config,
+    ) -> impl std::future::Future<Output = Result<Self, Status>> + 'a {
         // Reserved now, before the caller ever polls. If the future is dropped
         // without completing, the guard drops and decrements.
         let guard = RundownGuard::new(reg.state().clone());
         async move {
-            let (mut ctx, mut crx) = conn_ctx_channel();
+            let (mut ctx, mut crx) = conn_ctx_channel(h3config);
             let handler = move |conn_ref: ConnectionRef, ev: ConnectionEvent| {
                 let disp = conn_poison_disp(&ev);
                 // Per-invocation peer-stream ownership token (F-C): a fresh `Cell`
@@ -471,7 +503,12 @@ impl Connection {
             // path uses ConnHandle's proven ConnectionClose-then-guard drop
             // order rather than the async future's unspecified capture layout.
             let inner = msquic::Connection::open(reg.raw(), handler)?;
-            let conn = Arc::new(ConnHandle::new(inner, guard, crx.terminal.clone()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                crx.terminal.clone(),
+                h3config,
+            ));
             conn.start(config, server_name, server_port)?;
             // wait for connection. The one-shot carries `Result<(), Status>`: a
             // transport/peer shutdown before `Connected` resolves it with the
@@ -495,8 +532,12 @@ impl Connection {
     }
 
     /// attach to an accepted connection
-    pub(crate) fn attach(inner: msquic::Connection, guard: RundownGuard) -> Self {
-        let (mut ctx, crx) = conn_ctx_channel();
+    pub(crate) fn attach(
+        inner: msquic::Connection,
+        guard: RundownGuard,
+        h3config: H3Config,
+    ) -> Self {
+        let (mut ctx, crx) = conn_ctx_channel(h3config);
         let handler = move |conn_ref: ConnectionRef, ev: ConnectionEvent| {
             let disp = conn_poison_disp(&ev);
             // Per-invocation peer-stream ownership token (F-C); see `connect`.
@@ -510,7 +551,12 @@ impl Connection {
             )
         };
         inner.set_callback_handler(handler);
-        let conn = Arc::new(ConnHandle::new(inner, guard, crx.terminal.clone()));
+        let conn = Arc::new(ConnHandle::new(
+            inner,
+            guard,
+            crx.terminal.clone(),
+            h3config,
+        ));
 
         let opener = StreamOpener::new(conn.clone());
 
@@ -687,5 +733,55 @@ impl<B: Buf> OpenStreams<B> for Connection {
 
     fn close(&mut self, code: h3::error::Code, reason: &[u8]) {
         OpenStreams::<B>::close(&mut self.opener, code, reason)
+    }
+}
+
+/// Phase 1 (config threading) unit tests for the per-connection carrier: the
+/// same [`H3Config`] a listener passes into `Connection::attach` is stored on
+/// BOTH per-connection carriers — the callback-side `ConnCtxSender` (read in the
+/// `PeerStreamStarted` arm to build peer-accepted streams) and, via the same
+/// seam, the `ConnHandle` (read by `StreamOpener` for locally-opened streams).
+/// This asserts the dual carrier the accepted/local paths both depend on.
+#[cfg(test)]
+mod config_carrier {
+    use super::conn_ctx_channel;
+    use crate::H3Config;
+
+    fn custom() -> H3Config {
+        H3Config::builder()
+            .with_max_send_bytes(4096)
+            .with_max_recv_bytes(8192)
+            .with_max_recv_units(7)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn conn_ctx_channel_stores_config_on_the_sender_carrier() {
+        let cfg = custom();
+        let (sender, _recv) = conn_ctx_channel(cfg);
+        // The `PeerStreamStarted` arm reads `ctx.config` and passes it into
+        // `H3Stream::attach`; assert the value the callback will hand accepted
+        // streams equals the connection's configured caps.
+        assert_eq!(sender.config, cfg);
+        assert_eq!(sender.config.max_send_bytes(), 4096);
+        assert_eq!(sender.config.max_recv_bytes(), 8192);
+        assert_eq!(sender.config.max_recv_units(), 7);
+    }
+
+    #[test]
+    fn two_connections_keep_independent_configs() {
+        let a = H3Config::builder().with_max_recv_units(3).build().unwrap();
+        let b = H3Config::builder().with_max_recv_units(99).build().unwrap();
+        let (sa, _ra) = conn_ctx_channel(a);
+        let (sb, _rb) = conn_ctx_channel(b);
+        assert_eq!(sa.config.max_recv_units(), 3);
+        assert_eq!(sb.config.max_recv_units(), 99);
+    }
+
+    #[test]
+    fn default_config_carrier_matches_defaults() {
+        let (sender, _recv) = conn_ctx_channel(H3Config::default());
+        assert_eq!(sender.config, H3Config::default());
     }
 }

--- a/msquic-h3/src/error.rs
+++ b/msquic-h3/src/error.rs
@@ -23,9 +23,8 @@ use crate::msquic::{Status, StatusCode};
 /// encode. See [`clamp_application_code`].
 pub const MAX_QUIC_VARINT: u64 = (1 << 62) - 1;
 
-/// Maximum single `send_data` payload the adapter will accept before rejecting
-/// with [`OversizedSend`]. Provisional value (16 MiB); enforced by the send-length
-/// classification in [`crate::buffer`] and the `send_data` rejection site.
+/// Default maximum single `send_data` payload the adapter will accept before
+/// rejecting with [`OversizedSend`] (16 MiB). Configurable via [`H3Config`](crate::H3Config).
 pub const MAX_ADAPTER_SEND: u64 = 16 * 1024 * 1024;
 
 /// Clamp an outgoing application error code to the QUIC 62-bit varint maximum.
@@ -52,14 +51,16 @@ pub(crate) fn clamp_application_code(code: u64) -> u64 {
 pub struct OversizedSend {
     /// Requested payload length in bytes (the `remaining()` that was rejected).
     pub len: usize,
+    /// The connection's configured send-size ceiling that was exceeded.
+    pub max_bytes: u64,
 }
 
 impl fmt::Display for OversizedSend {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "send_data payload of {} bytes exceeds MAX_ADAPTER_SEND ({} bytes)",
-            self.len, MAX_ADAPTER_SEND
+            "send_data payload of {} bytes exceeds configured ceiling ({} bytes)",
+            self.len, self.max_bytes
         )
     }
 }
@@ -372,14 +373,14 @@ pub(crate) enum SendPoll {
 pub(crate) enum SendPayload {
     Empty,
     NonEmpty { len: u32 },
-    Oversized { len: usize },
+    Oversized { len: usize, ceiling: u64 },
 }
 
 /// One-shot, non-sticky adapter error for `send_data`. Never stored in the
 /// shared slot; a later `poll_ready` is unaffected.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SendOperationError {
-    OversizedSend { len: usize },
+    OversizedSend { len: usize, ceiling: u64 },
     Misuse(&'static str),
 }
 
@@ -477,8 +478,11 @@ pub(crate) enum SendCommand {
 /// returns. Never stored in the shared slot.
 pub(crate) fn convert_send_op(e: SendOperationError) -> StreamErrorIncoming {
     match e {
-        SendOperationError::OversizedSend { len } => {
-            StreamErrorIncoming::Unknown(Box::new(OversizedSend { len }))
+        SendOperationError::OversizedSend { len, ceiling } => {
+            StreamErrorIncoming::Unknown(Box::new(OversizedSend {
+                len,
+                max_bytes: ceiling,
+            }))
         }
         SendOperationError::Misuse(msg) => StreamErrorIncoming::ConnectionErrorIncoming {
             connection_error: ConnectionErrorIncoming::InternalError(msg.to_string()),
@@ -635,8 +639,8 @@ pub(crate) fn transition(state: &mut SendState, input: SendInput) -> SendCommand
             match payload {
                 // idle, no winner
                 SendPayload::Empty => ReturnSent, // no-op, no reservation
-                SendPayload::Oversized { len } => {
-                    ReturnImmediateError(SendOperationError::OversizedSend { len }) // state unchanged
+                SendPayload::Oversized { len, ceiling } => {
+                    ReturnImmediateError(SendOperationError::OversizedSend { len, ceiling }) // state unchanged
                 }
                 SendPayload::NonEmpty { .. } => {
                     state.send_submitting = true;
@@ -1437,13 +1441,19 @@ mod reducer_tests {
         let cmd = step(
             &mut st,
             SendInput::SendRequested {
-                payload: SendPayload::Oversized { len: 999 },
+                payload: SendPayload::Oversized {
+                    len: 999,
+                    ceiling: 4096,
+                },
                 terminal: None,
             },
         );
         assert!(matches!(
             cmd,
-            SendCommand::ReturnImmediateError(SendOperationError::OversizedSend { len: 999 })
+            SendCommand::ReturnImmediateError(SendOperationError::OversizedSend {
+                len: 999,
+                ceiling: 4096
+            })
         ));
         assert_eq!(
             st,

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -15,6 +15,8 @@ pub(crate) use h3::quic::ConnectionErrorIncoming;
 use msquic::{Status, StatusCode};
 
 mod buffer;
+mod config;
+pub use config::{ConfigError, H3Config, H3ConfigBuilder};
 mod callback;
 pub(crate) use callback::{
     CbClass, ForceShutdown, NoShutdown, PoisonFlag, ShutdownSeam, guard_callback,

--- a/msquic-h3/src/lib.rs
+++ b/msquic-h3/src/lib.rs
@@ -56,8 +56,8 @@ pub(crate) use crate::buffer::SendBuffer;
 pub(crate) use stream::{
     Admit, MAX_RECV_BUFFER, PreIdReceivers, PreIdTail, ReceiveEvent, RecvBudget, RecvExec,
     RecvStreamReceiveCtx, SendExec, SendStreamReceiveCtx, StreamSendCtx, stream_callback,
-    stream_ctx_channel, stream_ctx_channel_pre_id, stream_ctx_channel_with_conn,
-    stream_poison_disp, stream_recover, submit_owned_send,
+    stream_ctx_channel, stream_ctx_channel_pre_id, stream_ctx_channel_with_config,
+    stream_ctx_channel_with_conn, stream_poison_disp, stream_recover, submit_owned_send,
 };
 pub use stream::{H3RecvStream, H3SendStream, H3Stream};
 pub(crate) use stream::{OpenExec, OpeningStream, StreamOpenExecutor};

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -23,6 +23,10 @@ use crate::{
 pub struct Listener {
     inner: msquic::Listener,
     conn: ListenerCtxReceiver,
+    /// Per-connection memory budget applied to every connection this listener
+    /// accepts (threaded into `Connection::attach`).
+    #[allow(dead_code)]
+    config: crate::H3Config,
     // Dropped last: `inner`'s ListenerClose releases the native rundown ref
     // before this guard decrements and wakes `wait_idle` waiters.
     _guard: RundownGuard,
@@ -189,6 +193,7 @@ fn listener_callback(
     config: &Arc<msquic::Configuration>,
     state: &Arc<RundownState>,
     owned: &Cell<bool>,
+    h3config: crate::H3Config,
 ) -> Result<(), Status> {
     // `owned` is a PER-INVOCATION token (F-B); it starts `false` for every
     // callback (fresh `Cell` per invocation in the handler), so there is no
@@ -218,7 +223,7 @@ fn listener_callback(
                 // the owned connection (and must not also reject it).
                 let inner = unsafe { msquic::Connection::from_raw(connection.as_raw()) };
                 owned.set(true);
-                let conn = crate::Connection::attach(inner, guard);
+                let conn = crate::Connection::attach(inner, guard, h3config);
                 match ctx.conn.as_ref() {
                     Some(tx) => match tx.unbounded_send(Some(conn)) {
                         Ok(()) => true,
@@ -258,11 +263,27 @@ fn listener_callback(
 }
 
 impl Listener {
+    /// Create a listener using the default memory budgets ([`H3Config::default`]).
+    ///
+    /// [`H3Config::default`]: crate::H3Config::default
     pub fn new(
         reg: &crate::Registration,
         config: Arc<msquic::Configuration>,
         alpn: &[BufferRef],
         local_addr: Option<SocketAddr>,
+    ) -> Result<Self, Status> {
+        Self::with_config(reg, config, alpn, local_addr, crate::H3Config::default())
+    }
+
+    /// Create a listener with an explicit [`H3Config`], applied to every
+    /// connection it accepts (and thus to every stream those connections
+    /// open/accept).
+    pub fn with_config(
+        reg: &crate::Registration,
+        config: Arc<msquic::Configuration>,
+        alpn: &[BufferRef],
+        local_addr: Option<SocketAddr>,
+        h3config: crate::H3Config,
     ) -> Result<Self, Status> {
         let (tx, rx) = listener_ctx_channel();
         let state = reg.state().clone();
@@ -281,7 +302,7 @@ impl Listener {
                 &mut ctx_ref,
                 &NoShutdown,
                 disp,
-                |c| listener_callback(c, ev, &config, &state, &owned),
+                |c| listener_callback(c, ev, &config, &state, &owned, h3config),
                 |c, seam| listener_recover(c, seam, &owned),
             )
         };
@@ -297,6 +318,7 @@ impl Listener {
         let listener = Self {
             inner,
             conn: rx,
+            config: h3config,
             _guard: guard,
         };
         listener.inner.start(alpn, addr.as_ref())?;

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -275,9 +275,9 @@ impl Listener {
         Self::with_config(reg, config, alpn, local_addr, crate::H3Config::default())
     }
 
-    /// Create a listener with an explicit [`H3Config`], applied to every
-    /// connection it accepts (and thus to every stream those connections
-    /// open/accept).
+    /// Create a listener with an explicit [`H3Config`](crate::H3Config),
+    /// applied to every connection it accepts (and thus to every stream those
+    /// connections open/accept).
     pub fn with_config(
         reg: &crate::Registration,
         config: Arc<msquic::Configuration>,

--- a/msquic-h3/src/listener.rs
+++ b/msquic-h3/src/listener.rs
@@ -23,10 +23,10 @@ use crate::{
 pub struct Listener {
     inner: msquic::Listener,
     conn: ListenerCtxReceiver,
-    /// Per-connection memory budget applied to every connection this listener
-    /// accepts (threaded into `Connection::attach`).
-    #[allow(dead_code)]
-    config: crate::H3Config,
+    // The listener-wide `H3Config` is not stored here: it is captured by `Copy`
+    // into the accept callback closure (see `with_config`), which is the single
+    // source of truth passed to every accepted `Connection::attach`. Keeping a
+    // second copy on the struct would be dead, drift-prone state.
     // Dropped last: `inner`'s ListenerClose releases the native rundown ref
     // before this guard decrements and wakes `wait_idle` waiters.
     _guard: RundownGuard,
@@ -318,7 +318,6 @@ impl Listener {
         let listener = Self {
             inner,
             conn: rx,
-            config: h3config,
             _guard: guard,
         };
         listener.inner.start(alpn, addr.as_ref())?;

--- a/msquic-h3/src/opener.rs
+++ b/msquic-h3/src/opener.rs
@@ -279,7 +279,7 @@ mod stream_open_identity {
 
     #[test]
     fn accept_stream_id_success_takes_no_terminal() {
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         let id = accept_stream_id(&mut ctx, || Ok(8)).expect("valid id accepted");
         assert_eq!(id.into_inner(), 8);
         // No terminal published; both acceptor senders remain open.
@@ -289,7 +289,7 @@ mod stream_open_identity {
 
     #[test]
     fn accept_stream_id_query_failure_publishes_internal_and_wakes_acceptors() {
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         let status = Status::new(StatusCode::QUIC_STATUS_INTERNAL_ERROR);
         // A native get_stream_id failure returns its Status from the callback...
         let err = accept_stream_id(&mut ctx, || Err(status.clone())).expect_err("query failed");
@@ -308,7 +308,7 @@ mod stream_open_identity {
 
     #[test]
     fn accept_stream_id_invalid_id_publishes_internal_and_returns_internal_status() {
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         // A (synthetic) out-of-range ID fails h3 validation: internal terminal,
         // QUIC_STATUS_INTERNAL_ERROR returned so msquic closes the stream.
         let err = accept_stream_id(&mut ctx, || Ok(u64::MAX)).expect_err("invalid id rejected");
@@ -327,7 +327,7 @@ mod stream_open_identity {
     fn already_published_peer_terminal_wins_over_internal() {
         // An accepted-stream failure records Internal, but a peer application
         // close published first is preserved (first-writer-wins).
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         record_conn_terminal(&ctx.terminal, ConnectionTerminal::PeerApplication(7));
         let _ = accept_stream_id(&mut ctx, || Ok(u64::MAX)).expect_err("invalid id rejected");
         // The winning terminal is the earlier peer close, not the internal fault.
@@ -342,7 +342,7 @@ mod stream_open_identity {
         // Drive the exact seam the callback uses, but arm it through the
         // RECEIVER-side handle a live `Connection` frontend holds — proving the
         // failpoint atomic is shared with the callback's sender-side clone.
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         crx.accepted_id_failpoint.arm_query_fail();
         // The callback consults its own (shared) sender-side handle.
         let fp = ctx.accepted_id_failpoint.clone();
@@ -362,7 +362,7 @@ mod stream_open_identity {
 
     #[test]
     fn accepted_id_failpoint_invalid_seam_rejects() {
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         // Arm through the receiver-side (frontend) handle; read via the sender.
         crx.accepted_id_failpoint.arm_invalid_id();
         let fp = ctx.accepted_id_failpoint.clone();
@@ -542,7 +542,7 @@ mod stream_open_identity {
             })
             .unwrap();
         let guard = RundownGuard::new(reg.state().clone());
-        let conn = crate::Connection::attach(inner, guard);
+        let conn = crate::Connection::attach(inner, guard, crate::H3Config::default());
 
         // Arm query-fail through the live `Connection`; the shared atomic the
         // accept path consults trips once then consumes itself.
@@ -666,7 +666,12 @@ mod downcall_clamp {
             let inner =
                 Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
             let guard = RundownGuard::new(reg.state().clone());
-            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                new_conn_terminal_slot(),
+                crate::H3Config::default(),
+            ));
 
             let rec = RecordingOpenExec::default();
             let codes = rec.codes.clone();
@@ -714,7 +719,7 @@ mod downcall_clamp {
             if let Some(reason) = self.record.clone() {
                 record_conn_terminal(conn.terminal(), reason);
             }
-            let (ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone());
+            let (ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone(), conn.config());
             let flag = if uni {
                 StreamOpenFlags::UNIDIRECTIONAL
             } else {
@@ -731,6 +736,7 @@ mod downcall_clamp {
                 conn_terminal,
                 receive,
                 recv_budget,
+                max_send_bytes,
             } = recv;
             Ok(OpeningStream {
                 stream: Arc::new(s),
@@ -741,6 +747,7 @@ mod downcall_clamp {
                     conn_terminal,
                     receive,
                     recv_budget,
+                    max_send_bytes,
                 },
             })
         }
@@ -766,7 +773,12 @@ mod downcall_clamp {
             let inner =
                 Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
             let guard = RundownGuard::new(reg.state().clone());
-            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                new_conn_terminal_slot(),
+                crate::H3Config::default(),
+            ));
             let mut opener =
                 StreamOpener::with_open_exec(conn, Box::new(CancellingOpenExec { record: None }));
             let mut cx = noop_cx();
@@ -790,7 +802,12 @@ mod downcall_clamp {
             let inner =
                 Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
             let guard = RundownGuard::new(reg.state().clone());
-            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                new_conn_terminal_slot(),
+                crate::H3Config::default(),
+            ));
             let mut opener = StreamOpener::with_open_exec(
                 conn,
                 Box::new(CancellingOpenExec {
@@ -825,7 +842,12 @@ mod downcall_clamp {
             let inner =
                 Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
             let guard = RundownGuard::new(reg.state().clone());
-            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                new_conn_terminal_slot(),
+                crate::H3Config::default(),
+            ));
             record_conn_terminal(conn.terminal(), ConnectionTerminal::PeerApplication(9));
             let mut opener = StreamOpener::with_open_exec(
                 conn.clone(),
@@ -855,7 +877,12 @@ mod downcall_clamp {
             let inner =
                 Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
             let guard = RundownGuard::new(reg.state().clone());
-            let conn = Arc::new(ConnHandle::new(inner, guard, new_conn_terminal_slot()));
+            let conn = Arc::new(ConnHandle::new(
+                inner,
+                guard,
+                new_conn_terminal_slot(),
+                crate::H3Config::default(),
+            ));
             record_conn_terminal(conn.terminal(), ConnectionTerminal::PeerApplication(5));
             let mut opener = StreamOpener::with_open_exec(
                 conn.clone(),
@@ -893,8 +920,13 @@ mod downcall_clamp {
         let inner =
             Connection::open(reg.raw(), |_: ConnectionRef, _: ConnectionEvent| Ok(())).unwrap();
         let guard = RundownGuard::new(reg.state().clone());
-        let (ctx, crx) = crate::conn_ctx_channel();
-        let conn = Arc::new(ConnHandle::new(inner, guard, crx.terminal.clone()));
+        let (ctx, crx) = crate::conn_ctx_channel(crate::H3Config::default());
+        let conn = Arc::new(ConnHandle::new(
+            inner,
+            guard,
+            crx.terminal.clone(),
+            crate::H3Config::default(),
+        ));
         let opener = StreamOpener::new(conn.clone());
         let connection = crate::Connection {
             conn,

--- a/msquic-h3/src/send_seam.rs
+++ b/msquic-h3/src/send_seam.rs
@@ -10,9 +10,10 @@ use h3::quic::{SendStream, StreamErrorIncoming};
 use crate::error::{ConnectionTerminal, MAX_ADAPTER_SEND};
 use crate::msquic::{Status, StatusCode, StreamEvent};
 use crate::{
-    ConnTerminalSlot, ConnectionErrorIncoming, H3SendStream, OversizedSend, SendBuffer, SendExec,
-    SendStreamReceiveCtx, StreamSendCtx, new_conn_terminal_slot, record_conn_terminal,
-    stream_callback, stream_ctx_channel, stream_ctx_channel_with_conn,
+    ConnTerminalSlot, ConnectionErrorIncoming, H3Config, H3SendStream, OversizedSend, SendBuffer,
+    SendExec, SendStreamReceiveCtx, StreamSendCtx, new_conn_terminal_slot, record_conn_terminal,
+    stream_callback, stream_ctx_channel, stream_ctx_channel_with_config,
+    stream_ctx_channel_with_conn,
 };
 
 /// Shared, inspectable counters + `client_context` slots. A clone is kept by
@@ -117,6 +118,23 @@ fn test_send_ctx_with_conn(
     let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
     let (ctx, sctx, _rctx) = stream_ctx_channel_with_conn(id, conn_terminal);
     (sctx, ctx)
+}
+
+/// Like [`test_send_ctx`] but with an explicit [`H3Config`], so a send-seam
+/// test can drive the real `send_data` classification against a **custom**
+/// per-send-size ceiling (`config.max_send_bytes()`) instead of the default.
+fn test_send_ctx_with_config(config: H3Config) -> (SendStreamReceiveCtx, StreamSendCtx) {
+    let id: h3::quic::StreamId = 0u64.try_into().expect("valid StreamId");
+    let (ctx, sctx, _rctx) = stream_ctx_channel_with_config(id, new_conn_terminal_slot(), config);
+    (sctx, ctx)
+}
+
+/// A validated [`H3Config`] with only the per-send-size ceiling overridden.
+fn cfg_with_ceiling(ceiling: u64) -> H3Config {
+    H3Config::builder()
+        .with_max_send_bytes(ceiling)
+        .build()
+        .expect("valid custom send ceiling")
 }
 
 /// A connection-caused stream `ShutdownComplete` whose derived fallback is the
@@ -424,6 +442,101 @@ fn oversized_send_rejected_before_allocation() {
     assert_eq!(h.sends.load(Relaxed), 0);
     assert_eq!(h.allocs.load(Relaxed), 0);
     assert!(s.sctx.send.try_recv().is_err());
+}
+
+/// SC-001 / SC-004 (send): the real `send_data` path honors a **custom reduced**
+/// per-send-size ceiling `C`. The ceiling bounds the full copied frame length
+/// (`WriteBuf::remaining()` = the h3 DATA header + payload), so the test sizes
+/// its payload so the *framed* length is exactly `C + 1`: it is rejected up
+/// front as `OversizedSend` — which now reports the configured ceiling in
+/// `max_bytes` and the framed length in `len` — with ZERO copies and ZERO native
+/// submissions. This proves `send_data` classifies against
+/// `self.sctx.max_send_bytes` (the configured ceiling), not `MAX_ADAPTER_SEND`.
+#[test]
+fn custom_ceiling_send_data_rejects_oversized_before_allocation() {
+    use bytes::Buf;
+    const C: u64 = 4096;
+
+    // The h3 DATA framing overhead (`remaining()` - payload) is constant for
+    // payload sizes in this magnitude; measure it so the framed length lands on
+    // an exact boundary rather than hardcoding the varint header width.
+    let framed_len = |payload: Bytes| -> usize {
+        let wb: h3::quic::WriteBuf<Bytes> = Frame::Data(payload).into();
+        wb.remaining()
+    };
+    let header = framed_len(Bytes::from(vec![0u8; C as usize - 100])) - (C as usize - 100);
+    // Payload whose framed length is exactly C + 1 (one byte over the ceiling).
+    let over_payload = Bytes::from(vec![0u8; (C as usize + 1) - header]);
+    assert_eq!(framed_len(over_payload.clone()), C as usize + 1);
+
+    let h = CountingHandle::default();
+    let exec = Box::new(CountingExec::new(h.clone(), VecDeque::new()));
+    let (sctx, _ctx) = test_send_ctx_with_config(cfg_with_ceiling(C));
+    let mut s = H3SendStream::with_exec(exec, sctx);
+
+    let err = SendStream::<Bytes>::send_data(&mut s, Frame::Data(over_payload))
+        .expect_err("oversized send must be rejected at the custom ceiling");
+
+    match err {
+        StreamErrorIncoming::Unknown(e) => {
+            let os = e
+                .downcast_ref::<OversizedSend>()
+                .expect("expected OversizedSend");
+            assert_eq!(
+                os.len,
+                C as usize + 1,
+                "reported the rejected (framed) length"
+            );
+            assert_eq!(
+                os.max_bytes, C,
+                "OversizedSend must report the CONFIGURED ceiling, not MAX_ADAPTER_SEND"
+            );
+            assert_ne!(
+                os.max_bytes, MAX_ADAPTER_SEND,
+                "the custom ceiling must not be the default"
+            );
+        }
+        other => panic!("expected Unknown(OversizedSend), got {other:?}"),
+    }
+    // Rejected before any copy or native submission, and no send in flight.
+    assert_eq!(h.sends.load(Relaxed), 0);
+    assert_eq!(h.allocs.load(Relaxed), 0);
+    assert!(s.sctx.send.try_recv().is_err());
+}
+
+/// Complement to the rejection test: a send whose framed length is EXACTLY the
+/// custom ceiling `C` is accepted and submitted (one copy, one native
+/// submission), confirming the classifier admits `remaining <= C` rather than
+/// rejecting at the boundary.
+#[test]
+fn custom_ceiling_send_data_accepts_payload_at_the_ceiling() {
+    use bytes::Buf;
+    const C: u64 = 4096;
+
+    let framed_len = |payload: Bytes| -> usize {
+        let wb: h3::quic::WriteBuf<Bytes> = Frame::Data(payload).into();
+        wb.remaining()
+    };
+    let header = framed_len(Bytes::from(vec![0u8; C as usize - 100])) - (C as usize - 100);
+    // Payload whose framed length is exactly C (right at the ceiling).
+    let at_payload = Bytes::from(vec![0u8; C as usize - header]);
+    assert_eq!(framed_len(at_payload.clone()), C as usize);
+
+    let h = CountingHandle::default();
+    // A single scripted Ok so the native side "accepts ownership" of the copy.
+    let mut script = VecDeque::new();
+    script.push_back(Ok(()));
+    let exec = Box::new(CountingExec::new(h.clone(), script));
+    let (sctx, _ctx) = test_send_ctx_with_config(cfg_with_ceiling(C));
+    let mut s = H3SendStream::with_exec(exec, sctx);
+
+    SendStream::<Bytes>::send_data(&mut s, Frame::Data(at_payload))
+        .expect("a send exactly at the custom ceiling must be accepted");
+
+    // Exactly one copy and one native submission occurred.
+    assert_eq!(h.sends.load(Relaxed), 1);
+    assert_eq!(h.allocs.load(Relaxed), 1);
+    assert_eq!(h.client_ctx.lock().unwrap().len(), 1);
 }
 
 #[test]

--- a/msquic-h3/src/stream.rs
+++ b/msquic-h3/src/stream.rs
@@ -23,13 +23,14 @@ use msquic::{
 };
 
 use crate::buffer::{SendBuffer, SendLen, classify_send_len, copy_into_send_buffer};
+use crate::config::DEFAULT_MAX_RECV_UNITS;
 use crate::error::{
     ConnectionTerminal, ReceiveTerminal, SendCommand, SendEvent, SendInput, SendPayload, SendPoll,
     SendState, SendTerminal, clamp_application_code, convert_recv, convert_send, convert_send_op,
     transition,
 };
 use crate::{
-    CbClass, ConnHandle, ConnTerminalSlot, ForceShutdown, H3_INTERNAL_ERROR, PoisonFlag,
+    CbClass, ConnHandle, ConnTerminalSlot, ForceShutdown, H3_INTERNAL_ERROR, H3Config, PoisonFlag,
     SendTerminalSlot, ShutdownSeam, classify_conn_shutdown, commit_conn, guard_callback,
     internal_error_status, load_winner, lock_recover, new_send_terminal_slot, observe_conn_winner,
     peek_conn_terminal, publish_send, record_conn_terminal, report_contained_panic,
@@ -270,11 +271,28 @@ struct RecvState {
 
 /// Per-stream receive budget, shared (as an `Arc`) between the stream callback
 /// (writer) and the `poll_data` drain (reader). Each local or accepted stream
-/// owns its own independent 1 MiB budget; there is no connection-wide meter. See
-/// [`RecvState`].
-#[derive(Debug, Default)]
+/// owns its own independent budget sourced from the connection's [`H3Config`];
+/// there is no connection-wide meter. See [`RecvState`].
+///
+/// `max_bytes` is the per-stream byte ceiling (default [`MAX_RECV_BUFFER`]).
+/// `max_units` is the per-stream buffered-unit ceiling (default
+/// [`DEFAULT_MAX_RECV_UNITS`]); it is carried here from Phase 1 but not yet
+/// enforced — Phase 2 adds the unit-count backpressure that reads it.
+#[derive(Debug)]
 pub(crate) struct RecvBudget {
     state: Mutex<RecvState>,
+    /// Per-stream buffered-byte ceiling (config-sourced).
+    max_bytes: usize,
+    /// Per-stream buffered-unit ceiling (config-sourced). Plumbed in Phase 1;
+    /// enforced in Phase 2.
+    #[allow(dead_code)]
+    max_units: usize,
+}
+
+impl Default for RecvBudget {
+    fn default() -> Self {
+        Self::new(MAX_RECV_BUFFER, DEFAULT_MAX_RECV_UNITS)
+    }
 }
 
 /// Outcome of the callback-side [`RecvBudget::admit`] transition.
@@ -292,6 +310,15 @@ pub(crate) enum Admit {
 }
 
 impl RecvBudget {
+    /// Build a receive budget with explicit per-stream caps (from [`H3Config`]).
+    pub(crate) fn new(max_bytes: usize, max_units: usize) -> Self {
+        Self {
+            state: Mutex::new(RecvState::default()),
+            max_bytes,
+            max_units,
+        }
+    }
+
     /// Lock the receive state, recovering a poisoned lock rather than panicking
     /// (FFI callbacks must never unwind across the msquic boundary).
     fn lock(&self) -> MutexGuard<'_, RecvState> {
@@ -321,7 +348,7 @@ impl RecvBudget {
         if st.buffered > st.peak {
             st.peak = st.buffered;
         }
-        let pend = st.buffered >= MAX_RECV_BUFFER;
+        let pend = st.buffered >= self.max_bytes;
         if pend {
             st.pend_outstanding = true;
             st.pending_indication_len = total as u64;
@@ -356,7 +383,7 @@ impl RecvBudget {
             st.buffered
         );
         st.buffered = st.buffered.saturating_sub(len);
-        if st.pend_outstanding && st.buffered < MAX_RECV_BUFFER {
+        if st.pend_outstanding && st.buffered < self.max_bytes {
             st.pend_outstanding = false;
             let complete = st.pending_indication_len;
             st.pending_indication_len = 0;
@@ -380,6 +407,15 @@ impl RecvBudget {
     }
     fn pending_indication_len(&self) -> u64 {
         self.lock().pending_indication_len
+    }
+    /// Config-sourced per-stream byte ceiling (threading assertion).
+    pub(crate) fn max_bytes(&self) -> usize {
+        self.max_bytes
+    }
+    /// Config-sourced per-stream unit ceiling (threading assertion; Phase 2
+    /// enforces it).
+    pub(crate) fn max_units(&self) -> usize {
+        self.max_units
     }
 }
 
@@ -489,6 +525,12 @@ pub(crate) struct SendStreamReceiveCtx {
     /// Single ordered send-event source (MF-1): data completion, terminal wake,
     /// and finish completion. The reducer observes it only as a [`SendPoll`].
     pub(crate) send: mpsc::UnboundedReceiver<SendEvent>,
+    /// Per-stream `send_data` payload ceiling (config-sourced, default
+    /// [`MAX_ADAPTER_SEND`]). Read by `send_data` to classify/reject oversized
+    /// payloads before any allocation.
+    ///
+    /// [`MAX_ADAPTER_SEND`]: crate::error::MAX_ADAPTER_SEND
+    pub(crate) max_send_bytes: u64,
     /// Pure send-side reducer bookkeeping (replaces the old `send_inprogress`).
     pub(crate) reducer: SendState,
 }
@@ -509,9 +551,9 @@ pub(crate) struct PreIdReceivers {
     pub(crate) receive: mpsc::UnboundedReceiver<ReceiveEvent>,
     /// Per-stream receive budget (SF-A), carried into the receive half's ctx.
     pub(crate) recv_budget: Arc<RecvBudget>,
+    /// Per-stream `send_data` ceiling (config-sourced), moved into the send half.
+    pub(crate) max_send_bytes: u64,
 }
-
-/// A locally opened stream whose native handle is started but whose h3
 /// [`h3::quic::StreamId`] is not yet known. Private to [`StreamOpener`]; the
 /// only stream form allowed to exist without a cached ID. On a successful
 /// `StartComplete` it is consumed into an [`H3Stream`] with concrete ID fields
@@ -538,6 +580,8 @@ pub(crate) struct PreIdTail {
     pub(crate) receive: mpsc::UnboundedReceiver<ReceiveEvent>,
     /// Per-stream receive budget (SF-A), carried into the receive half's ctx.
     pub(crate) recv_budget: Arc<RecvBudget>,
+    /// Per-stream `send_data` ceiling (config-sourced), moved into the send half.
+    pub(crate) max_send_bytes: u64,
 }
 
 impl OpeningStream {
@@ -556,6 +600,7 @@ impl OpeningStream {
             conn_terminal,
             receive,
             recv_budget,
+            max_send_bytes,
         } = tail;
         H3Stream {
             send: H3SendStream {
@@ -567,6 +612,7 @@ impl OpeningStream {
                     send_terminal,
                     conn_terminal: conn_terminal.clone(),
                     send,
+                    max_send_bytes,
                     reducer: SendState::new(),
                 },
             },
@@ -595,12 +641,16 @@ impl OpeningStream {
 /// the receivers so both frontend halves resolve+freeze the same winner.
 pub(crate) fn stream_ctx_channel_pre_id(
     conn_terminal: ConnTerminalSlot,
+    config: H3Config,
 ) -> (StreamSendCtx, PreIdReceivers) {
     let (start_tx, start_rx) = oneshot::channel::<Result<u64, Status>>();
     let (send_tx, send_rx) = mpsc::unbounded();
     let send_terminal = new_send_terminal_slot();
     let (receive_tx, receive_rx) = mpsc::unbounded();
-    let recv_budget = Arc::new(RecvBudget::default());
+    let recv_budget = Arc::new(RecvBudget::new(
+        config.max_recv_bytes(),
+        config.max_recv_units(),
+    ));
     (
         StreamSendCtx {
             start: Some(start_tx),
@@ -619,6 +669,7 @@ pub(crate) fn stream_ctx_channel_pre_id(
             conn_terminal,
             receive: receive_rx,
             recv_budget,
+            max_send_bytes: config.max_send_bytes(),
         },
     )
 }
@@ -626,8 +677,9 @@ pub(crate) fn stream_ctx_channel_pre_id(
 /// ID-bearing stream channel builder used where the identity is already known
 /// (accepted streams and tests). Splits the pre-ID receivers into the two
 /// frontend halves' ctxs directly. Creates a fresh, standalone connection
-/// terminal slot; tests that need to drive connection-terminal refinement use
-/// [`stream_ctx_channel_with_conn`] to inject a shared slot.
+/// terminal slot and uses the default [`H3Config`]; tests that need to drive
+/// connection-terminal refinement use [`stream_ctx_channel_with_conn`], and
+/// tests that need custom caps use [`stream_ctx_channel_with_config`].
 #[cfg(test)]
 pub(crate) fn stream_ctx_channel(
     id: h3::quic::StreamId,
@@ -637,13 +689,26 @@ pub(crate) fn stream_ctx_channel(
 
 /// ID-bearing stream channel builder sharing an explicit connection terminal
 /// slot with the caller, so a test can record/refine the connection terminal and
-/// observe how the stream halves resolve+freeze it (FR-013).
+/// observe how the stream halves resolve+freeze it (FR-013). Uses the default
+/// [`H3Config`].
 #[cfg(test)]
 pub(crate) fn stream_ctx_channel_with_conn(
     id: h3::quic::StreamId,
     conn_terminal: ConnTerminalSlot,
 ) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
-    let (ctx, recv) = stream_ctx_channel_pre_id(conn_terminal);
+    stream_ctx_channel_with_config(id, conn_terminal, H3Config::default())
+}
+
+/// ID-bearing stream channel builder with an explicit [`H3Config`], so a test
+/// can assert the connection's caps thread into both stream halves (the
+/// `RecvBudget` byte/unit caps and the send ceiling).
+#[cfg(test)]
+pub(crate) fn stream_ctx_channel_with_config(
+    id: h3::quic::StreamId,
+    conn_terminal: ConnTerminalSlot,
+    config: H3Config,
+) -> (StreamSendCtx, SendStreamReceiveCtx, RecvStreamReceiveCtx) {
+    let (ctx, recv) = stream_ctx_channel_pre_id(conn_terminal, config);
     let PreIdReceivers {
         start: _,
         send,
@@ -651,6 +716,7 @@ pub(crate) fn stream_ctx_channel_with_conn(
         conn_terminal,
         receive,
         recv_budget,
+        max_send_bytes,
     } = recv;
     (
         ctx,
@@ -659,6 +725,7 @@ pub(crate) fn stream_ctx_channel_with_conn(
             send_terminal,
             conn_terminal: conn_terminal.clone(),
             send,
+            max_send_bytes,
             reducer: SendState::new(),
         },
         RecvStreamReceiveCtx {
@@ -946,13 +1013,16 @@ impl H3Stream {
     ///
     /// `conn_terminal` is the accepting connection's SHARED terminal slot, so an
     /// accepted stream reports the same refinable connection cause the accept
-    /// frontends do (FR-013).
+    /// frontends do (FR-013). `config` is the accepting connection's memory
+    /// budget, so the accepted stream inherits the same caps as a locally-opened
+    /// one (FR-009).
     pub(crate) fn attach(
         stream: msquic::Stream,
         id: h3::quic::StreamId,
         conn_terminal: ConnTerminalSlot,
+        config: H3Config,
     ) -> Self {
-        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn_terminal);
+        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn_terminal, config);
         let handler = move |stream_ref: StreamRef, ev: StreamEvent| {
             let disp = stream_poison_disp(&ev);
             guard_callback(
@@ -975,6 +1045,7 @@ impl H3Stream {
                 conn_terminal: recv.conn_terminal,
                 receive: recv.receive,
                 recv_budget: recv.recv_budget,
+                max_send_bytes: recv.max_send_bytes,
             },
         }
         .finalize(id)
@@ -988,7 +1059,7 @@ impl H3Stream {
         tracing::instrument(skip_all, level = "trace", err, ret)
     )]
     fn open_and_start(conn: &ConnHandle, uni: bool) -> Result<OpeningStream, Status> {
-        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone());
+        let (mut ctx, recv) = stream_ctx_channel_pre_id(conn.terminal().clone(), conn.config());
         let handler = move |stream_ref: StreamRef, ev: StreamEvent| {
             let disp = stream_poison_disp(&ev);
             guard_callback(
@@ -1017,6 +1088,7 @@ impl H3Stream {
                 conn_terminal: recv.conn_terminal,
                 receive: recv.receive,
                 recv_budget: recv.recv_budget,
+                max_send_bytes: recv.max_send_bytes,
             },
         })
     }
@@ -1103,7 +1175,7 @@ impl<B: Buf> SendStream<B> for H3SendStream {
         // when the reducer returns `SubmitSend`, so nothing is copied on a
         // terminal / misuse / oversized / empty path.
         let mut wb: h3::quic::WriteBuf<B> = data.into();
-        let payload = classify_payload(wb.remaining());
+        let payload = classify_payload(wb.remaining(), self.sctx.max_send_bytes);
         let mut input = SendInput::SendRequested {
             payload,
             terminal: self.sctx.resolve_terminal(),
@@ -1334,10 +1406,11 @@ impl SendStreamReceiveCtx {
 }
 
 /// Classify a `send_data` payload length into a [`SendPayload`] before any
-/// allocation. The `NonEmpty` upper bound is `MAX_ADAPTER_SEND` (< `u32::MAX`),
-/// so the `as u32` cast never truncates.
-fn classify_payload(remaining: usize) -> SendPayload {
-    match classify_send_len(remaining) {
+/// allocation. The `NonEmpty` upper bound is the configured `ceiling`
+/// (`<= u32::MAX` by [`H3Config`] validation), so the `as u32` cast never
+/// truncates.
+fn classify_payload(remaining: usize, ceiling: u64) -> SendPayload {
+    match classify_send_len(remaining, ceiling) {
         SendLen::Empty => SendPayload::Empty,
         SendLen::Oversized => SendPayload::Oversized { len: remaining },
         SendLen::NonEmpty => SendPayload::NonEmpty {
@@ -2317,5 +2390,101 @@ mod receive_events {
             other => panic!("expected concatenated data, got {other:?}"),
         }
         assert_eq!(rrx.recv_budget.buffered(), 9);
+    }
+}
+
+/// Phase 1 (config foundation & threading) unit tests: prove a connection's
+/// [`H3Config`] caps reach BOTH stream halves via the same seam
+/// (`stream_ctx_channel*`) that `H3Stream::attach` (peer-accepted) and
+/// `OpeningStream::finalize` (locally-opened) funnel through, that distinct
+/// per-connection configs stay isolated, and that the defaults equal the
+/// historical constants (behavior unchanged). Hermetic (no network).
+#[cfg(test)]
+mod config_threading {
+    use crate::error::MAX_ADAPTER_SEND;
+    use crate::{H3Config, MAX_RECV_BUFFER, new_conn_terminal_slot};
+
+    use super::stream_ctx_channel_with_config;
+
+    fn custom_config() -> H3Config {
+        H3Config::builder()
+            .with_max_send_bytes(4096)
+            .with_max_recv_bytes(8192)
+            .with_max_recv_units(7)
+            .build()
+            .unwrap()
+    }
+
+    /// A custom config threads into a stream ctx built via the seam (the exact
+    /// path both a locally-opened and a peer-accepted stream take through
+    /// `stream_ctx_channel_pre_id`): the receive byte/unit caps and the send
+    /// ceiling all equal the configured values.
+    #[test]
+    fn custom_config_threads_recv_and_send_caps() {
+        let cfg = custom_config();
+        let (_ctx, sctx, rctx) =
+            stream_ctx_channel_with_config(4u64.try_into().unwrap(), new_conn_terminal_slot(), cfg);
+        assert_eq!(rctx.recv_budget.max_bytes(), 8192);
+        assert_eq!(rctx.recv_budget.max_units(), 7);
+        assert_eq!(sctx.max_send_bytes, 4096);
+    }
+
+    /// The same custom config reaching an ACCEPTED-shaped stream (distinct
+    /// conn-terminal slot, mimicking `H3Stream::attach`'s dedicated seam call)
+    /// carries the identical caps: peer-accepted streams inherit the connection
+    /// config (FR-009).
+    #[test]
+    fn custom_config_threads_to_accepted_shaped_stream() {
+        let cfg = custom_config();
+        let accepted_slot = new_conn_terminal_slot();
+        let (_ctx, sctx, rctx) =
+            stream_ctx_channel_with_config(6u64.try_into().unwrap(), accepted_slot, cfg);
+        assert_eq!(rctx.recv_budget.max_bytes(), 8192);
+        assert_eq!(rctx.recv_budget.max_units(), 7);
+        assert_eq!(sctx.max_send_bytes, 4096);
+    }
+
+    /// Default-config construction yields caps equal to the historical constants
+    /// (no behavioral change).
+    #[test]
+    fn default_config_threads_the_historical_constants() {
+        let (_ctx, sctx, rctx) = stream_ctx_channel_with_config(
+            4u64.try_into().unwrap(),
+            new_conn_terminal_slot(),
+            H3Config::default(),
+        );
+        assert_eq!(rctx.recv_budget.max_bytes(), MAX_RECV_BUFFER);
+        assert_eq!(rctx.recv_budget.max_units(), 16384);
+        assert_eq!(sctx.max_send_bytes, MAX_ADAPTER_SEND);
+    }
+
+    /// Two connections with different configs produce streams with their own
+    /// respective caps — no cross-talk (Spec per-connection independence).
+    #[test]
+    fn two_configs_are_isolated() {
+        let a = H3Config::builder()
+            .with_max_send_bytes(1024)
+            .with_max_recv_bytes(2048)
+            .with_max_recv_units(3)
+            .build()
+            .unwrap();
+        let b = H3Config::builder()
+            .with_max_send_bytes(9999)
+            .with_max_recv_bytes(55555)
+            .with_max_recv_units(99)
+            .build()
+            .unwrap();
+        let (_ca, sa, ra) =
+            stream_ctx_channel_with_config(4u64.try_into().unwrap(), new_conn_terminal_slot(), a);
+        let (_cb, sb, rb) =
+            stream_ctx_channel_with_config(8u64.try_into().unwrap(), new_conn_terminal_slot(), b);
+
+        assert_eq!(ra.recv_budget.max_bytes(), 2048);
+        assert_eq!(ra.recv_budget.max_units(), 3);
+        assert_eq!(sa.max_send_bytes, 1024);
+
+        assert_eq!(rb.recv_budget.max_bytes(), 55555);
+        assert_eq!(rb.recv_budget.max_units(), 99);
+        assert_eq!(sb.max_send_bytes, 9999);
     }
 }

--- a/msquic-h3/src/stream.rs
+++ b/msquic-h3/src/stream.rs
@@ -256,6 +256,11 @@ pub(crate) const MAX_RECV_BUFFER: usize = 1024 * 1024; // 1 MiB per stream
 struct RecvState {
     /// Undrained bytes currently sitting in this stream's receive channel.
     buffered: usize,
+    /// Undrained receive UNITS (queued `Data` events) on this stream. Charged
+    /// exactly once per admitted non-empty indication and released one-per-drain
+    /// in `on_drained` (matching `poll_data`'s one-event-per-poll consumption).
+    /// An empty indication enqueues no `Data` event and takes no unit.
+    units: usize,
     /// True once this stream returned `QUIC_STATUS_PENDING` and has not yet been
     /// re-armed via `receive_complete`.
     pend_outstanding: bool,
@@ -264,9 +269,12 @@ struct RecvState {
     /// frees the budget.
     pending_indication_len: u64,
     /// Peak `buffered` ever observed on this stream (test/measurement
-    /// observation for the SC-004 bound; must stay ≤ `MAX_RECV_BUFFER` + one
+    /// observation for the SC-003 byte bound; must stay ≤ `max_bytes` + one
     /// in-flight indication).
     peak: usize,
+    /// Peak `units` ever observed on this stream (test/measurement observation
+    /// for the SC-002/SC-003 unit bound; must stay ≤ `max_units`).
+    peak_units: usize,
 }
 
 /// Per-stream receive budget, shared (as an `Arc`) between the stream callback
@@ -276,16 +284,15 @@ struct RecvState {
 ///
 /// `max_bytes` is the per-stream byte ceiling (default [`MAX_RECV_BUFFER`]).
 /// `max_units` is the per-stream buffered-unit ceiling (default
-/// [`DEFAULT_MAX_RECV_UNITS`]); it is carried here from Phase 1 but not yet
-/// enforced — Phase 2 adds the unit-count backpressure that reads it.
+/// [`DEFAULT_MAX_RECV_UNITS`]); it bounds the count of queued receive
+/// allocations independently of their byte total, closing the paced-tiny-frame
+/// allocation-amplification vector.
 #[derive(Debug)]
 pub(crate) struct RecvBudget {
     state: Mutex<RecvState>,
     /// Per-stream buffered-byte ceiling (config-sourced).
     max_bytes: usize,
-    /// Per-stream buffered-unit ceiling (config-sourced). Plumbed in Phase 1;
-    /// enforced in Phase 2.
-    #[allow(dead_code)]
+    /// Per-stream buffered-unit ceiling (config-sourced).
     max_units: usize,
 }
 
@@ -327,7 +334,10 @@ impl RecvBudget {
 
     /// Callback-side single synchronized transition — **accounting BEFORE
     /// drain-visibility, publish and decision atomic under one lock**. Adds a
-    /// full indication of `total` bytes, decides whether the stream must pend
+    /// full indication of `total` bytes, charges one buffered UNIT when
+    /// `charge_unit` is set (a non-empty indication that will enqueue a `Data`
+    /// event — an empty indication enqueues nothing and takes no unit), decides
+    /// whether the stream must pend on EITHER the byte or the unit ceiling
     /// (saving this indication's FULL length), and then — still holding the
     /// lock, as the LAST step — runs `publish` to make the bytes drain-visible.
     /// `publish` returns `true` on a successful hand-off (or when there is
@@ -336,11 +346,13 @@ impl RecvBudget {
     /// never observe stale accounting, and [`Admit::PublishFailed`] is returned.
     /// Because the publish is the last step, a concurrent drain can never
     /// subtract before the increment lands.
-    fn admit(&self, total: usize, publish: impl FnOnce() -> bool) -> Admit {
+    fn admit(&self, total: usize, charge_unit: bool, publish: impl FnOnce() -> bool) -> Admit {
         let mut st = self.lock();
         // Snapshot for exact rollback if the publication fails.
         let prev_buffered = st.buffered;
+        let prev_units = st.units;
         let prev_peak = st.peak;
+        let prev_peak_units = st.peak_units;
         let prev_pend = st.pend_outstanding;
         let prev_len = st.pending_indication_len;
 
@@ -348,7 +360,13 @@ impl RecvBudget {
         if st.buffered > st.peak {
             st.peak = st.buffered;
         }
-        let pend = st.buffered >= self.max_bytes;
+        if charge_unit {
+            st.units += 1;
+            if st.units > st.peak_units {
+                st.peak_units = st.units;
+            }
+        }
+        let pend = st.buffered >= self.max_bytes || st.units >= self.max_units;
         if pend {
             st.pend_outstanding = true;
             st.pending_indication_len = total as u64;
@@ -357,10 +375,13 @@ impl RecvBudget {
         if publish() {
             if pend { Admit::Pend } else { Admit::Accepted }
         } else {
-            // Roll the whole transition back: buffered, peak watermark, and the
-            // pend fields all return to their pre-indication values.
+            // Roll the whole transition back: buffered, units, both peak
+            // watermarks, and the pend fields all return to their pre-indication
+            // values (no leaked unit charge on a failed publish).
             st.buffered = prev_buffered;
+            st.units = prev_units;
             st.peak = prev_peak;
+            st.peak_units = prev_peak_units;
             st.pend_outstanding = prev_pend;
             st.pending_indication_len = prev_len;
             Admit::PublishFailed
@@ -368,9 +389,11 @@ impl RecvBudget {
     }
 
     /// Drain-side single synchronized transition. Subtracts `len` drained bytes
-    /// and, if a pend is outstanding and the budget has fallen below the bound,
-    /// clears the pend and returns the FULL saved indication length to hand to
-    /// `receive_complete` (re-arming the stream). Returns `None` otherwise.
+    /// AND releases exactly one buffered unit (each delivered `Data` event
+    /// consumed exactly one queued unit) and, if a pend is outstanding and BOTH
+    /// the byte and unit budgets have fallen below their bounds, clears the pend
+    /// and returns the FULL saved indication length to hand to `receive_complete`
+    /// (re-arming the stream). Returns `None` otherwise.
     fn on_drained(&self, len: usize) -> Option<u64> {
         let mut st = self.lock();
         // The publish-last ordering in `admit` guarantees the increment for these
@@ -383,7 +406,15 @@ impl RecvBudget {
             st.buffered
         );
         st.buffered = st.buffered.saturating_sub(len);
-        if st.pend_outstanding && st.buffered < self.max_bytes {
+        // A delivered `Data` event always corresponds to exactly one charged
+        // unit (empty indications enqueue no event), so this never underflows.
+        debug_assert!(
+            st.units >= 1,
+            "recv units underflow on drain: units={}",
+            st.units
+        );
+        st.units = st.units.saturating_sub(1);
+        if st.pend_outstanding && st.buffered < self.max_bytes && st.units < self.max_units {
             st.pend_outstanding = false;
             let complete = st.pending_indication_len;
             st.pending_indication_len = 0;
@@ -401,6 +432,12 @@ impl RecvBudget {
     }
     fn peak(&self) -> usize {
         self.lock().peak
+    }
+    fn units(&self) -> usize {
+        self.lock().units
+    }
+    fn peak_units(&self) -> usize {
+        self.lock().peak_units
     }
     fn pend_outstanding(&self) -> bool {
         self.lock().pend_outstanding
@@ -822,11 +859,14 @@ pub(crate) fn stream_callback(ctx: &mut StreamSendCtx, ev: StreamEvent) -> Resul
                     }
                 }
                 let b = b.freeze();
+                // An empty, non-FIN indication enqueues no `Data` event and so
+                // takes no unit; a non-empty indication charges exactly one unit.
+                let charge_unit = !b.is_empty();
                 // ONE synchronized transition: increment → decide-pend (saving
                 // this indication's FULL length) → publish under the lock. On a
                 // failed publication the whole mutation is rolled back inside
                 // `admit`, so a dropped frontend leaves accounting untouched.
-                match ctx.recv_budget.admit(total, || {
+                match ctx.recv_budget.admit(total, charge_unit, || {
                     // An empty, non-FIN notification produces NO event (Finding
                     // 8): a zero-length receive is not by itself end-of-stream,
                     // and counts as a successful (no-op) publication.
@@ -2104,7 +2144,7 @@ mod receive_events {
         // pend and PUBLISHES the bytes under the lock, returning the pend outcome
         // the callback has NOT yet acted on.
         let racing = Bytes::from(vec![0xEEu8; RACE]);
-        let outcome = recv.rctx.recv_budget.admit(RACE, || {
+        let outcome = recv.rctx.recv_budget.admit(RACE, true, || {
             ctx.receive
                 .as_ref()
                 .expect("frontend live")
@@ -2185,7 +2225,7 @@ mod receive_events {
                 for _ in 0..ITERS {
                     // Exactly the callback's transition: the publish (channel send)
                     // is the LAST step, under the lock, after the increment.
-                    budget.admit(CHUNK, || tx.send(CHUNK).is_ok());
+                    budget.admit(CHUNK, true, || tx.send(CHUNK).is_ok());
                 }
                 drop(tx);
             })
@@ -2390,6 +2430,300 @@ mod receive_events {
             other => panic!("expected concatenated data, got {other:?}"),
         }
         assert_eq!(rrx.recv_budget.buffered(), 9);
+    }
+
+    // ----- Phase 2: per-stream receive UNIT-count backpressure -----
+
+    use super::stream_ctx_channel_with_config;
+    use crate::H3Config;
+    use crate::config::DEFAULT_MAX_RECV_UNITS;
+
+    /// SC-002 (the key regression): a PENDING-honoring paced driver offers ≥
+    /// 100,000 ONE-BYTE frames one at a time to a stream whose application does
+    /// NOT consume, and — modelling msquic's single-receive-mode semantics —
+    /// STOPS offering after a `QUIC_STATUS_PENDING` until a recorded drain
+    /// (`receive_complete` via the seam) re-arms the stream. The peak buffered
+    /// UNIT count must stay ≤ `max_recv_units` (16384) and peak bytes ≤
+    /// `max_recv_bytes` + one indication. (Old behaviour would have buffered
+    /// ~1,048,576 units.)
+    #[test]
+    fn paced_tiny_frames_are_bounded_by_the_unit_cap() {
+        let (mut ctx, _sctx, rctx) = stream_ctx_channel(0u64.try_into().unwrap());
+        let rec = RecordingRecvExec::default();
+        let mut recv = H3RecvStream::with_exec(Box::new(rec), rctx);
+        let mut cx = noop_context();
+
+        const OFFER_TARGET: usize = 100_000;
+        let mut offered = 0usize;
+        let mut peak_units = 0usize;
+        let mut peak_bytes = 0usize;
+        let mut pend_returns = 0usize;
+        while offered < OFFER_TARGET {
+            if recv.rctx.recv_budget.pend_outstanding() {
+                // Native has paused THIS stream after PENDING: no further
+                // indication is delivered until the app drains one buffered unit,
+                // which re-arms the window via the RecvExec seam.
+                match recv.poll_data(&mut cx) {
+                    Poll::Ready(Ok(Some(_))) => {}
+                    other => panic!("expected buffered data while paced-stalled, got {other:?}"),
+                }
+                continue;
+            }
+            // A REAL one-byte offer through the real receive callback/seam.
+            let res = feed_receive_result(&mut ctx, &[0xAB], ReceiveFlags::NONE);
+            offered += 1;
+            peak_units = peak_units.max(recv.rctx.recv_budget.units());
+            peak_bytes = peak_bytes.max(recv.rctx.recv_budget.buffered());
+            if is_pending(&res) {
+                pend_returns += 1;
+                assert!(recv.rctx.recv_budget.pend_outstanding());
+            } else {
+                assert!(res.is_ok(), "sub-cap offer must be Ok, got {res:?}");
+            }
+        }
+
+        assert!(offered >= OFFER_TARGET);
+        assert!(pend_returns > 0, "the unit cap must engage backpressure");
+        // The unit count is bounded by the cap — never the ~1M it would reach
+        // without unit accounting.
+        assert_eq!(
+            peak_units, DEFAULT_MAX_RECV_UNITS,
+            "peak units must reach and stay at the unit cap ({DEFAULT_MAX_RECV_UNITS})"
+        );
+        assert_eq!(recv.rctx.recv_budget.peak_units(), DEFAULT_MAX_RECV_UNITS);
+        // With one-byte frames the byte budget is nowhere near binding.
+        assert!(
+            peak_bytes <= MAX_RECV_BUFFER + 1,
+            "peak bytes {peak_bytes} must stay <= byte budget + one indication"
+        );
+        assert!(
+            peak_units < 1_048_576,
+            "the unit cap prevents the ~1,048,576-unit amplification (peak={peak_units})"
+        );
+    }
+
+    /// SC-003 (exact, no tie): frames each ≥ F = 128 bytes fill the BYTE budget
+    /// (reached at ≤ 8192 units) strictly before the unit cap (16384). Feeding
+    /// 128-byte frames until backpressure, the buffered byte total reaches the
+    /// byte budget within one indication AND the unit count stays STRICTLY below
+    /// the unit cap.
+    #[test]
+    fn frames_at_or_above_128_bytes_bind_on_bytes_first() {
+        const F: usize = 128;
+        let (mut ctx, _sctx, _rctx) = stream_ctx_channel(0u64.try_into().unwrap());
+        let frame = vec![0x5Au8; F];
+
+        let mut res = feed_receive_result(&mut ctx, &frame, ReceiveFlags::NONE);
+        while !is_pending(&res) {
+            res = feed_receive_result(&mut ctx, &frame, ReceiveFlags::NONE);
+        }
+        let buffered = ctx.recv_budget.buffered();
+        let units = ctx.recv_budget.units();
+        // The byte budget bound first, within one indication.
+        assert!(
+            (MAX_RECV_BUFFER..=MAX_RECV_BUFFER + F).contains(&buffered),
+            "buffered {buffered} should reach the byte budget within one indication"
+        );
+        // The unit count stayed STRICTLY below the unit cap (no tie): 1 MiB / 128
+        // = 8192 units < 16384.
+        assert!(
+            units < DEFAULT_MAX_RECV_UNITS,
+            "units {units} must be strictly below the unit cap ({DEFAULT_MAX_RECV_UNITS})"
+        );
+        assert_eq!(
+            units,
+            MAX_RECV_BUFFER / F,
+            "byte budget bound at 8192 units"
+        );
+    }
+
+    /// SC-004 (recv unit half): a smaller `max_recv_units` engages receive
+    /// backpressure at exactly the configured unit count (byte budget kept at its
+    /// default so it cannot bind).
+    #[test]
+    fn custom_recv_unit_cap_engages_backpressure_at_configured_value() {
+        const UNITS: usize = 8;
+        let cfg = H3Config::builder()
+            .with_max_recv_units(UNITS)
+            .build()
+            .unwrap();
+        let (mut ctx, _sctx, _rctx) =
+            stream_ctx_channel_with_config(0u64.try_into().unwrap(), new_conn_terminal_slot(), cfg);
+
+        // The first UNITS-1 one-byte offers stay sub-cap; the UNITS-th pends.
+        for i in 0..UNITS - 1 {
+            assert!(
+                feed_receive_result(&mut ctx, &[0x11], ReceiveFlags::NONE).is_ok(),
+                "offer {i} below the unit cap must be Ok"
+            );
+        }
+        let res = feed_receive_result(&mut ctx, &[0x11], ReceiveFlags::NONE);
+        assert!(is_pending(&res), "the configured unit cap must pend");
+        assert_eq!(ctx.recv_budget.units(), UNITS);
+        assert!(ctx.recv_budget.pend_outstanding());
+    }
+
+    /// SC-004 (recv byte half): a smaller `max_recv_bytes` engages receive
+    /// backpressure at the configured byte budget (unit cap kept at its default
+    /// so it cannot bind).
+    #[test]
+    fn custom_recv_byte_cap_engages_backpressure_at_configured_value() {
+        const BYTES: usize = 512;
+        const F: usize = 128;
+        let cfg = H3Config::builder()
+            .with_max_recv_bytes(BYTES)
+            .build()
+            .unwrap();
+        let (mut ctx, _sctx, _rctx) =
+            stream_ctx_channel_with_config(0u64.try_into().unwrap(), new_conn_terminal_slot(), cfg);
+
+        let frame = vec![0x22u8; F];
+        for _ in 0..(BYTES / F) - 1 {
+            assert!(feed_receive_result(&mut ctx, &frame, ReceiveFlags::NONE).is_ok());
+        }
+        let res = feed_receive_result(&mut ctx, &frame, ReceiveFlags::NONE);
+        assert!(is_pending(&res), "the configured byte budget must pend");
+        assert_eq!(ctx.recv_budget.buffered(), BYTES);
+        // The byte budget, not the (default, huge) unit cap, was the binding cap.
+        assert!(ctx.recv_budget.units() < DEFAULT_MAX_RECV_UNITS);
+    }
+
+    /// SC-005 (a): repeated admit/consume cycles return BOTH the unit count and
+    /// the byte total to zero — no monotonic growth.
+    #[test]
+    fn admit_consume_cycles_are_leak_free() {
+        let (mut ctx, _sctx, rctx) = stream_ctx_channel(0u64.try_into().unwrap());
+        let rec = RecordingRecvExec::default();
+        let mut recv = H3RecvStream::with_exec(Box::new(rec), rctx);
+        let mut cx = noop_context();
+
+        for _ in 0..1_000 {
+            assert!(feed_receive_result(&mut ctx, &[0x42], ReceiveFlags::NONE).is_ok());
+            match recv.poll_data(&mut cx) {
+                Poll::Ready(Ok(Some(b))) => assert_eq!(&b[..], &[0x42]),
+                other => panic!("expected data, got {other:?}"),
+            }
+        }
+        // No drift: both counters return to zero and the peak never grew beyond a
+        // single in-flight unit.
+        assert_eq!(
+            recv.rctx.recv_budget.units(),
+            0,
+            "unit count returns to zero"
+        );
+        assert_eq!(
+            recv.rctx.recv_budget.buffered(),
+            0,
+            "byte total returns to zero"
+        );
+        assert_eq!(
+            recv.rctx.recv_budget.peak_units(),
+            1,
+            "at most one unit buffered at a time"
+        );
+        assert!(!recv.rctx.recv_budget.pend_outstanding());
+    }
+
+    /// SC-005 (b): a forced channel-publish failure (dropped frontend) rolls back
+    /// the unit charge — `units` is unchanged after the failed admit.
+    #[test]
+    fn failed_publish_rolls_back_the_unit_charge() {
+        let (mut ctx, _sctx, rctx) = stream_ctx_channel(0u64.try_into().unwrap());
+
+        // One successful non-empty indication establishes a live, undrained unit.
+        assert!(feed_receive_result(&mut ctx, &[0x01], ReceiveFlags::NONE).is_ok());
+        let units_before = ctx.recv_budget.units();
+        let buffered_before = ctx.recv_budget.buffered();
+        assert_eq!(units_before, 1);
+
+        // Drop the frontend receiver: the next publish (send) fails.
+        drop(rctx);
+
+        let res = feed_receive_result(&mut ctx, &[0x02], ReceiveFlags::NONE);
+        assert!(res.is_ok(), "a dropped frontend must not strand PENDING");
+        assert_eq!(
+            ctx.recv_budget.units(),
+            units_before,
+            "the unit charge was rolled back (no leaked unit)"
+        );
+        assert_eq!(
+            ctx.recv_budget.buffered(),
+            buffered_before,
+            "bytes rolled back too"
+        );
+        assert!(
+            ctx.receive.is_none(),
+            "dropped frontend detaches the sender"
+        );
+    }
+
+    /// SC-005 (c): an EMPTY, non-FIN indication enqueues no `Data` event and so
+    /// consumes NO unit (and no bytes).
+    #[test]
+    fn empty_indication_consumes_no_unit() {
+        let (mut ctx, _sctx, _rctx) = stream_ctx_channel(0u64.try_into().unwrap());
+        assert!(feed_receive_result(&mut ctx, &[], ReceiveFlags::NONE).is_ok());
+        assert_eq!(
+            ctx.recv_budget.units(),
+            0,
+            "empty indication charges no unit"
+        );
+        assert_eq!(
+            ctx.recv_budget.buffered(),
+            0,
+            "empty indication buffers no bytes"
+        );
+    }
+
+    /// Teardown-at-cap: a stream terminated (peer reset) while sitting at the unit
+    /// cap drains its buffered units and surfaces the terminal cleanly — no hang,
+    /// no panic, no counter underflow — driven entirely via the recv seam.
+    #[test]
+    fn teardown_while_at_unit_cap_releases_cleanly() {
+        const UNITS: usize = 16;
+        let cfg = H3Config::builder()
+            .with_max_recv_units(UNITS)
+            .build()
+            .unwrap();
+        let (mut ctx, _sctx, rctx) =
+            stream_ctx_channel_with_config(0u64.try_into().unwrap(), new_conn_terminal_slot(), cfg);
+        let rec = RecordingRecvExec::default();
+        let mut recv = H3RecvStream::with_exec(Box::new(rec), rctx);
+        let mut cx = noop_context();
+
+        // Fill to the unit cap: the UNITS-th one-byte offer pends.
+        let mut res = Ok(());
+        for _ in 0..UNITS {
+            res = feed_receive_result(&mut ctx, &[0x07], ReceiveFlags::NONE);
+        }
+        assert!(is_pending(&res), "at the unit cap the stream must pend");
+        assert_eq!(recv.rctx.recv_budget.units(), UNITS);
+
+        // Terminate the stream while at the cap (peer reset via the recv seam).
+        assert!(stream_callback(&mut ctx, StreamEvent::PeerSendAborted { error_code: 5 }).is_ok());
+
+        // Drain: buffered data comes first (FIFO), then the terminal — releasing
+        // every unit cleanly with no hang and no panic.
+        let mut drained = 0usize;
+        loop {
+            match recv.poll_data(&mut cx) {
+                Poll::Ready(Ok(Some(_))) => drained += 1,
+                Poll::Ready(Err(StreamErrorIncoming::StreamTerminated { error_code })) => {
+                    assert_eq!(error_code, 5);
+                    break;
+                }
+                other => panic!("expected data then terminal, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            drained, UNITS,
+            "all buffered units drained before the terminal"
+        );
+        assert_eq!(
+            recv.rctx.recv_budget.units(),
+            0,
+            "units released cleanly to zero"
+        );
     }
 }
 

--- a/msquic-h3/src/stream.rs
+++ b/msquic-h3/src/stream.rs
@@ -1134,6 +1134,28 @@ impl H3Stream {
     }
 }
 
+/// Test-only accessors that read the LIVE per-stream budgets a fully-constructed
+/// stream is actually enforcing, so an end-to-end loopback test can confirm the
+/// connection's [`H3Config`] threaded all the way through the real
+/// `PeerStreamStarted`/`attach`/`finalize` (accepted) and `open_and_start`
+/// (locally-opened) hand-offs — not just through the shared seam helper.
+#[cfg(test)]
+impl H3Stream {
+    /// The live per-stream receive caps `(max_recv_bytes, max_recv_units)` this
+    /// stream's `RecvBudget` is enforcing.
+    pub(crate) fn recv_budget_caps(&self) -> (usize, usize) {
+        (
+            self.recv.rctx.recv_budget.max_bytes(),
+            self.recv.rctx.recv_budget.max_units(),
+        )
+    }
+
+    /// The live per-stream `send_data` ceiling this stream is enforcing.
+    pub(crate) fn max_send_bytes(&self) -> u64 {
+        self.send.sctx.max_send_bytes
+    }
+}
+
 impl<B: Buf> SendStream<B> for H3SendStream {
     // h3 calls `poll_ready` after `send_data` to await the in-flight send.
     #[cfg_attr(
@@ -1452,7 +1474,10 @@ impl SendStreamReceiveCtx {
 fn classify_payload(remaining: usize, ceiling: u64) -> SendPayload {
     match classify_send_len(remaining, ceiling) {
         SendLen::Empty => SendPayload::Empty,
-        SendLen::Oversized => SendPayload::Oversized { len: remaining },
+        SendLen::Oversized => SendPayload::Oversized {
+            len: remaining,
+            ceiling,
+        },
         SendLen::NonEmpty => SendPayload::NonEmpty {
             len: remaining as u32,
         },
@@ -2439,17 +2464,29 @@ mod receive_events {
     use crate::config::DEFAULT_MAX_RECV_UNITS;
 
     /// SC-002 (the key regression): a PENDING-honoring paced driver offers ≥
-    /// 100,000 ONE-BYTE frames one at a time to a stream whose application does
-    /// NOT consume, and — modelling msquic's single-receive-mode semantics —
-    /// STOPS offering after a `QUIC_STATUS_PENDING` until a recorded drain
-    /// (`receive_complete` via the seam) re-arms the stream. The peak buffered
-    /// UNIT count must stay ≤ `max_recv_units` (16384) and peak bytes ≤
+    /// 100,000 ONE-BYTE frames one at a time on a **drain-one-per-pend cyclic**
+    /// model. It offers frames until the callback returns `QUIC_STATUS_PENDING`
+    /// (native has paused THIS stream); it then STOPS offering and drains
+    /// EXACTLY ONE buffered unit, which must produce EXACTLY ONE recorded native
+    /// `receive_complete` (the re-arm) through the `RecvExec` seam before any
+    /// further offer. The application never gets ahead of the flood — it only
+    /// consumes the single unit needed to re-open the window — so the peak
+    /// buffered UNIT count stays ≤ `max_recv_units` (16384) and peak bytes ≤
     /// `max_recv_bytes` + one indication. (Old behaviour would have buffered
     /// ~1,048,576 units.)
+    ///
+    /// Retaining the `RecordingRecvExec` completion log lets the driver assert
+    /// the seam actually fired `receive_complete` once per pend, rather than
+    /// merely observing an internal flag clear: if `poll_data` cleared the pend
+    /// state without invoking the native `receive_complete`, a real MsQuic
+    /// stream would stay permanently paused, and this test now fails.
     #[test]
     fn paced_tiny_frames_are_bounded_by_the_unit_cap() {
         let (mut ctx, _sctx, rctx) = stream_ctx_channel(0u64.try_into().unwrap());
         let rec = RecordingRecvExec::default();
+        // RETAIN the completion log so we can assert each pend is re-armed by
+        // exactly one recorded native `receive_complete`.
+        let completes = rec.completes.clone();
         let mut recv = H3RecvStream::with_exec(Box::new(rec), rctx);
         let mut cx = noop_context();
 
@@ -2458,15 +2495,37 @@ mod receive_events {
         let mut peak_units = 0usize;
         let mut peak_bytes = 0usize;
         let mut pend_returns = 0usize;
+        let mut completions = 0usize;
+
+        // Drain exactly one buffered unit and require exactly one NEW recorded
+        // `receive_complete` (the re-arm). Returns after asserting the pend
+        // cleared.
+        let drain_one_and_require_rearm =
+            |recv: &mut H3RecvStream, cx: &mut Context<'_>, completions: &mut usize| {
+                let before = completes.lock().unwrap().len();
+                match recv.poll_data(cx) {
+                    Poll::Ready(Ok(Some(_))) => {}
+                    other => panic!("expected buffered data while paced-stalled, got {other:?}"),
+                }
+                let after = completes.lock().unwrap().len();
+                assert_eq!(
+                    after,
+                    before + 1,
+                    "each pend must be re-armed by exactly ONE recorded receive_complete"
+                );
+                assert!(
+                    !recv.rctx.recv_budget.pend_outstanding(),
+                    "draining one unit below the cap must clear the pend"
+                );
+                *completions += 1;
+            };
+
         while offered < OFFER_TARGET {
             if recv.rctx.recv_budget.pend_outstanding() {
                 // Native has paused THIS stream after PENDING: no further
                 // indication is delivered until the app drains one buffered unit,
-                // which re-arms the window via the RecvExec seam.
-                match recv.poll_data(&mut cx) {
-                    Poll::Ready(Ok(Some(_))) => {}
-                    other => panic!("expected buffered data while paced-stalled, got {other:?}"),
-                }
+                // which must re-arm the window via a recorded `receive_complete`.
+                drain_one_and_require_rearm(&mut recv, &mut cx, &mut completions);
                 continue;
             }
             // A REAL one-byte offer through the real receive callback/seam.
@@ -2482,8 +2541,25 @@ mod receive_events {
             }
         }
 
+        // Drain a final outstanding pend (if the last offer pended) so the
+        // recorded-completion count matches the pend count exactly.
+        if recv.rctx.recv_budget.pend_outstanding() {
+            drain_one_and_require_rearm(&mut recv, &mut cx, &mut completions);
+        }
+
         assert!(offered >= OFFER_TARGET);
         assert!(pend_returns > 0, "the unit cap must engage backpressure");
+        // Exactly one recorded native `receive_complete` per pend (the seam
+        // genuinely re-armed the stream every time it paused).
+        assert_eq!(
+            completions, pend_returns,
+            "exactly one drain-driven re-arm per pend"
+        );
+        assert_eq!(
+            completes.lock().unwrap().len(),
+            pend_returns,
+            "the native receive_complete seam fired exactly once per pend"
+        );
         // The unit count is bounded by the cap — never the ~1M it would reach
         // without unit accounting.
         assert_eq!(

--- a/msquic-h3/src/terminal.rs
+++ b/msquic-h3/src/terminal.rs
@@ -256,7 +256,7 @@ mod connection_terminal {
     /// Drive one connection event through the callback and return the frozen,
     /// converted terminal the accept frontend would report.
     fn map_event(ev: ConnectionEvent) -> ConnectionErrorIncoming {
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         assert!(connection_callback(&mut ctx, ev, &no_stream_owned()).is_ok());
         observe_terminal(&crx.terminal)
     }
@@ -353,7 +353,7 @@ mod connection_terminal {
 
     #[test]
     fn connected_resolves_ok() {
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         let ev = ConnectionEvent::Connected {
             session_resumed: false,
             negotiated_alpn: &[],
@@ -364,7 +364,7 @@ mod connection_terminal {
 
     #[test]
     fn connected_waiter_resolves_with_transport_status_on_early_shutdown() {
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         // Transport shutdown before Connected carries the real status.
         let ev = ConnectionEvent::ShutdownInitiatedByTransport {
             status: Status::new(StatusCode::QUIC_STATUS_HANDSHAKE_FAILURE),
@@ -381,7 +381,7 @@ mod connection_terminal {
 
     #[test]
     fn connected_waiter_resolves_on_peer_shutdown_before_connected() {
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         assert!(
             connection_callback(
                 &mut ctx,
@@ -405,7 +405,7 @@ mod connection_terminal {
 
     #[test]
     fn connected_waiter_resolves_on_bare_shutdown_complete() {
-        let (mut ctx, mut crx) = conn_ctx_channel();
+        let (mut ctx, mut crx) = conn_ctx_channel(crate::H3Config::default());
         assert!(
             connection_callback(
                 &mut ctx,
@@ -519,7 +519,7 @@ mod connection_terminal {
     fn callback_records_local_close_provisionally_then_refines() {
         // Simulate OpenStreams::close (records LocalClose) racing a peer cause
         // that lands before the frontend observes: the specific cause wins.
-        let (mut ctx, crx) = conn_ctx_channel();
+        let (mut ctx, crx) = conn_ctx_channel(crate::H3Config::default());
         record_conn_terminal(&ctx.terminal, ConnectionTerminal::LocalClose);
         assert!(
             connection_callback(


### PR DESCRIPTION

## Summary

Closes the must-fix receive-side out-of-memory finding from the crate performance/architecture review (validated by an adversarial debate against the vendored msquic C source) and gives applications configurable control over the adapter's memory footprint via a new public `H3Config`.

Two exposures were found where the adapter metered memory on the wrong axis:

1. **Receive (hard fix):** the adapter admitted data against a per-stream *byte* budget (1 MiB) but queued each indication with one heap allocation, counting only bytes. Because msquic's small-frame coalescing is a defeatable arrival-timing optimization, a peer pacing tiny (1-byte) frames could force ~1 allocation per byte — ~1,048,576 allocations for 1 MiB of accounted payload (≥40× amplification), reaching a gigabyte across a few dozen stalled streams. **Now bounded** by a per-stream **unit-count** budget (default 16384) enforced as receive backpressure (the callback returns `PENDING`).

2. **Send (configurable mitigation):** the adapter holds one owned payload copy per outstanding send with no aggregate ceiling, so N stalled streams pin ≈ N × 16 MiB. A true *backpressure* cap is **infeasible** here: the h3 0.0.8 trait contract calls the synchronous `send_data` (which copies and takes ownership) *before* the only async readiness hook `poll_ready`, and `send_data` returns `Result`, not `Poll` (verified: h3-0.0.8 `src/stream.rs:37-38`; adapter comment `stream.rs:1026`). The mitigation is a **configurable per-send-size ceiling** (`max_send_bytes`, default 16 MiB): applications bound per-connection send memory to `concurrent-streams × max_send_bytes` and cap concurrent streams at the application level. This trade-off was an explicit maintainer decision.

## Changes

- **New public `H3Config`** (`msquic-h3/src/config.rs`): private, validated fields `max_send_bytes` (16 MiB), `max_recv_bytes` (1 MiB), `max_recv_units` (16384); constructible only via `Default` or a validated `H3Config::builder()` / `try_new` (rejects zero / `>= u32::MAX` send size, zero recv bytes, zero recv units). New public `ConfigError`. Re-exported at the crate root.
- **Additive constructors:** `Connection::connect_with_config` and `Listener::with_config`. Existing `Connection::connect` / `Listener::new` are unchanged and use the defaults. The crate-private `Connection::attach` gained a config parameter (not a public break).
- **Dual per-connection carrier:** config rides both `ConnHandle` and the callback `ConnCtxSender` (mirroring the existing terminal-slot pattern), so it reaches **both** locally-opened and peer-accepted streams.
- **Receive unit-count enforcement** (`RecvBudget`): `admit` pends when `buffered >= max_bytes` **or** `units >= max_units`; charges one unit per non-empty enqueued `Data` event; rolls `units`/`peak_units` back in the same transaction on a channel publish failure; empty indications charge nothing; `on_drained` releases exactly one unit per consumed event and re-arms below both caps. Single-mutex transition shape preserved.
- **Configurable send ceiling** threaded into the send classification; the public `OversizedSend` error now reports the configured ceiling (`max_bytes`) instead of a hardcoded constant.
- **Docs:** `docs/receive-and-send.md`, `docs/architecture.md`, `README.md` (a "Configuring memory budgets" section), `CHANGELOG.md`, and rustdoc on all new public items — including an explicit, accurate explanation that the send side has no aggregate cap and why.

## Testing

- Full suite green on **both** provenances: `cargo test --no-default-features --features native-find` and `--features native-src` → **203 passed, 0 failed, 2 ignored**. `clippy --all-targets -D warnings`, `cargo fmt --all -- --check` (toolchains 1.90.0 and 1.97.0), and `cargo doc` all clean. The four CI `--exact` gate test paths are unchanged.
- Key regression / behavior tests:
  - `paced_tiny_frames_are_bounded_by_the_unit_cap` (SC-002): offers ≥100,000 one-byte frames through a `PENDING`-honoring paced driver (asserts one recorded `receive_complete` per pend) and verifies peak buffered units stay ≤ 16384 (was ~1,048,576).
  - `frames_at_or_above_128_bytes_bind_on_bytes_first` (SC-003): frames ≥ 128 B bind on the byte budget first; unit count stays strictly < 16384.
  - `custom_ceiling_send_data_rejects_oversized_before_allocation` / `..._accepts_payload_at_the_ceiling`: a payload above a custom `max_send_bytes` is rejected as `OversizedSend` (reporting the configured ceiling) with zero copy/submission; a payload at the ceiling is accepted.
  - `custom_config_threads_through_real_loopback` / `distinct_connection_configs_do_not_cross_talk`: real 127.0.0.1 loopback via `Listener::with_config` + `Connection::connect_with_config`, asserting a custom `H3Config` reaches both peer-accepted and locally-opened live streams through the actual `PeerStreamStarted → attach` / `open_and_start` hand-offs, with no cross-connection talk.
  - Config validation, leak-free admit/consume cycles, publish-failure rollback, empty-indication exclusion, and teardown-at-cap.

## Breaking changes

None. Existing public constructors and signatures are unchanged (additive `*_with_config` entry points; the changed `attach` is crate-private). Defaults equal the historical `MAX_ADAPTER_SEND` / `MAX_RECV_BUFFER` constants; the only default behavior change is the new protective 16384-unit receive cap, which only engages under highly fragmented tiny-frame input (frames ≥ 128 B are unaffected).

## Reviewer focus

- The receive unit accounting exactly-once / leak-freedom (charge per non-empty enqueued event, release per consumed event, rollback on publish failure).
- The dual-carrier config threading reaching peer-accepted streams (covered by the real-loopback test).
- The documented send-side trade-off (no aggregate cap; `max_send_bytes × concurrent streams` scaling) — confirm the guidance reads correctly for operators.

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)
